### PR TITLE
Remove residual dependency from fcc-edm-legacy

### DIFF
--- a/FCCeeAnalyses/tt/fccee_ana_tt.py
+++ b/FCCeeAnalyses/tt/fccee_ana_tt.py
@@ -32,7 +32,7 @@ df2 = df.Define("selected_electrons",  "selectParticlesPtIso(10, 0.4)(electrons,
         .Define("selected_lights",     "noMatchJets(0.2)(jets_10_lights, selected_leptons)") \
         .Define("nbjets",              "get_njets(selected_bs)") \
         .Define("njets",               "get_njets2(selected_bs, selected_lights)") \
-        .Define("weight",              "id_float_legacy(mcEventWeights)") \
+        .Define("weight",              "id_float(mcEventWeights)") \
         .Define("n_selected_electrons","get_nparticles(electrons)") \
         
          

--- a/FCChhAnalyses/FCChh/tth_4l/dataframe/fcchh_ana_tth_4l.cxx
+++ b/FCChhAnalyses/FCChh/tth_4l/dataframe/fcchh_ana_tth_4l.cxx
@@ -7,7 +7,7 @@
 #include "datamodel/ParticleData.h"
 #include "datamodel/LorentzVector.h"
 #include "datamodel/JetData.h"
-#include "datamodel/FloatData.h"
+#include "datamodel/FloatValueData.h"
 #include "datamodel/TaggedParticleData.h"
 #include "datamodel/TaggedJetData.h"
 
@@ -67,7 +67,7 @@ int main(int argc, char* argv[]){
                       .Define("selected_lights", noMatchJets(0.2), {"jets_30_lights", "selected_leptons"})
                       .Define("nbjets", get_njets, {"selected_bs"})
                       .Define("njets", get_njets2, {"selected_bs", "selected_lights"})
-                      .Define("weight", id_float_legacy, {"mcEventWeights"})
+                      .Define("weight", id_float, {"mcEventWeights"})
                       .Define("n_selected_leptons", get_nparticles, {"selected_leptons"})
                     ;
   auto nentries = selectors.Count();

--- a/FCChhAnalyses/FCChh/tth_4l/dataframe/fcchh_ana_tth_4l.py
+++ b/FCChhAnalyses/FCChh/tth_4l/dataframe/fcchh_ana_tth_4l.py
@@ -53,7 +53,7 @@ df2 = df.Define("selected_electrons", "selectParticlesPtIso(20, 0.4)(electrons, 
         .Define("selected_lights", "noMatchJets(0.2)(jets_30_lights, selected_leptons)") \
         .Define("nbjets", "get_njets(selected_bs)") \
         .Define("njets", "get_njets2(selected_bs, selected_lights)") \
-        .Define("weight"," id_float_legacy(mcEventWeights)") \
+        .Define("weight"," id_float(mcEventWeights)") \
         .Define("n_selected_electrons", "get_nparticles(electrons)") \
         
          

--- a/analyzers/dataframe/FCCAnalyses.cc
+++ b/analyzers/dataframe/FCCAnalyses.cc
@@ -188,14 +188,6 @@ ROOT::VecOps::RVec<float> id_float(ROOT::VecOps::RVec<fcc::FloatValueData> x) {
   return result;
 }
 
-ROOT::VecOps::RVec<float> id_float_legacy(ROOT::VecOps::RVec<fcc::FloatData> x) {
-  ROOT::VecOps::RVec<float> result;
-  for (auto & p: x) {
-    result.push_back(p.value);
-  }
-  return result;
-}
-
 ROOT::VecOps::RVec<float> get_mass(ROOT::VecOps::RVec<fcc::ParticleData> x) {
   ROOT::VecOps::RVec<float> result;
   for (auto & p: x) {

--- a/analyzers/dataframe/FCCAnalyses.h
+++ b/analyzers/dataframe/FCCAnalyses.h
@@ -16,9 +16,6 @@
 #include "datamodel/Point.h"
 #include "datamodel/LorentzVector.h"
 #include "datamodel/FloatValueData.h"
-// legacy
-#include "datamodel/FloatData.h"
-
 
 
 /// transverse mass 
@@ -129,9 +126,6 @@ ROOT::VecOps::RVec<fcc::ParticleData> operator()(ROOT::VecOps::RVec<fcc::JetData
 
 /// cast FloatValueData to a primitive float
 ROOT::VecOps::RVec<float> id_float(ROOT::VecOps::RVec<fcc::FloatValueData> x);
-
-/// cast FloatData (used in earlier versions of fcc-edm) to a primitive float
-ROOT::VecOps::RVec<float> id_float_legacy(ROOT::VecOps::RVec<fcc::FloatData> x);
 
 /// return the masses of the input particles
 ROOT::VecOps::RVec<float> get_mass(ROOT::VecOps::RVec<fcc::ParticleData> x); 

--- a/analyzers/dataframe/LinkDef.h
+++ b/analyzers/dataframe/LinkDef.h
@@ -20,7 +20,7 @@
 #pragma link C++ function merge_particles;
 #pragma link C++ class ResonanceBuilder;
 #pragma link C++ function id_float;
-#pragma link C++ function id_float_legacy;
+
 #pragma link C++ function get_mass;
 #pragma link C++ function get_n_particles;
 #pragma link C++ function get_n_particles_rvec;


### PR DESCRIPTION
Dependency is due to the use of datamodel/FloatData.h, which can be replaced by datamodel/FloatValueData.h .
In addition fcc-edm-legacy does not build with the latest Podio (v 0.11)