### PR TITLE
No edm legacy no afs

### DIFF
--- a/FCCeeAnalyses/ZH_Zee/dataframe/finalSel.py
+++ b/FCCeeAnalyses/ZH_Zee/dataframe/finalSel.py
@@ -1,11 +1,14 @@
+from common_defaults import deffccdicts
+
 #python FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py 
+import os
 import ROOT
 
 ###Input directory where the files produced at the pre-selection level are
-baseDir  = "/afs/cern.ch/user/h/helsens/FCCsoft/FCCAnalyses/Outputs/FCCee/ZH_Zmumu/"
+baseDir  = "/home/ganis/local/fcc/work/tutorials/aug2020/ch/FCCAnalyses/Outputs/FCCee/ZH_Zmumu/"
 
 ###Link to the dictonary that contains all the cross section informations etc...
-procDict = "/afs/cern.ch/work/h/helsens/public/FCCDicts/FCCee_procDict_fcc_v01.json"
+procDict = os.path.join(os.environ['FCCDICTSDIR'], '') + "FCCee_procDict_fcc_v01.json"
 
 process_list=['p8_ee_ZZ_ecm240','p8_ee_WW_ecm240','p8_ee_ZH_ecm240']
 

--- a/FCCeeAnalyses/ZH_Zee/dataframe/finalSel.py
+++ b/FCCeeAnalyses/ZH_Zee/dataframe/finalSel.py
@@ -8,7 +8,7 @@ import ROOT
 baseDir  = "/home/ganis/local/fcc/work/tutorials/aug2020/ch/FCCAnalyses/Outputs/FCCee/ZH_Zmumu/"
 
 ###Link to the dictonary that contains all the cross section informations etc...
-procDict = os.path.join(os.environ['FCCDICTSDIR'], '') + "FCCee_procDict_fcc_v01.json"
+procDict = os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + "FCCee_procDict_fcc_v01.json"
 
 process_list=['p8_ee_ZZ_ecm240','p8_ee_WW_ecm240','p8_ee_ZH_ecm240']
 

--- a/FCCeeAnalyses/ZH_Zee/dataframe/preSel.py
+++ b/FCCeeAnalyses/ZH_Zee/dataframe/preSel.py
@@ -3,7 +3,7 @@ from common_defaults import deffccdicts
 #python FCCeeAnalyses/ZH_Zmumu/dataframe/preSel.py 
 import os
 
-basedir=os.path.join(os.environ['FCCDICTSDIR'], '') + "yaml/FCCee/fcc_v01/"
+basedir=os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + "yaml/FCCee/fcc_v01/"
 outdir="FCCee/ZH_Zmumu/"
 NUM_CPUS = 15
 process_list=['p8_ee_ZZ_ecm240','p8_ee_WW_ecm240','p8_ee_ZH_ecm240']

--- a/FCCeeAnalyses/ZH_Zee/dataframe/preSel.py
+++ b/FCCeeAnalyses/ZH_Zee/dataframe/preSel.py
@@ -1,6 +1,9 @@
-#python FCCeeAnalyses/ZH_Zmumu/dataframe/preSel.py 
+from common_defaults import deffccdicts
 
-basedir="/afs/cern.ch/work/h/helsens/public/FCCDicts/yaml/FCCee/fcc_v01/"
+#python FCCeeAnalyses/ZH_Zmumu/dataframe/preSel.py 
+import os
+
+basedir=os.path.join(os.environ['FCCDICTSDIR'], '') + "yaml/FCCee/fcc_v01/"
 outdir="FCCee/ZH_Zmumu/"
 NUM_CPUS = 15
 process_list=['p8_ee_ZZ_ecm240','p8_ee_WW_ecm240','p8_ee_ZH_ecm240']

--- a/FCCeeAnalyses/ZH_Zee/heppy/analysis.py
+++ b/FCCeeAnalyses/ZH_Zee/heppy/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], ''))
 
 comp = cfg.Component(
     'example',

--- a/FCCeeAnalyses/ZH_Zee/heppy/analysis.py
+++ b/FCCeeAnalyses/ZH_Zee/heppy/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], ''))
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), ''))
 
 comp = cfg.Component(
     'example',

--- a/FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py
+++ b/FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py
@@ -1,12 +1,14 @@
+from common_defaults import deffccdicts
+
 #python FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py 
-import sys
+import sys, os
 import ROOT
 
 ###Input directory where the files produced at the pre-selection level are
 baseDir  = "FCCee/ZH_Zmumu/"
 
 ###Link to the dictonary that contains all the cross section informations etc...
-procDict = "/afs/cern.ch/work/h/helsens/public/FCCDicts/FCCee_procDict_fcc_v01.json"
+procDict = os.path.join(os.environ['FCCDICTSDIR'], '') + "FCCee_procDict_fcc_v01.json"
 
 process_list=['p8_ee_ZZ_ecm240','p8_ee_WW_ecm240','p8_ee_ZH_ecm240']
 

--- a/FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py
+++ b/FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py
@@ -1,4 +1,5 @@
 #python FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py 
+import sys
 import ROOT
 
 ###Input directory where the files produced at the pre-selection level are
@@ -32,6 +33,8 @@ variables = {
 NUM_CPUS = 10
 
 ###This part is standard to all analyses
-import bin.runDataFrameFinal as rdf
+sys.path.append('./bin')
+import runDataFrameFinal as rdf
+#import bin.runDataFrameFinal as rdf
 myana=rdf.runDataFrameFinal(baseDir,procDict,process_list,cut_list,variables)
 myana.run(ncpu=NUM_CPUS)

--- a/FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py
+++ b/FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py
@@ -8,7 +8,7 @@ import ROOT
 baseDir  = "FCCee/ZH_Zmumu/"
 
 ###Link to the dictonary that contains all the cross section informations etc...
-procDict = os.path.join(os.environ['FCCDICTSDIR'], '') + "FCCee_procDict_fcc_v01.json"
+procDict = os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + "FCCee_procDict_fcc_v01.json"
 
 process_list=['p8_ee_ZZ_ecm240','p8_ee_WW_ecm240','p8_ee_ZH_ecm240']
 

--- a/FCCeeAnalyses/ZH_Zmumu/dataframe/preSel.py
+++ b/FCCeeAnalyses/ZH_Zmumu/dataframe/preSel.py
@@ -1,6 +1,8 @@
-#python FCCeeAnalyses/ZH_Zmumu/dataframe/preSel.py 
+from common_defaults import deffccdicts
+ #python FCCeeAnalyses/ZH_Zmumu/dataframe/preSel.py 
+import os
 
-basedir="/afs/cern.ch/work/h/helsens/public/FCCDicts/yaml/FCCee/fcc_v01/"
+basedir=os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + "yaml/FCCee/fcc_v01/"
 outdir="FCCee/ZH_Zmumu/"
 NUM_CPUS = 15
 process_list=['p8_ee_ZZ_ecm240','p8_ee_WW_ecm240','p8_ee_ZH_ecm240']

--- a/FCCeeAnalyses/ZH_Zmumu/heppy/analysis.py
+++ b/FCCeeAnalyses/ZH_Zmumu/heppy/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], ''))
 
 comp = cfg.Component(
     'example',

--- a/FCCeeAnalyses/ZH_Zmumu/heppy/analysis.py
+++ b/FCCeeAnalyses/ZH_Zmumu/heppy/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], ''))
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), ''))
 
 comp = cfg.Component(
     'example',

--- a/FCCeeAnalyses/tt/analysis.py
+++ b/FCCeeAnalyses/tt/analysis.py
@@ -1,3 +1,4 @@
+from common_defaults import deffccdicts
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +9,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), ''))
 
 comp = cfg.Component(
     'example',

--- a/FCCeeAnalyses/tt/fccee_ana_tt.py
+++ b/FCCeeAnalyses/tt/fccee_ana_tt.py
@@ -32,7 +32,7 @@ df2 = df.Define("selected_electrons",  "selectParticlesPtIso(10, 0.4)(electrons,
         .Define("selected_lights",     "noMatchJets(0.2)(jets_10_lights, selected_leptons)") \
         .Define("nbjets",              "get_njets(selected_bs)") \
         .Define("njets",               "get_njets2(selected_bs, selected_lights)") \
-        .Define("weight",              "id_float_legacy(mcEventWeights)") \
+        .Define("weight",              "id_float(mcEventWeights)") \
         .Define("n_selected_electrons","get_nparticles(electrons)") \
         
          

--- a/FCChhAnalyses/FCChh/Dijet_reso/analysis.py
+++ b/FCChhAnalyses/FCChh/Dijet_reso/analysis.py
@@ -11,13 +11,13 @@ import imp
 logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 comp = cfg.Component(
     'example',
      files = ["/eos/experiment/fcc/hh/generation/DelphesEvents/fcc_v02/p8_pp_ExcitedQ_30TeV_qq/events_113722907.root"]
 )
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 selectedComponents = [
 

--- a/FCChhAnalyses/FCChh/Dijet_reso/analysis.py
+++ b/FCChhAnalyses/FCChh/Dijet_reso/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -9,13 +11,13 @@ import imp
 logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
 comp = cfg.Component(
     'example',
      files = ["/eos/experiment/fcc/hh/generation/DelphesEvents/fcc_v02/p8_pp_ExcitedQ_30TeV_qq/events_113722907.root"]
 )
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
 
 selectedComponents = [
 

--- a/FCChhAnalyses/FCChh/RSGraviton_ww/analysis.py
+++ b/FCChhAnalyses/FCChh/RSGraviton_ww/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/RSGraviton_ww/analysis.py
+++ b/FCChhAnalyses/FCChh/RSGraviton_ww/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/W_top_vs_QCD_tagger/analysis.py
+++ b/FCChhAnalyses/FCChh/W_top_vs_QCD_tagger/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/W_top_vs_QCD_tagger/analysis.py
+++ b/FCChhAnalyses/FCChh/W_top_vs_QCD_tagger/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/Zprime_ll/analysis.py
+++ b/FCChhAnalyses/FCChh/Zprime_ll/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/Zprime_ll/analysis.py
+++ b/FCChhAnalyses/FCChh/Zprime_ll/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/Zprime_mumu_flav_ano/analysis.py
+++ b/FCChhAnalyses/FCChh/Zprime_mumu_flav_ano/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/Zprime_mumu_flav_ano/analysis.py
+++ b/FCChhAnalyses/FCChh/Zprime_mumu_flav_ano/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/Zprime_tautau/analysis.py
+++ b/FCChhAnalyses/FCChh/Zprime_tautau/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/Zprime_tautau/analysis.py
+++ b/FCChhAnalyses/FCChh/Zprime_tautau/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/Zprime_tt/analysis.py
+++ b/FCChhAnalyses/FCChh/Zprime_tt/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/Zprime_tt/analysis.py
+++ b/FCChhAnalyses/FCChh/Zprime_tt/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/h2l2v/analysis.py
+++ b/FCChhAnalyses/FCChh/h2l2v/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/h2l2v/analysis.py
+++ b/FCChhAnalyses/FCChh/h2l2v/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/h4l/analysis.py
+++ b/FCChhAnalyses/FCChh/h4l/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/h4l/analysis.py
+++ b/FCChhAnalyses/FCChh/h4l/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/haa/analysis.py
+++ b/FCChhAnalyses/FCChh/haa/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/haa/analysis.py
+++ b/FCChhAnalyses/FCChh/haa/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy, math
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hh_boosted/analysis.py
+++ b/FCChhAnalyses/FCChh/hh_boosted/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hh_boosted/analysis.py
+++ b/FCChhAnalyses/FCChh/hh_boosted/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy, math
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hhbbaa/analysis.py
+++ b/FCChhAnalyses/FCChh/hhbbaa/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hhbbaa/analysis.py
+++ b/FCChhAnalyses/FCChh/hhbbaa/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hhbbaa/analysis_fakes.py
+++ b/FCChhAnalyses/FCChh/hhbbaa/analysis_fakes.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hhbbaa/analysis_fakes.py
+++ b/FCChhAnalyses/FCChh/hhbbaa/analysis_fakes.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys, math
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hmumu/analysis.py
+++ b/FCChhAnalyses/FCChh/hmumu/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hmumu/analysis.py
+++ b/FCChhAnalyses/FCChh/hmumu/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hza/analysis.py
+++ b/FCChhAnalyses/FCChh/hza/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hza/analysis.py
+++ b/FCChhAnalyses/FCChh/hza/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/ttV_test/analysis.py
+++ b/FCChhAnalyses/FCChh/ttV_test/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/ttV_test/analysis.py
+++ b/FCChhAnalyses/FCChh/ttV_test/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/tth_4l/analysis.py
+++ b/FCChhAnalyses/FCChh/tth_4l/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import imp
 import copy
@@ -9,8 +11,8 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
 
 
 comps = cfg.Component(

--- a/FCChhAnalyses/FCChh/tth_4l/analysis.py
+++ b/FCChhAnalyses/FCChh/tth_4l/analysis.py
@@ -11,8 +11,8 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 
 comps = cfg.Component(

--- a/FCChhAnalyses/FCChh/tth_4l/dataframe/fcchh_ana_tth_4l.cxx
+++ b/FCChhAnalyses/FCChh/tth_4l/dataframe/fcchh_ana_tth_4l.cxx
@@ -7,7 +7,7 @@
 #include "datamodel/ParticleData.h"
 #include "datamodel/LorentzVector.h"
 #include "datamodel/JetData.h"
-#include "datamodel/FloatData.h"
+#include "datamodel/FloatValueData.h"
 #include "datamodel/TaggedParticleData.h"
 #include "datamodel/TaggedJetData.h"
 
@@ -67,7 +67,7 @@ int main(int argc, char* argv[]){
                       .Define("selected_lights", noMatchJets(0.2), {"jets_30_lights", "selected_leptons"})
                       .Define("nbjets", get_njets, {"selected_bs"})
                       .Define("njets", get_njets2, {"selected_bs", "selected_lights"})
-                      .Define("weight", id_float_legacy, {"mcEventWeights"})
+                      .Define("weight", id_float, {"mcEventWeights"})
                       .Define("n_selected_leptons", get_nparticles, {"selected_leptons"})
                     ;
   auto nentries = selectors.Count();

--- a/FCChhAnalyses/FCChh/tth_4l/dataframe/fcchh_ana_tth_4l.py
+++ b/FCChhAnalyses/FCChh/tth_4l/dataframe/fcchh_ana_tth_4l.py
@@ -53,7 +53,7 @@ df2 = df.Define("selected_electrons", "selectParticlesPtIso(20, 0.4)(electrons, 
         .Define("selected_lights", "noMatchJets(0.2)(jets_30_lights, selected_leptons)") \
         .Define("nbjets", "get_njets(selected_bs)") \
         .Define("njets", "get_njets2(selected_bs, selected_lights)") \
-        .Define("weight"," id_float_legacy(mcEventWeights)") \
+        .Define("weight"," id_float(mcEventWeights)") \
         .Define("n_selected_electrons", "get_nparticles(electrons)") \
         
          

--- a/FCChhAnalyses/FCChh/tth_boosted/analysis.py
+++ b/FCChhAnalyses/FCChh/tth_boosted/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/tth_boosted/analysis.py
+++ b/FCChhAnalyses/FCChh/tth_boosted/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy, math
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/tth_mumu/analysis.py
+++ b/FCChhAnalyses/FCChh/tth_mumu/analysis.py
@@ -11,7 +11,7 @@ reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
 # for the sample lists
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 
 # pre-produced input files

--- a/FCChhAnalyses/FCChh/tth_mumu/analysis.py
+++ b/FCChhAnalyses/FCChh/tth_mumu/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -9,7 +11,7 @@ reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
 # for the sample lists
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
 
 
 # pre-produced input files

--- a/FCChhAnalyses/FCChh/tttt/analysis.py
+++ b/FCChhAnalyses/FCChh/tttt/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/tttt/analysis.py
+++ b/FCChhAnalyses/FCChh/tttt/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/vbs/analysis.py
+++ b/FCChhAnalyses/FCChh/vbs/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/vbs/analysis.py
+++ b/FCChhAnalyses/FCChh/vbs/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/vbs_ww/analysis.py
+++ b/FCChhAnalyses/FCChh/vbs_ww/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/vbs_ww/analysis.py
+++ b/FCChhAnalyses/FCChh/vbs_ww/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/Dijet_reso/analysis.py
+++ b/FCChhAnalyses/HELHC/Dijet_reso/analysis.py
@@ -11,14 +11,14 @@ import imp
 logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
-sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 comp = cfg.Component(
     'example',
      files = ["/eos/experiment/fcc/helhc/generation/DelphesEvents/helhc_v01/p8_pp_ExcitedQ_10TeV_qq/events_145027450.root"]
      #files = ["/eos/experiment/fcc/helhc/generation/DelphesEvents/helhc_v01/mgp8_pp_jj_5f_HT_2000_5000/events_163309325.root"]
 )
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 selectedComponents = [
     sample.p8_pp_ExcitedQ_2TeV_qq,

--- a/FCChhAnalyses/HELHC/Dijet_reso/analysis.py
+++ b/FCChhAnalyses/HELHC/Dijet_reso/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -9,14 +11,14 @@ import imp
 logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.environ['FCCDICTSDIR'], '') + '')
 comp = cfg.Component(
     'example',
      files = ["/eos/experiment/fcc/helhc/generation/DelphesEvents/helhc_v01/p8_pp_ExcitedQ_10TeV_qq/events_145027450.root"]
      #files = ["/eos/experiment/fcc/helhc/generation/DelphesEvents/helhc_v01/mgp8_pp_jj_5f_HT_2000_5000/events_163309325.root"]
 )
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 selectedComponents = [
     sample.p8_pp_ExcitedQ_2TeV_qq,

--- a/FCChhAnalyses/HELHC/RSGraviton_ww/analysis.py
+++ b/FCChhAnalyses/HELHC/RSGraviton_ww/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/RSGraviton_ww/analysis.py
+++ b/FCChhAnalyses/HELHC/RSGraviton_ww/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/Zprime_ll/analysis.py
+++ b/FCChhAnalyses/HELHC/Zprime_ll/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/Zprime_ll/analysis.py
+++ b/FCChhAnalyses/HELHC/Zprime_ll/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/Zprime_mumu_flav_ano/analysis.py
+++ b/FCChhAnalyses/HELHC/Zprime_mumu_flav_ano/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/Zprime_mumu_flav_ano/analysis.py
+++ b/FCChhAnalyses/HELHC/Zprime_mumu_flav_ano/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/Zprime_tautau/analysis.py
+++ b/FCChhAnalyses/HELHC/Zprime_tautau/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.environ['FCCDICTSDIR'] + '/HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/Zprime_tautau/analysis.py
+++ b/FCChhAnalyses/HELHC/Zprime_tautau/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', os.environ['FCCDICTSDIR'] + '/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.getenv('FCCDICTSDIR', deffccdicts) + '/HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/Zprime_tt/analysis.py
+++ b/FCChhAnalyses/HELHC/Zprime_tt/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/Zprime_tt/analysis.py
+++ b/FCChhAnalyses/HELHC/Zprime_tt/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/tth_boosted/analysis.py
+++ b/FCChhAnalyses/HELHC/tth_boosted/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy, math
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/tth_boosted/analysis.py
+++ b/FCChhAnalyses/HELHC/tth_boosted/analysis.py
@@ -10,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', os.path.join(os.environ['FCCDICTSDIR'], '') + 'HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/analyzers/dataframe/FCCAnalyses.cc
+++ b/analyzers/dataframe/FCCAnalyses.cc
@@ -188,14 +188,6 @@ ROOT::VecOps::RVec<float> id_float(ROOT::VecOps::RVec<fcc::FloatValueData> x) {
   return result;
 }
 
-ROOT::VecOps::RVec<float> id_float_legacy(ROOT::VecOps::RVec<fcc::FloatData> x) {
-  ROOT::VecOps::RVec<float> result;
-  for (auto & p: x) {
-    result.push_back(p.value);
-  }
-  return result;
-}
-
 ROOT::VecOps::RVec<float> get_mass(ROOT::VecOps::RVec<fcc::ParticleData> x) {
   ROOT::VecOps::RVec<float> result;
   for (auto & p: x) {

--- a/analyzers/dataframe/FCCAnalyses.h
+++ b/analyzers/dataframe/FCCAnalyses.h
@@ -16,9 +16,6 @@
 #include "datamodel/Point.h"
 #include "datamodel/LorentzVector.h"
 #include "datamodel/FloatValueData.h"
-// legacy
-#include "datamodel/FloatData.h"
-
 
 
 /// transverse mass 
@@ -129,9 +126,6 @@ ROOT::VecOps::RVec<fcc::ParticleData> operator()(ROOT::VecOps::RVec<fcc::JetData
 
 /// cast FloatValueData to a primitive float
 ROOT::VecOps::RVec<float> id_float(ROOT::VecOps::RVec<fcc::FloatValueData> x);
-
-/// cast FloatData (used in earlier versions of fcc-edm) to a primitive float
-ROOT::VecOps::RVec<float> id_float_legacy(ROOT::VecOps::RVec<fcc::FloatData> x);
 
 /// return the masses of the input particles
 ROOT::VecOps::RVec<float> get_mass(ROOT::VecOps::RVec<fcc::ParticleData> x); 

--- a/analyzers/dataframe/LinkDef.h
+++ b/analyzers/dataframe/LinkDef.h
@@ -20,7 +20,7 @@
 #pragma link C++ function merge_particles;
 #pragma link C++ class ResonanceBuilder;
 #pragma link C++ function id_float;
-#pragma link C++ function id_float_legacy;
+
 #pragma link C++ function get_mass;
 #pragma link C++ function get_n_particles;
 #pragma link C++ function get_n_particles_rvec;

--- a/common_defaults.py
+++ b/common_defaults.py
@@ -1,0 +1,1 @@
+deffccdicts     = "/afs/cern.ch/work/h/helsens/public/FCCDicts/"

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
-#!/bin/sh -u
+#!/bin/bash
 source /cvmfs/fcc.cern.ch/sw/latest/setup.sh
 
-export PATH=/cvmfs/sft.cern.ch/lcg/releases/CMake/3.11.1-773ff/x86_64-centos7-gcc8-opt/bin/:$PATH
+export PATH=/cvmfs/sft.cern.ch/lcg/contrib/CMake/latest/Linux-x86_64/bin/:$PATH
 export PYTHONPATH=$PWD:$PYTHONPATH
 export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
 export ROOT_INCLUDE_PATH=$PWD/install/include:$ROOT_INCLUDE_PATH


### PR DESCRIPTION
This PR adds support for controlling the FCCDicts dir with env FCCDICTSDIR

FCCDICTSDIR should point to a directory containing the json files and the rest.
For example, on lxplus:

    $ export FCCDICTSDIR=/afs/cern.ch/work/h/helsens/public/FCCDicts/

(the trailing '/' is optional, it will be checked and added inside)

The default is called 'deffccdicts' read from the new file common_default.py .
It is currently set to '/afs/cern.ch/work/h/helsens/public/FCCDicts/' , so nothing
should change for people able to address that directory.
