### PR TITLE
No afs

### DIFF
--- a/FCCeeAnalyses/ZH_Zee/dataframe/finalSel.py
+++ b/FCCeeAnalyses/ZH_Zee/dataframe/finalSel.py
@@ -1,11 +1,18 @@
 from common_defaults import deffccdicts
 
 #python FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py 
-import os
+import os, sys
 import ROOT
 
 ###Input directory where the files produced at the pre-selection level are
-baseDir  = "/home/ganis/local/fcc/work/tutorials/aug2020/ch/FCCAnalyses/Outputs/FCCee/ZH_Zmumu/"
+defbaseDir = os.path.join(os.getenv('PWD',''), '') + "FCCAnalyses/Outputs/FCCee/ZH_Zmumu/"
+baseDir = os.path.join(os.getenv('FCCANAOUT', defbaseDir), '')
+if not os.path.exists(baseDir):
+    try:
+        os.makedirs(baseDir)
+    except:
+        print("Output directory " , baseDir ,  " could not be created - exit")
+        sys.exit(1)
 
 ###Link to the dictonary that contains all the cross section informations etc...
 procDict = os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + "FCCee_procDict_fcc_v01.json"

--- a/FCCeeAnalyses/ZH_Zee/dataframe/finalSel.py
+++ b/FCCeeAnalyses/ZH_Zee/dataframe/finalSel.py
@@ -1,11 +1,14 @@
+from common_defaults import deffccdicts
+
 #python FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py 
+import os
 import ROOT
 
 ###Input directory where the files produced at the pre-selection level are
-baseDir  = "/afs/cern.ch/user/h/helsens/FCCsoft/FCCAnalyses/Outputs/FCCee/ZH_Zmumu/"
+baseDir  = "/home/ganis/local/fcc/work/tutorials/aug2020/ch/FCCAnalyses/Outputs/FCCee/ZH_Zmumu/"
 
 ###Link to the dictonary that contains all the cross section informations etc...
-procDict = "/afs/cern.ch/work/h/helsens/public/FCCDicts/FCCee_procDict_fcc_v01.json"
+procDict = os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + "FCCee_procDict_fcc_v01.json"
 
 process_list=['p8_ee_ZZ_ecm240','p8_ee_WW_ecm240','p8_ee_ZH_ecm240']
 

--- a/FCCeeAnalyses/ZH_Zee/dataframe/preSel.py
+++ b/FCCeeAnalyses/ZH_Zee/dataframe/preSel.py
@@ -1,6 +1,9 @@
-#python FCCeeAnalyses/ZH_Zmumu/dataframe/preSel.py 
+from common_defaults import deffccdicts
 
-basedir="/afs/cern.ch/work/h/helsens/public/FCCDicts/yaml/FCCee/fcc_v01/"
+#python FCCeeAnalyses/ZH_Zmumu/dataframe/preSel.py 
+import os
+
+basedir=os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + "yaml/FCCee/fcc_v01/"
 outdir="FCCee/ZH_Zmumu/"
 NUM_CPUS = 15
 process_list=['p8_ee_ZZ_ecm240','p8_ee_WW_ecm240','p8_ee_ZH_ecm240']

--- a/FCCeeAnalyses/ZH_Zee/heppy/analysis.py
+++ b/FCCeeAnalyses/ZH_Zee/heppy/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), ''))
 
 comp = cfg.Component(
     'example',

--- a/FCCeeAnalyses/ZH_Zmumu/dataframe/#finalSel.py#
+++ b/FCCeeAnalyses/ZH_Zmumu/dataframe/#finalSel.py#
@@ -1,0 +1,37 @@
+#python FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py 
+import ROOT
+
+###Input directory where the files produced at the pre-selection level are
+baseDir  = "FCCee/ZH_Zmumu/"
+
+###Link to the dictonary that contains all the cross section informations etc...
+procDict = "/afs/cern.ch/work/h/helsens/public/FCCDicts/FCCee_procDict_fcc_v01.json"
+
+process_list=['p8_ee_ZZ_ecm240','p8_ee_WW_ecm240','p8_ee_ZH_ecm240']
+
+###Dictionnay of the list of cuts. The key is the name of the selection that will be added to the output file
+cut_list = {"sel0":"zed_leptonic_m.size() == 1",
+            "sel1":"zed_leptonic_m.size() == 1 && zed_leptonic_m[0] > 80 &&  zed_leptonic_m[0] < 100",
+            "sel2":"zed_leptonic_m.size() == 1 && zed_leptonic_m[0] > 80 &&  zed_leptonic_m[0] < 100 && nbjets==2",
+            "sel3":"zed_leptonic_m.size() == 1 && higgs_hadronic_b_m.size() ==1 && zed_leptonic_m[0] > 80 &&  zed_leptonic_m[0] < 100 && nbjets==2"
+            }
+
+
+###Dictionary for the ouput variable/hitograms. The key is the name of the variable in the output files. "name" is the name of the variable in the input file, "title" is the x-axis label of the histogram, "bin" the number of bins of the histogram, "xmin" the minimum x-axis value and "xmax" the maximum x-axis value.
+variables = {
+    "mz":{"name":"zed_leptonic_m","title":"m_{Z} [GeV]","bin":125,"xmin":0,"xmax":250},
+    "mz_zoom":{"name":"zed_leptonic_m","title":"m_{Z} [GeV]","bin":40,"xmin":80,"xmax":100},
+    "nbjets":{"name":"nbjets","title":"number of bjets","bin":10,"xmin":0,"xmax":10},
+    "leptonic_recoil_m":{"name":"zed_leptonic_recoil_m","title":"Z leptonic recoil [GeV]","bin":100,"xmin":0,"xmax":200},
+    "leptonic_recoil_m_zoom":{"name":"zed_leptonic_recoil_m","title":"Z leptonic recoil [GeV]","bin":100,"xmin":120,"xmax":140},
+    "leptonic_recoil_m_zoom2":{"name":"zed_leptonic_recoil_m","title":"Z leptonic recoil [GeV]","bin":200,"xmin":120,"xmax":140},
+    "higgs_hadronic_b_mass":{"name":"higgs_hadronic_b_m","title":"Higgs hadronic bb mass [GeV]","bin":100,"xmin":0,"xmax":200},
+}
+
+###Number of CPUs to use
+NUM_CPUS = 10
+
+###This part is standard to all analyses
+import bin.runDataFrameFinal as rdf
+myana=rdf.runDataFrameFinal(baseDir,procDict,process_list,cut_list,variables)
+myana.run(ncpu=NUM_CPUS)

--- a/FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py
+++ b/FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py
@@ -1,11 +1,14 @@
+from common_defaults import deffccdicts
+
 #python FCCeeAnalyses/ZH_Zmumu/dataframe/finalSel.py 
+import sys, os
 import ROOT
 
 ###Input directory where the files produced at the pre-selection level are
 baseDir  = "FCCee/ZH_Zmumu/"
 
 ###Link to the dictonary that contains all the cross section informations etc...
-procDict = "/afs/cern.ch/work/h/helsens/public/FCCDicts/FCCee_procDict_fcc_v01.json"
+procDict = os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + "FCCee_procDict_fcc_v01.json"
 
 process_list=['p8_ee_ZZ_ecm240','p8_ee_WW_ecm240','p8_ee_ZH_ecm240']
 
@@ -32,6 +35,8 @@ variables = {
 NUM_CPUS = 10
 
 ###This part is standard to all analyses
-import bin.runDataFrameFinal as rdf
+sys.path.append('./bin')
+import runDataFrameFinal as rdf
+#import bin.runDataFrameFinal as rdf
 myana=rdf.runDataFrameFinal(baseDir,procDict,process_list,cut_list,variables)
 myana.run(ncpu=NUM_CPUS)

--- a/FCCeeAnalyses/ZH_Zmumu/dataframe/preSel.py
+++ b/FCCeeAnalyses/ZH_Zmumu/dataframe/preSel.py
@@ -1,6 +1,8 @@
-#python FCCeeAnalyses/ZH_Zmumu/dataframe/preSel.py 
+from common_defaults import deffccdicts
+ #python FCCeeAnalyses/ZH_Zmumu/dataframe/preSel.py 
+import os
 
-basedir="/afs/cern.ch/work/h/helsens/public/FCCDicts/yaml/FCCee/fcc_v01/"
+basedir=os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + "yaml/FCCee/fcc_v01/"
 outdir="FCCee/ZH_Zmumu/"
 NUM_CPUS = 15
 process_list=['p8_ee_ZZ_ecm240','p8_ee_WW_ecm240','p8_ee_ZH_ecm240']

--- a/FCCeeAnalyses/ZH_Zmumu/heppy/analysis.py
+++ b/FCCeeAnalyses/ZH_Zmumu/heppy/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), ''))
 
 comp = cfg.Component(
     'example',

--- a/FCCeeAnalyses/tt/analysis.py
+++ b/FCCeeAnalyses/tt/analysis.py
@@ -1,3 +1,4 @@
+from common_defaults import deffccdicts
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +9,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), ''))
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/Dijet_reso/analysis.py
+++ b/FCChhAnalyses/FCChh/Dijet_reso/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -9,13 +11,13 @@ import imp
 logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 comp = cfg.Component(
     'example',
      files = ["/eos/experiment/fcc/hh/generation/DelphesEvents/fcc_v02/p8_pp_ExcitedQ_30TeV_qq/events_113722907.root"]
 )
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 selectedComponents = [
 

--- a/FCChhAnalyses/FCChh/RSGraviton_ww/analysis.py
+++ b/FCChhAnalyses/FCChh/RSGraviton_ww/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/W_top_vs_QCD_tagger/analysis.py
+++ b/FCChhAnalyses/FCChh/W_top_vs_QCD_tagger/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/Zprime_ll/analysis.py
+++ b/FCChhAnalyses/FCChh/Zprime_ll/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/Zprime_mumu_flav_ano/analysis.py
+++ b/FCChhAnalyses/FCChh/Zprime_mumu_flav_ano/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/Zprime_tautau/analysis.py
+++ b/FCChhAnalyses/FCChh/Zprime_tautau/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/Zprime_tt/analysis.py
+++ b/FCChhAnalyses/FCChh/Zprime_tt/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/h2l2v/analysis.py
+++ b/FCChhAnalyses/FCChh/h2l2v/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/h4l/analysis.py
+++ b/FCChhAnalyses/FCChh/h4l/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/haa/analysis.py
+++ b/FCChhAnalyses/FCChh/haa/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy, math
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hh_boosted/analysis.py
+++ b/FCChhAnalyses/FCChh/hh_boosted/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy, math
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hhbbaa/analysis.py
+++ b/FCChhAnalyses/FCChh/hhbbaa/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hhbbaa/analysis_fakes.py
+++ b/FCChhAnalyses/FCChh/hhbbaa/analysis_fakes.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys, math
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hmumu/analysis.py
+++ b/FCChhAnalyses/FCChh/hmumu/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/hza/analysis.py
+++ b/FCChhAnalyses/FCChh/hza/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/ttV_test/analysis.py
+++ b/FCChhAnalyses/FCChh/ttV_test/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/tth_4l/analysis.py
+++ b/FCChhAnalyses/FCChh/tth_4l/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import imp
 import copy
@@ -9,8 +11,8 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 
 comps = cfg.Component(

--- a/FCChhAnalyses/FCChh/tth_4l/dataframe/fcchh_ana_tth_4l.cxx
+++ b/FCChhAnalyses/FCChh/tth_4l/dataframe/fcchh_ana_tth_4l.cxx
@@ -7,9 +7,10 @@
 #include "datamodel/ParticleData.h"
 #include "datamodel/LorentzVector.h"
 #include "datamodel/JetData.h"
-#include "datamodel/FloatData.h"
 #include "datamodel/TaggedParticleData.h"
 #include "datamodel/TaggedJetData.h"
+# Legacy class
+#include "utilities/FloatData.h"
 
 #include "FCCAnalyses.h"
 

--- a/FCChhAnalyses/FCChh/tth_4l/dataframe/fcchh_ana_tth_4l.cxx
+++ b/FCChhAnalyses/FCChh/tth_4l/dataframe/fcchh_ana_tth_4l.cxx
@@ -9,7 +9,7 @@
 #include "datamodel/JetData.h"
 #include "datamodel/TaggedParticleData.h"
 #include "datamodel/TaggedJetData.h"
-# Legacy class
+// Legacy class
 #include "utilities/FloatData.h"
 
 #include "FCCAnalyses.h"

--- a/FCChhAnalyses/FCChh/tth_boosted/analysis.py
+++ b/FCChhAnalyses/FCChh/tth_boosted/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy, math
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/tth_mumu/analysis.py
+++ b/FCChhAnalyses/FCChh/tth_mumu/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -9,7 +11,7 @@ reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
 # for the sample lists
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 
 # pre-produced input files

--- a/FCChhAnalyses/FCChh/tttt/analysis.py
+++ b/FCChhAnalyses/FCChh/tttt/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/FCC_heppySampleList_fcc_v02.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'FCC_heppySampleList_fcc_v02.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/vbs/analysis.py
+++ b/FCChhAnalyses/FCChh/vbs/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/FCChh/vbs_ww/analysis.py
+++ b/FCChhAnalyses/FCChh/vbs_ww/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/Dijet_reso/analysis.py
+++ b/FCChhAnalyses/HELHC/Dijet_reso/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -9,14 +11,14 @@ import imp
 logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
-sys.path.append('/afs/cern.ch/work/h/helsens/public/FCCDicts/')
+sys.path.append(os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + '')
 comp = cfg.Component(
     'example',
      files = ["/eos/experiment/fcc/helhc/generation/DelphesEvents/helhc_v01/p8_pp_ExcitedQ_10TeV_qq/events_145027450.root"]
      #files = ["/eos/experiment/fcc/helhc/generation/DelphesEvents/helhc_v01/mgp8_pp_jj_5f_HT_2000_5000/events_163309325.root"]
 )
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 selectedComponents = [
     sample.p8_pp_ExcitedQ_2TeV_qq,

--- a/FCChhAnalyses/HELHC/RSGraviton_ww/analysis.py
+++ b/FCChhAnalyses/HELHC/RSGraviton_ww/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/Zprime_ll/analysis.py
+++ b/FCChhAnalyses/HELHC/Zprime_ll/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/Zprime_mumu_flav_ano/analysis.py
+++ b/FCChhAnalyses/HELHC/Zprime_mumu_flav_ano/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/Zprime_tautau/analysis.py
+++ b/FCChhAnalyses/HELHC/Zprime_tautau/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.getenv('FCCDICTSDIR', deffccdicts) + '/HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/Zprime_tt/analysis.py
+++ b/FCChhAnalyses/HELHC/Zprime_tt/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os
 import copy
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/FCChhAnalyses/HELHC/tth_boosted/analysis.py
+++ b/FCChhAnalyses/HELHC/tth_boosted/analysis.py
@@ -1,3 +1,5 @@
+from common_defaults import deffccdicts
+
 import os, sys
 import copy, math
 import heppy.framework.config as cfg
@@ -8,7 +10,7 @@ logging.shutdown()
 reload(logging)
 logging.basicConfig(level=logging.WARNING)
 
-sample=imp.load_source('heppylist', '/afs/cern.ch/work/h/helsens/public/FCCDicts/HELHC_heppySampleList_helhc_v01.py')
+sample=imp.load_source('heppylist', os.path.join(os.getenv('FCCDICTSDIR', deffccdicts), '') + 'HELHC_heppySampleList_helhc_v01.py')
 
 comp = cfg.Component(
     'example',

--- a/analyzers/dataframe/FCCAnalyses.h
+++ b/analyzers/dataframe/FCCAnalyses.h
@@ -17,7 +17,7 @@
 #include "datamodel/LorentzVector.h"
 #include "datamodel/FloatValueData.h"
 // legacy
-#include "datamodel/FloatData.h"
+#include "utilities/FloatData.h"
 
 
 

--- a/common_defaults.py
+++ b/common_defaults.py
@@ -1,0 +1,1 @@
+deffccdicts     = "/afs/cern.ch/work/h/helsens/public/FCCDicts/"

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
-#!/bin/sh -u
+#!/bin/bash
 source /cvmfs/fcc.cern.ch/sw/latest/setup.sh
 
-export PATH=/cvmfs/sft.cern.ch/lcg/releases/CMake/3.11.1-773ff/x86_64-centos7-gcc8-opt/bin/:$PATH
+export PATH=/cvmfs/sft.cern.ch/lcg/contrib/CMake/latest/Linux-x86_64/bin/:$PATH
 export PYTHONPATH=$PWD:$PYTHONPATH
 export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
 export ROOT_INCLUDE_PATH=$PWD/install/include:$ROOT_INCLUDE_PATH


### PR DESCRIPTION
This PR, replacing #22, adds support for controlling the FCCDicts dir with env FCCDICTSDIR

FCCDICTSDIR should point to a directory containing the json files and the rest.
For example, on lxplus:

$ export FCCDICTSDIR=/afs/cern.ch/work/h/helsens/public/FCCDicts/
(the trailing '/' is optional, it will be checked and added inside)

The default is called 'deffccdicts' read from the new file common_default.py .
It is currently set to '/afs/cern.ch/work/h/helsens/public/FCCDicts/' , so nothing
should change for people able to address that directory.