### PR TITLE
Access detector geometry

### DIFF
--- a/analyzers/dataframe/CMakeLists.txt
+++ b/analyzers/dataframe/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 find_package(ROOT REQUIRED COMPONENTS ROOTDataFrame ROOTVecOps TMVA)
+find_package(DD4hep)
 include(${ROOT_USE_FILE})
 #include("${ROOT_DIR}/modules/RootNewMacros.cmake")
 
@@ -62,6 +63,8 @@ target_link_libraries(FCCAnalyses
 		      EDM4HEP::edm4hep 
 		      EDM4HEP::edm4hepDict 
 		      podio::podio 
+              DD4hep::DDCore
+
 		      ${FASTJET_LIBRARY} fastjetplugins
 		      ${acts_LIBRARY} ActsCore
 		      #${AWKWARD_LIBRARIES}

--- a/analyzers/dataframe/CaloNtupleizer.cc
+++ b/analyzers/dataframe/CaloNtupleizer.cc
@@ -5,12 +5,55 @@
 
 #include <math.h>
 
+#include "DD4hep/Detector.h"
+
 using namespace CaloNtupleizer;
+
+dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
+
+void CaloNtupleizer::loadGeometry(std::string xmlGeometryPath){
+//void loadGeometry(std::string xmlGeometryPath){
+  dd4hep::Detector* dd4hepgeo = &(dd4hep::Detector::getInstance());
+  //dd4hepgeo->fromCompact("/afs/cern.ch/user/b/brfranco/work/public/Fellow/FCCSW/dummy_releases/Mark_Test2/FCCDetectors/Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectMaster.xml");
+  //std::string xml = "/afs/cern.ch/user/b/brfranco/work/public/Fellow/FCCSW/dummy_releases/Mark_Test2/FCCDetectors/Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectMaster.xml";
+  dd4hepgeo->fromCompact(xmlGeometryPath);
+  dd4hepgeo->volumeManager();
+  dd4hepgeo->apply("DD4hepVolumeManager", 0, 0);
+  
+  //dd4hep::DDSegmentation::BitFieldCoder* m_decoder = dd4hepgeo->readout("ECalBarrelPhiEta").idSpec().decoder();
+  m_decoder = dd4hepgeo->readout("ECalBarrelPhiEta").idSpec().decoder();
+
+  
+  //dd4hep::DDSegmentation::BitFieldCoder* m_decoder = new dd4hep::DDSegmentation::BitFieldCoder("system:4");
+
+  //auto decoder = m_geoSvc->lcdd()->readout(m_readoutName).idSpec().decoder();
+
+  //dd4hep::DDSegmentation::CellID cellId = positionedHit.getCellID();
+
+  //dd4hep::DDSegmentation::CellID cellId = 103121172484;
+  //auto systemId = m_decoder->get(cellId, "system");
+  //std::cout << "systemId " << systemId << std::endl;
+  //auto layerId = m_decoder->get(cellId, "layer");
+  //auto phiId = m_decoder->get(cellId, "phi");
+  //auto etaId = m_decoder->get(cellId, "eta");
+  //std::cout << "layerId " << layerId << std::endl;
+  //std::cout << "phiId " << phiId << std::endl;
+  //std::cout << "etaId " << etaId << std::endl;
+  
+  //dd4hep::Detector* dd4hepgeo;// = &(dd4hep::Detector::getInstance());
+  //dd4hep::Detector* dd4hepgeo = &(dd4hep::Detector::getInstance());
+  //dd4hepgeo->fromCompact(xmlGeometryPath);
+
+
+
+}
+
 
 // calo hit
 ROOT::VecOps::RVec<float> CaloNtupleizer::getCaloHit_x (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in){
   ROOT::VecOps::RVec<float> result;
   for (auto & p: in){
+     // std::cout << p.cellID << std::endl;
     result.push_back(p.position.x);
   }
   return result;
@@ -42,6 +85,15 @@ ROOT::VecOps::RVec<float> CaloNtupleizer::getCaloHit_phi (ROOT::VecOps::RVec<edm
   return result;
 }
 
+ROOT::VecOps::RVec<int> CaloNtupleizer::getCaloHit_phiBin (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in){
+  ROOT::VecOps::RVec<int> result;
+  for (auto & p: in){
+    dd4hep::DDSegmentation::CellID cellId = p.cellID;
+    result.push_back(m_decoder->get(cellId, "phi"));
+  }
+  return result;
+}
+
 ROOT::VecOps::RVec<float> CaloNtupleizer::getCaloHit_theta (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in){
   ROOT::VecOps::RVec<float> result;
   for (auto & p: in){
@@ -62,10 +114,28 @@ ROOT::VecOps::RVec<float> CaloNtupleizer::getCaloHit_eta (ROOT::VecOps::RVec<edm
   return result;
 }
 
+ROOT::VecOps::RVec<int> CaloNtupleizer::getCaloHit_etaBin (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in){
+  ROOT::VecOps::RVec<int> result;
+  for (auto & p: in){
+    dd4hep::DDSegmentation::CellID cellId = p.cellID;
+    result.push_back(m_decoder->get(cellId, "eta"));
+  }
+  return result;
+}
+
 ROOT::VecOps::RVec<float> CaloNtupleizer::getCaloHit_energy (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in){
   ROOT::VecOps::RVec<float> result;
   for (auto & p: in){
     result.push_back(p.energy);
+  }
+  return result;
+}
+
+ROOT::VecOps::RVec<int> CaloNtupleizer::getCaloHit_layer (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in){
+  ROOT::VecOps::RVec<int> result;
+  for (auto & p: in){
+    dd4hep::DDSegmentation::CellID cellId = p.cellID;
+    result.push_back(m_decoder->get(cellId, "layer"));
   }
   return result;
 }

--- a/analyzers/dataframe/CaloNtupleizer.cc
+++ b/analyzers/dataframe/CaloNtupleizer.cc
@@ -12,40 +12,11 @@ using namespace CaloNtupleizer;
 dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
 
 void CaloNtupleizer::loadGeometry(std::string xmlGeometryPath){
-//void loadGeometry(std::string xmlGeometryPath){
   dd4hep::Detector* dd4hepgeo = &(dd4hep::Detector::getInstance());
-  //dd4hepgeo->fromCompact("/afs/cern.ch/user/b/brfranco/work/public/Fellow/FCCSW/dummy_releases/Mark_Test2/FCCDetectors/Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectMaster.xml");
-  //std::string xml = "/afs/cern.ch/user/b/brfranco/work/public/Fellow/FCCSW/dummy_releases/Mark_Test2/FCCDetectors/Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectMaster.xml";
   dd4hepgeo->fromCompact(xmlGeometryPath);
   dd4hepgeo->volumeManager();
   dd4hepgeo->apply("DD4hepVolumeManager", 0, 0);
-  
-  //dd4hep::DDSegmentation::BitFieldCoder* m_decoder = dd4hepgeo->readout("ECalBarrelPhiEta").idSpec().decoder();
   m_decoder = dd4hepgeo->readout("ECalBarrelPhiEta").idSpec().decoder();
-
-  
-  //dd4hep::DDSegmentation::BitFieldCoder* m_decoder = new dd4hep::DDSegmentation::BitFieldCoder("system:4");
-
-  //auto decoder = m_geoSvc->lcdd()->readout(m_readoutName).idSpec().decoder();
-
-  //dd4hep::DDSegmentation::CellID cellId = positionedHit.getCellID();
-
-  //dd4hep::DDSegmentation::CellID cellId = 103121172484;
-  //auto systemId = m_decoder->get(cellId, "system");
-  //std::cout << "systemId " << systemId << std::endl;
-  //auto layerId = m_decoder->get(cellId, "layer");
-  //auto phiId = m_decoder->get(cellId, "phi");
-  //auto etaId = m_decoder->get(cellId, "eta");
-  //std::cout << "layerId " << layerId << std::endl;
-  //std::cout << "phiId " << phiId << std::endl;
-  //std::cout << "etaId " << etaId << std::endl;
-  
-  //dd4hep::Detector* dd4hepgeo;// = &(dd4hep::Detector::getInstance());
-  //dd4hep::Detector* dd4hepgeo = &(dd4hep::Detector::getInstance());
-  //dd4hepgeo->fromCompact(xmlGeometryPath);
-
-
-
 }
 
 
@@ -53,7 +24,6 @@ void CaloNtupleizer::loadGeometry(std::string xmlGeometryPath){
 ROOT::VecOps::RVec<float> CaloNtupleizer::getCaloHit_x (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in){
   ROOT::VecOps::RVec<float> result;
   for (auto & p: in){
-     // std::cout << p.cellID << std::endl;
     result.push_back(p.position.x);
   }
   return result;

--- a/analyzers/dataframe/CaloNtupleizer.h
+++ b/analyzers/dataframe/CaloNtupleizer.h
@@ -13,15 +13,38 @@
 #include "TVector3.h"
 #include "TLorentzVector.h"
 
+#include "DD4hep/Detector.h"
+
 namespace CaloNtupleizer{
+
+//class geometry_toolbox {
+//  public:
+//    dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
+//    geometry_toolbox(std::string xmlGeometryPath) {
+//      dd4hep::Detector* dd4hepgeo = &(dd4hep::Detector::getInstance());
+//      dd4hepgeo->fromCompact(xmlGeometryPath);
+//      dd4hepgeo->volumeManager();
+//      dd4hepgeo->apply("DD4hepVolumeManager", 0, 0);
+//      m_decoder = dd4hepgeo->readout("ECalBarrelPhiEta").idSpec().decoder();
+//    }
+//};
+
+void loadGeometry(std::string xmlGeometryPath);
+
+//dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
+//dd4hep::Detector* dd4hepgeo;
+//IDDescriptors
 
 // calo hits (single cells)
 ROOT::VecOps::RVec<float> getCaloHit_x (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in);
 ROOT::VecOps::RVec<float> getCaloHit_y (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in);
 ROOT::VecOps::RVec<float> getCaloHit_z (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in);
 ROOT::VecOps::RVec<float> getCaloHit_phi (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in);
+ROOT::VecOps::RVec<int> getCaloHit_phiBin (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in);
 ROOT::VecOps::RVec<float> getCaloHit_theta (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in);
 ROOT::VecOps::RVec<float> getCaloHit_eta (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in);
+ROOT::VecOps::RVec<int> getCaloHit_etaBin (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in);
+ROOT::VecOps::RVec<int> getCaloHit_layer (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in);
 ROOT::VecOps::RVec<float> getCaloHit_energy (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in);
 ROOT::VecOps::RVec<TVector3> getCaloHit_positionVector3 (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in);
 

--- a/analyzers/dataframe/CaloNtupleizer.h
+++ b/analyzers/dataframe/CaloNtupleizer.h
@@ -13,27 +13,9 @@
 #include "TVector3.h"
 #include "TLorentzVector.h"
 
-#include "DD4hep/Detector.h"
-
 namespace CaloNtupleizer{
 
-//class geometry_toolbox {
-//  public:
-//    dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
-//    geometry_toolbox(std::string xmlGeometryPath) {
-//      dd4hep::Detector* dd4hepgeo = &(dd4hep::Detector::getInstance());
-//      dd4hepgeo->fromCompact(xmlGeometryPath);
-//      dd4hepgeo->volumeManager();
-//      dd4hepgeo->apply("DD4hepVolumeManager", 0, 0);
-//      m_decoder = dd4hepgeo->readout("ECalBarrelPhiEta").idSpec().decoder();
-//    }
-//};
-
 void loadGeometry(std::string xmlGeometryPath);
-
-//dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
-//dd4hep::Detector* dd4hepgeo;
-//IDDescriptors
 
 // calo hits (single cells)
 ROOT::VecOps::RVec<float> getCaloHit_x (ROOT::VecOps::RVec<edm4hep::CalorimeterHitData> in);

--- a/examples/FCCee/fullSim/caloNtupleizer/analysis.py
+++ b/examples/FCCee/fullSim/caloNtupleizer/analysis.py
@@ -30,8 +30,8 @@ parser.add_argument("-storeClusterCellsBranches", default = False, help="Whether
 parser.add_argument("-clusterCellsBranchNames", default = ["PositionedCaloClusterCells"], help="Name of the cluster-attached-cells branches in the input rootfile. Order must follow -clusterBranchNames and the cells must have positions attached!", type = str, nargs = '+')
 parser.add_argument("-storeGenBranches", default = True, help="Whether or not to store gen information", type = str2bool)
 parser.add_argument("-genBranchName", default = "genParticles", help="Name of the gen particle branch in the input rootfile", type = str)
-parser.add_argument("-storeSimParticleSecondaries", default = False, help="Whether to store the SimParticleSecondaries information", type = str2bool)
-parser.add_argument("-simParticleSecondariesNames", default = ["SimParticleSecondaries"],  help = "name of the SimParticleSecondaries branch", type = str)
+parser.add_argument("-storeSimParticleSecondaries", default = False, help="Whether to store the SimParticleSecondaries information", type = str2bool) 
+parser.add_argument("-simParticleSecondariesNames", default = ["SimParticleSecondaries"],  help = "name of the SimParticleSecondaries branch", type = str) 
 parser.add_argument("-useGeometry", default = True, help="Whether or not to load the FCCSW geometry. Used to get the detector segmentation for e.g. the definition of the cell layer index.", type = str2bool)
 parser.add_argument("-geometryFile", default = '/afs/cern.ch/user/b/brfranco/work/public/Fellow/FCCSW/dummy_releases/Mark_Test2/FCCDetectors/Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectMaster.xml',  help = "Path to the xml geometry file", type = str)
 parser.add_argument("-readoutName", default = 'ECalBarrelPhiEta',  help = "Name of the readout to use for the layer/phi/theta bin definition", type = str)
@@ -63,13 +63,14 @@ class analysis():
                 dict_outputBranchName_function["%s_y"%cellBranchName] = "CaloNtupleizer::getCaloHit_y(%s)"%cellBranchName
                 dict_outputBranchName_function["%s_z"%cellBranchName] = "CaloNtupleizer::getCaloHit_z(%s)"%cellBranchName
                 dict_outputBranchName_function["%s_phi"%cellBranchName] = "CaloNtupleizer::getCaloHit_phi(%s)"%cellBranchName
-                dict_outputBranchName_function["%s_phiBin"%cellBranchName] = "CaloNtupleizer::getCaloHit_phiBin(%s)"%cellBranchName
                 dict_outputBranchName_function["%s_theta"%cellBranchName] = "CaloNtupleizer::getCaloHit_theta(%s)"%cellBranchName
                 dict_outputBranchName_function["%s_eta"%cellBranchName] = "CaloNtupleizer::getCaloHit_eta(%s)"%cellBranchName
-                dict_outputBranchName_function["%s_etaBin"%cellBranchName] = "CaloNtupleizer::getCaloHit_etaBin(%s)"%cellBranchName
-                dict_outputBranchName_function["%s_layer"%cellBranchName] = "CaloNtupleizer::getCaloHit_layer(%s)"%cellBranchName
                 #dict_outputBranchName_function["%s_position"%cellBranchName] = "CaloNtupleizer::getCaloHit_positionVector3(%s)"%cellBranchName
                 dict_outputBranchName_function["%s_energy"%cellBranchName] = "CaloNtupleizer::getCaloHit_energy(%s)"%cellBranchName
+                if args.useGeometry:
+                    dict_outputBranchName_function["%s_phiBin"%cellBranchName] = "CaloNtupleizer::getCaloHit_phiBin(%s)"%cellBranchName
+                    dict_outputBranchName_function["%s_layer"%cellBranchName] = "CaloNtupleizer::getCaloHit_layer(%s)"%cellBranchName
+                    dict_outputBranchName_function["%s_etaBin"%cellBranchName] = "CaloNtupleizer::getCaloHit_etaBin(%s)"%cellBranchName
 
         # clusters
         if args.storeClusterBranches:

--- a/examples/FCCee/fullSim/caloNtupleizer/analysis.py
+++ b/examples/FCCee/fullSim/caloNtupleizer/analysis.py
@@ -30,8 +30,11 @@ parser.add_argument("-storeClusterCellsBranches", default = False, help="Whether
 parser.add_argument("-clusterCellsBranchNames", default = ["PositionedCaloClusterCells"], help="Name of the cluster-attached-cells branches in the input rootfile. Order must follow -clusterBranchNames and the cells must have positions attached!", type = str, nargs = '+')
 parser.add_argument("-storeGenBranches", default = True, help="Whether or not to store gen information", type = str2bool)
 parser.add_argument("-genBranchName", default = "genParticles", help="Name of the gen particle branch in the input rootfile", type = str)
-parser.add_argument("-storeSimParticleSecondaries", default = False, help="Whether to store the SimParticleSecondaries information", type = str2bool) 
-parser.add_argument("-simParticleSecondariesNames", default = ["SimParticleSecondaries"],  help = "name of the SimParticleSecondaries branch", type = str) 
+parser.add_argument("-storeSimParticleSecondaries", default = False, help="Whether to store the SimParticleSecondaries information", type = str2bool)
+parser.add_argument("-simParticleSecondariesNames", default = ["SimParticleSecondaries"],  help = "name of the SimParticleSecondaries branch", type = str)
+parser.add_argument("-useGeometry", default = True, help="Whether or not to load the FCCSW geometry. Used to get the detector segmentation for e.g. the definition of the cell layer index.", type = str2bool)
+parser.add_argument("-geometryFile", default = '/afs/cern.ch/user/b/brfranco/work/public/Fellow/FCCSW/dummy_releases/Mark_Test2/FCCDetectors/Detector/DetFCCeeIDEA-LAr/compact/FCCee_DectMaster.xml',  help = "Path to the xml geometry file", type = str)
+parser.add_argument("-readoutName", default = 'ECalBarrelPhiEta',  help = "Name of the readout to use for the layer/phi/theta bin definition", type = str)
 
 args = parser.parse_args()
 
@@ -46,6 +49,8 @@ class analysis():
         ROOT.ROOT.EnableImplicitMT(ncpu)
 
         self.df = ROOT.RDataFrame("events", inputlist)
+        if args.useGeometry:
+            ROOT.CaloNtupleizer.loadGeometry(args.geometryFile)
 
     def run(self):
 
@@ -58,8 +63,11 @@ class analysis():
                 dict_outputBranchName_function["%s_y"%cellBranchName] = "CaloNtupleizer::getCaloHit_y(%s)"%cellBranchName
                 dict_outputBranchName_function["%s_z"%cellBranchName] = "CaloNtupleizer::getCaloHit_z(%s)"%cellBranchName
                 dict_outputBranchName_function["%s_phi"%cellBranchName] = "CaloNtupleizer::getCaloHit_phi(%s)"%cellBranchName
+                dict_outputBranchName_function["%s_phiBin"%cellBranchName] = "CaloNtupleizer::getCaloHit_phiBin(%s)"%cellBranchName
                 dict_outputBranchName_function["%s_theta"%cellBranchName] = "CaloNtupleizer::getCaloHit_theta(%s)"%cellBranchName
                 dict_outputBranchName_function["%s_eta"%cellBranchName] = "CaloNtupleizer::getCaloHit_eta(%s)"%cellBranchName
+                dict_outputBranchName_function["%s_etaBin"%cellBranchName] = "CaloNtupleizer::getCaloHit_etaBin(%s)"%cellBranchName
+                dict_outputBranchName_function["%s_layer"%cellBranchName] = "CaloNtupleizer::getCaloHit_layer(%s)"%cellBranchName
                 #dict_outputBranchName_function["%s_position"%cellBranchName] = "CaloNtupleizer::getCaloHit_positionVector3(%s)"%cellBranchName
                 dict_outputBranchName_function["%s_energy"%cellBranchName] = "CaloNtupleizer::getCaloHit_energy(%s)"%cellBranchName
 


### PR DESCRIPTION
This PR allows to make the link between the DD4hep geometry used in FCCSW and the caloNtupleizer. This is useful to easily access non-trivial geometrical information that are defined in the fullSim such as the sensitive detector segmentation.