### PR TITLE
Adding JetClusteringUtils::set_pseudoJets_xyzm and illustrating usage in examples/FCCee/top/hadronic/analysis.py

### DIFF
--- a/analyzers/dataframe/JetClusteringUtils.cc
+++ b/analyzers/dataframe/JetClusteringUtils.cc
@@ -25,6 +25,25 @@ std::vector<fastjet::PseudoJet> JetClusteringUtils::set_pseudoJets(ROOT::VecOps:
   return result;
 }
 
+std::vector<fastjet::PseudoJet> JetClusteringUtils::set_pseudoJets_xyzm(ROOT::VecOps::RVec<float> px, 
+								   ROOT::VecOps::RVec<float> py, 
+								   ROOT::VecOps::RVec<float> pz, 
+								   ROOT::VecOps::RVec<float> m) {
+  std::vector<fastjet::PseudoJet> result;
+  unsigned index = 0;
+  for (size_t i = 0; i < px.size(); ++i) {
+    double px_d = px.at(i);
+    double py_d = py.at(i);
+    double pz_d = pz.at(i);
+    double  m_d =  m.at(i);
+    double  E_d = sqrt(px_d*px_d + py_d*py_d + pz_d*pz_d + m_d*m_d);
+    result.emplace_back(px_d, py_D, pz_d, E_d);
+    result.back().set_user_index(index);
+    ++index;
+  }
+  return result;
+}
+
 
 ROOT::VecOps::RVec<float> JetClusteringUtils::get_px(ROOT::VecOps::RVec<fastjet::PseudoJet> in){
   ROOT::VecOps::RVec<float> result;

--- a/analyzers/dataframe/JetClusteringUtils.cc
+++ b/analyzers/dataframe/JetClusteringUtils.cc
@@ -37,7 +37,7 @@ std::vector<fastjet::PseudoJet> JetClusteringUtils::set_pseudoJets_xyzm(ROOT::Ve
     double pz_d = pz.at(i);
     double  m_d =  m.at(i);
     double  E_d = sqrt(px_d*px_d + py_d*py_d + pz_d*pz_d + m_d*m_d);
-    result.emplace_back(px_d, py_D, pz_d, E_d);
+    result.emplace_back(px_d, py_d, pz_d, E_d);
     result.back().set_user_index(index);
     ++index;
   }

--- a/analyzers/dataframe/JetClusteringUtils.h
+++ b/analyzers/dataframe/JetClusteringUtils.h
@@ -33,6 +33,19 @@ namespace JetClusteringUtils{
 						 ROOT::VecOps::RVec<float> pz, 
 						 ROOT::VecOps::RVec<float> e);
 
+  /** Set fastjet pseudoJet for later reconstruction using px, py, pz and m
+   * 
+   * This version is to be preferred over the px,py,pz,E version when m is known 
+   * accurately, because it uses double precision to reconstruct the energy, 
+   * reducing the size of rounding errors on FastJet calculations (e.g. of
+   * PseudoJet masses)
+   * 
+  */
+  std::vector<fastjet::PseudoJet> set_pseudoJets_xyzm(ROOT::VecOps::RVec<float> px, 
+						 ROOT::VecOps::RVec<float> py, 
+						 ROOT::VecOps::RVec<float> pz, 
+						 ROOT::VecOps::RVec<float> m);
+
   /** Get fastjet pseudoJet after reconstruction from FCCAnalyses jets*/
   ROOT::VecOps::RVec<fastjet::PseudoJet> get_pseudoJets(FCCAnalysesJet);
 

--- a/examples/FCCee/top/hadronic/analysis.py
+++ b/examples/FCCee/top/hadronic/analysis.py
@@ -36,10 +36,11 @@ class analysis():
                .Define("RP_px",          "ReconstructedParticle::get_px(ReconstructedParticles)")
                .Define("RP_py",          "ReconstructedParticle::get_py(ReconstructedParticles)")
                .Define("RP_pz",          "ReconstructedParticle::get_pz(ReconstructedParticles)")               
-               .Define("RP_e",           "ReconstructedParticle::get_e(ReconstructedParticles)")
+               .Define("RP_m",           "ReconstructedParticle::get_e(ReconstructedParticles)")
 
-               #build pseudo jets with the RP
-               .Define("pseudo_jets",    "JetClusteringUtils::set_pseudoJets(RP_px, RP_py, RP_pz, RP_e)")
+               #build pseudo jets with the RP, using the interface that takes px,py,pz,m for better
+               #handling of rounding errors
+               .Define("pseudo_jets",    "JetClusteringUtils::set_pseudoJets_xyzm(RP_px, RP_py, RP_pz, RP_m)")
 
                #run jet clustering with all reconstructed particles. kt_algorithm, R=0.5, exclusive clustering, exactly 4 jets, E0-scheme
                .Define("FCCAnalysesJets_kt", "JetClustering::clustering_kt(0.5, 2, 4, 0, 10)(pseudo_jets)")

--- a/examples/FCCee/top/hadronic/analysis.py
+++ b/examples/FCCee/top/hadronic/analysis.py
@@ -36,7 +36,7 @@ class analysis():
                .Define("RP_px",          "ReconstructedParticle::get_px(ReconstructedParticles)")
                .Define("RP_py",          "ReconstructedParticle::get_py(ReconstructedParticles)")
                .Define("RP_pz",          "ReconstructedParticle::get_pz(ReconstructedParticles)")               
-               .Define("RP_m",           "ReconstructedParticle::get_e(ReconstructedParticles)")
+               .Define("RP_m",           "ReconstructedParticle::get_m(ReconstructedParticles)")
 
                #build pseudo jets with the RP, using the interface that takes px,py,pz,m for better
                #handling of rounding errors


### PR DESCRIPTION
Creating `PseudoJet`s from float px,py,pz,E components results in larger than necessary rounding errors. This PR provides an approach that should work around that, using float px,py,pz,m components. This should ensure that `PseudoJet::m()` returns a much more reliable mass. (There's also a question of how information is transferred back from FastJet and whether one wants to take similar care there; that is not addressed by this PR)

Note: I can't yet compile FCCAnalyses, so the code will need testing before merging. 