### PR TITLE
Origin of MC leptons

### DIFF
--- a/analyzers/dataframe/MCParticle.h
+++ b/analyzers/dataframe/MCParticle.h
@@ -204,6 +204,7 @@ namespace MCParticle{
   int get_lepton_origin( int idx, ROOT::VecOps::RVec<edm4hep::MCParticleData> in, ROOT::VecOps::RVec<int> ind) ;
   int get_lepton_origin( edm4hep::MCParticleData p, ROOT::VecOps::RVec<edm4hep::MCParticleData> in, ROOT::VecOps::RVec<int> ind) ;
 
+  ROOT::VecOps::RVec<int> get_leptons_origin( ROOT::VecOps::RVec<edm4hep::MCParticleData> particles, ROOT::VecOps::RVec<edm4hep::MCParticleData> in, ROOT::VecOps::RVec<int> ind) ;
 
 
 }


### PR DESCRIPTION
Addition of methods in MCParticle that determine the origin of a stable, MC lepton (recursive pass through the parents in case of a FSR). Example use case: select MC electrons that come from a W or Z decay.