### PR TITLE
Remove hardcoding of pion mass in myUtils (plus other updates)

### DIFF
--- a/analyzers/dataframe/myUtils.cc
+++ b/analyzers/dataframe/myUtils.cc
@@ -1059,7 +1059,7 @@ ROOT::VecOps::RVec<float> myUtils::getFCCAnalysesComposite_mass(ROOT::VecOps::RV
       tlvtmp.SetXYZM( updated_track_momentum_at_vertex.at(i).Px(),
 		      updated_track_momentum_at_vertex.at(i).Py(),
 		      updated_track_momentum_at_vertex.at(i).Pz(),
-		      0.13957039);
+		      p.particle.M());
       tlv+=tlvtmp;
       
     }
@@ -1067,6 +1067,38 @@ ROOT::VecOps::RVec<float> myUtils::getFCCAnalysesComposite_mass(ROOT::VecOps::RV
   }
   return result;
 }
+
+ROOT::VecOps::RVec<float> myUtils::getFCCAnalysesComposite_mass(ROOT::VecOps::RVec<FCCAnalysesComposite2> in,
+							   ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
+							   ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop,
+							   int index){
+
+
+  ROOT::VecOps::RVec<float> result;
+  for (auto & p: in) {
+
+    int recoind = vertex.at(p.vertex).reco_ind.at(index);
+    result.push_back(recop.at(recoind).mass);
+  }
+  return result;
+}
+
+ROOT::VecOps::RVec<int> myUtils::getFCCAnalysesComposite_type(ROOT::VecOps::RVec<FCCAnalysesComposite2> in,
+							   ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
+							   ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop,
+							   int index){
+
+
+  ROOT::VecOps::RVec<int> result;
+  for (auto & p: in) {
+
+    int recoind = vertex.at(p.vertex).reco_ind.at(index);
+    result.push_back(recop.at(recoind).type);
+  }
+  return result;
+}
+
+
 
 ROOT::VecOps::RVec<int> myUtils::getFCCAnalysesComposite_vertex(ROOT::VecOps::RVec<FCCAnalysesComposite2> in){
   ROOT::VecOps::RVec<int> result;
@@ -1585,7 +1617,6 @@ myUtils::PID(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop,
 	     ROOT::VecOps::RVec<int> mcind, 
 	     ROOT::VecOps::RVec<edm4hep::MCParticleData> mc){
 
-
   for (size_t i = 0; i < recind.size(); ++i) {
     
     //id a pion
@@ -1650,11 +1681,11 @@ ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> myUtils::get_RP_atVertex(
       recop.at(reco_ind.at(i)).momentum.x = updated_track_momentum_at_vertex.at(i).Px();
       recop.at(reco_ind.at(i)).momentum.y = updated_track_momentum_at_vertex.at(i).Py();
       recop.at(reco_ind.at(i)).momentum.z = updated_track_momentum_at_vertex.at(i).Pz();
-      recop.at(reco_ind.at(i)).mass = 0.13957039;
+      //recop.at(reco_ind.at(i)).mass = 0.13957039;
       recop.at(reco_ind.at(i)).energy = sqrt(pow(updated_track_momentum_at_vertex.at(i).Px(),2) + 
 					     pow(updated_track_momentum_at_vertex.at(i).Py(),2) + 
 					     pow(updated_track_momentum_at_vertex.at(i).Pz(),2) + 
-					     pow(0.13957039,2));
+					     pow(recop.at(reco_ind.at(i)).mass,2));
     }
   }
   return recop;
@@ -2030,6 +2061,43 @@ ROOT::VecOps::RVec<FCCAnalysesComposite2> myUtils::build_Bd2KstNuNu(ROOT::VecOps
     
     result.push_back(comp);
     counter+=1;
+  }
+  return result;
+}
+
+
+ROOT::VecOps::RVec<FCCAnalysesComposite2> myUtils::build_Bs2PhiNuNu(ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
+								    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop){
+
+  ROOT::VecOps::RVec<FCCAnalysesComposite2> result;
+  //loop over the reconstructed vertex collection
+  for (size_t i=0;i<vertex.size();i++){
+    
+    //not consider PV, exactly 2 tracks
+    if (vertex.at(i).vertex.primary==1)continue;
+    if (vertex.at(i).ntracks!=2)       continue;
+    
+    //2 tracks id as kaons
+    int charge_phi=0;
+    int nobj_phi=0;
+    for (auto &r:vertex.at(i).reco_ind){
+      if (recop.at(r).type==321 ){
+	nobj_phi+=1;
+	charge_phi+=recop.at(r).charge;
+      }
+    }
+    //select candidates with exactly 2 kaons and charge 0 
+    if (nobj_phi!=2)   continue;
+    if (charge_phi!=0) continue;
+     
+    //build a composite vertex
+    FCCAnalysesComposite2 comp;
+    comp.vertex = i;
+    comp.particle = build_tlv(recop,vertex.at(i).reco_ind);
+    comp.charge = charge_phi;
+    
+    //add the composite vertex to the collection
+    result.push_back(comp);
   }
   return result;
 }

--- a/analyzers/dataframe/myUtils.cc
+++ b/analyzers/dataframe/myUtils.cc
@@ -1950,8 +1950,7 @@ ROOT::VecOps::RVec<FCCAnalysesComposite2> myUtils::build_B2Kstee(ROOT::VecOps::R
     FCCAnalysesComposite2 comp;
     comp.vertex = counter;
     comp.particle = build_tlv(recop,p.reco_ind);
-    comp.charge = charge_ee+charge_pi+charge_pi
-;
+    comp.charge = charge_ee+charge_pi+charge_k;
     
     result.push_back(comp);
     counter+=1;

--- a/analyzers/dataframe/myUtils.h
+++ b/analyzers/dataframe/myUtils.h
@@ -121,6 +121,9 @@ namespace myUtils{
   ROOT::VecOps::RVec<FCCAnalysesComposite2> build_Bd2KstNuNu(ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
 							     ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop);
 
+  ROOT::VecOps::RVec<FCCAnalysesComposite2> build_Bs2PhiNuNu(ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
+							     ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop);
+
   ROOT::VecOps::RVec<FCCAnalysesComposite2> build_Bd2MuMu(ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
 							  ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop);
   
@@ -295,6 +298,16 @@ namespace myUtils{
 
   ROOT::VecOps::RVec<float> getFCCAnalysesComposite_mass(ROOT::VecOps::RVec<FCCAnalysesComposite2> in,
 							 ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex);
+
+  ROOT::VecOps::RVec<float> getFCCAnalysesComposite_mass(ROOT::VecOps::RVec<FCCAnalysesComposite2> in,
+						    ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
+						    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop,
+						    int index);
+
+  ROOT::VecOps::RVec<int> getFCCAnalysesComposite_type(ROOT::VecOps::RVec<FCCAnalysesComposite2> in,
+						    ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
+						    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop,
+						    int index);
 
   ROOT::VecOps::RVec<float> getFCCAnalysesComposite_p(ROOT::VecOps::RVec<FCCAnalysesComposite2> in,
 						      int type);

--- a/examples/FCCee/flavour/Bd2KstNuNu/analysis_stage1.py
+++ b/examples/FCCee/flavour/Bd2KstNuNu/analysis_stage1.py
@@ -52,6 +52,7 @@ class analysis():
                .Define("MC_M2",  "myUtils::get_MCMother2(Particle,Particle0)")
                .Define("MC_D1",  "myUtils::get_MCDaughter1(Particle,Particle1)")
                .Define("MC_D2",  "myUtils::get_MCDaughter2(Particle,Particle1)")
+               #.Define("MC_D3",  "myUtils::get_MCDaughter3(Particle,Particle1)")
                .Define("MC_x",   "MCParticle::get_vertex_x(Particle)")
                .Define("MC_y",   "MCParticle::get_vertex_y(Particle)")
                .Define("MC_z",   "MCParticle::get_vertex_z(Particle)")
@@ -247,12 +248,21 @@ class analysis():
                .Define("KiPiCandidates_pion2d0", "myUtils::getFCCAnalysesComposite_d0(KiPiCandidates, VertexObject, 1)")
                .Define("KiPiCandidates_pion2z0", "myUtils::getFCCAnalysesComposite_z0(KiPiCandidates, VertexObject, 1)")
                
-               .Define("TrueKiPiBc_vertex",        "myUtils::get_trueVertex(MCVertexObject,Particle,Particle0, 15, 541)")
-               .Define("TrueKiPiBc_track",         "myUtils::get_truetrack(TrueKiPiBc_vertex, MCVertexObject, Particle)")
-               .Define("TrueKiPiBc_d0",            "myUtils::get_trackd0(TrueKiPiBc_track)")
-               .Define("TrueKiPiBc_z0",            "myUtils::get_trackz0(TrueKiPiBc_track)")
+               .Define("TrueKBu_vertex",        "myUtils::get_trueVertex(MCVertexObject,Particle,Particle0, 321, 521)")
+               .Define("TrueKBu_track",         "myUtils::get_truetrack(TrueKBu_vertex, MCVertexObject, Particle)")
+               .Define("TrueKBu_d0",            "myUtils::get_trackd0(TrueKBu_track)")
+               .Define("TrueKBu_z0",            "myUtils::get_trackz0(TrueKBu_track)")
 
-               .Define("TrueKiPiBu_vertex",        "myUtils::get_trueVertex(MCVertexObject,Particle,Particle0, 15, 521)")
+               .Define("TrueKPiBd_vertex",        "myUtils::get_trueVertex(MCVertexObject,Particle,Particle0, 313, 511)")
+               .Define("TrueKPiBd_track",         "myUtils::get_truetrack(TrueKPiBd_vertex, MCVertexObject, Particle)")
+               .Define("TrueKPiBd_d0",            "myUtils::get_trackd0(TrueKPiBd_track)")
+               .Define("TrueKPiBd_z0",            "myUtils::get_trackz0(TrueKPiBd_track)")
+
+               .Define("TrueKKBs_vertex",        "myUtils::get_trueVertex(MCVertexObject,Particle,Particle0, 333, 531)")
+               .Define("TrueKKBs_track",         "myUtils::get_truetrack(TrueKKBs_vertex, MCVertexObject, Particle)")
+               .Define("TrueKKBs_d0",            "myUtils::get_trackd0(TrueKKBs_track)")
+               .Define("TrueKKBs_z0",            "myUtils::get_trackz0(TrueKKBs_track)")
+
 
            )
         # select branches for output file
@@ -291,9 +301,10 @@ class analysis():
                 "Vertex_d2PVErr", "Vertex_d2PVxErr", "Vertex_d2PVyErr", "Vertex_d2PVzErr",
                 "Vertex_mass",
                 "DV_d0","DV_z0",
-
-                "TrueKiPiBc_vertex","TrueKiPiBc_d0","TrueKiPiBc_z0",
-                "TrueKiPiBu_vertex",
+                
+                "TrueKBu_vertex", "TrueKBu_d0", "TrueKBu_z0", 
+                "TrueKPiBd_vertex", "TrueKPiBd_d0", "TrueKPiBd_z0", 
+                "TrueKKBs_vertex", "TrueKKBs_d0", "TrueKKBs_z0", 
                 
                 "KiPiCandidates_mass", "KiPiCandidates_vertex", "KiPiCandidates_mcvertex", "KiPiCandidates_B",
                 "KiPiCandidates_px", "KiPiCandidates_py", "KiPiCandidates_pz", "KiPiCandidates_p", "KiPiCandidates_q",

--- a/examples/FCCee/flavour/Bs2PhiNuNu/analysis_stage1.py
+++ b/examples/FCCee/flavour/Bs2PhiNuNu/analysis_stage1.py
@@ -139,15 +139,15 @@ class analysis():
                .Define("EVT_dPV2DVave",   "myUtils::get_dPV2DV_ave(Vertex_d2PV)")
                
                #############################################
-               ##        Build Kstz -> KPi  candidates      ##
+               ##        Build Phi -> KK  candidates      ##
                #############################################
-               .Define("KPiCandidates",         "myUtils::build_Bd2KstNuNu(VertexObject,RecoPartPIDAtVertex)")
+               .Define("KKCandidates",         "myUtils::build_Bs2PhiNuNu(VertexObject,RecoPartPIDAtVertex)")
 
                #############################################
-               ##       Filter Kstz -> KPi candidates      ##
+               ##       Filter Phi -> KK candidates      ##
                ############################################# 
-               .Define("EVT_NKPi",              "float(myUtils::getFCCAnalysesComposite_N(KPiCandidates))")
-               .Filter("EVT_NKPi>0")
+               .Define("EVT_NKK",              "float(myUtils::getFCCAnalysesComposite_N(KKCandidates))")
+               .Filter("EVT_NKK>0")
 
                
                #############################################
@@ -213,48 +213,49 @@ class analysis():
                .Define("DV_d0",            "myUtils::get_trackd0(DV_tracks)")
                .Define("DV_z0",            "myUtils::get_trackz0(DV_tracks)")
                
-               .Define("KPiCandidates_mass",    "myUtils::getFCCAnalysesComposite_mass(KPiCandidates)")
-               .Define("KPiCandidates_q",       "myUtils::getFCCAnalysesComposite_charge(KPiCandidates)")
-               .Define("KPiCandidates_vertex",  "myUtils::getFCCAnalysesComposite_vertex(KPiCandidates)")
-               .Define("KPiCandidates_mcvertex","myUtils::getFCCAnalysesComposite_mcvertex(KPiCandidates,VertexObject)")
-               .Define("KPiCandidates_px",      "myUtils::getFCCAnalysesComposite_p(KPiCandidates,0)")
-               .Define("KPiCandidates_py",      "myUtils::getFCCAnalysesComposite_p(KPiCandidates,1)")
-               .Define("KPiCandidates_pz",      "myUtils::getFCCAnalysesComposite_p(KPiCandidates,2)")
-               .Define("KPiCandidates_p",       "myUtils::getFCCAnalysesComposite_p(KPiCandidates,-1)")
-               .Define("KPiCandidates_B",       "myUtils::getFCCAnalysesComposite_B(KPiCandidates, VertexObject, RecoPartPIDAtVertex)")
+               .Define("KKCandidates_mass",    "myUtils::getFCCAnalysesComposite_mass(KKCandidates)")
+               .Define("KKCandidates_q",       "myUtils::getFCCAnalysesComposite_charge(KKCandidates)")
+               .Define("KKCandidates_vertex",  "myUtils::getFCCAnalysesComposite_vertex(KKCandidates)")
+               .Define("KKCandidates_mcvertex","myUtils::getFCCAnalysesComposite_mcvertex(KKCandidates,VertexObject)")
+               .Define("KKCandidates_px",      "myUtils::getFCCAnalysesComposite_p(KKCandidates,0)")
+               .Define("KKCandidates_py",      "myUtils::getFCCAnalysesComposite_p(KKCandidates,1)")
+               .Define("KKCandidates_pz",      "myUtils::getFCCAnalysesComposite_p(KKCandidates,2)")
+               .Define("KKCandidates_p",       "myUtils::getFCCAnalysesComposite_p(KKCandidates,-1)")
+               .Define("KKCandidates_B",       "myUtils::getFCCAnalysesComposite_B(KKCandidates, VertexObject, RecoPartPIDAtVertex)")
                
-               .Define("KPiCandidates_track",   "myUtils::getFCCAnalysesComposite_track(KPiCandidates, VertexObject)")
-               .Define("KPiCandidates_d0",      "myUtils::get_trackd0(KPiCandidates_track)")
-               .Define("KPiCandidates_z0",      "myUtils::get_trackz0(KPiCandidates_track)")
+               .Define("KKCandidates_track",   "myUtils::getFCCAnalysesComposite_track(KKCandidates, VertexObject)")
+               .Define("KKCandidates_d0",      "myUtils::get_trackd0(KKCandidates_track)")
+               .Define("KKCandidates_z0",      "myUtils::get_trackz0(KKCandidates_track)")
 
-               .Define("KPiCandidates_anglethrust", "myUtils::getFCCAnalysesComposite_anglethrust(KPiCandidates, EVT_thrust)")
-               .Define("CUT_hasCandEmin",           "myUtils::has_anglethrust_emin(KPiCandidates_anglethrust)")
+               .Define("KKCandidates_anglethrust", "myUtils::getFCCAnalysesComposite_anglethrust(KKCandidates, EVT_thrust)")
+               .Define("CUT_hasCandEmin",           "myUtils::has_anglethrust_emin(KKCandidates_anglethrust)")
                .Filter("CUT_hasCandEmin>0")
                
-               .Define("KPiCandidates_h1px",   "myUtils::getFCCAnalysesComposite_p(KPiCandidates, VertexObject, RecoPartPIDAtVertex, 0, 0)")
-               .Define("KPiCandidates_h1py",   "myUtils::getFCCAnalysesComposite_p(KPiCandidates, VertexObject, RecoPartPIDAtVertex, 0, 1)")
-               .Define("KPiCandidates_h1pz",   "myUtils::getFCCAnalysesComposite_p(KPiCandidates, VertexObject, RecoPartPIDAtVertex, 0, 2)")
-               .Define("KPiCandidates_h1p",    "myUtils::getFCCAnalysesComposite_p(KPiCandidates, VertexObject, RecoPartPIDAtVertex, 0, -1)")
-               .Define("KPiCandidates_h1q",    "myUtils::getFCCAnalysesComposite_q(KPiCandidates, VertexObject, RecoPartPIDAtVertex, 0)")
-               .Define("KPiCandidates_h1m",    "myUtils::getFCCAnalysesComposite_mass(KPiCandidates, VertexObject, RecoPartPIDAtVertex, 0)")
-               .Define("KPiCandidates_h1type", "myUtils::getFCCAnalysesComposite_type(KPiCandidates, VertexObject, RecoPartPIDAtVertex, 0)")
-               .Define("KPiCandidates_h1d0",   "myUtils::getFCCAnalysesComposite_d0(KPiCandidates, VertexObject, 0)")
-               .Define("KPiCandidates_h1z0",   "myUtils::getFCCAnalysesComposite_z0(KPiCandidates, VertexObject, 0)")
+               .Define("KKCandidates_K1px",   "myUtils::getFCCAnalysesComposite_p(KKCandidates, VertexObject, RecoPartPIDAtVertex, 0, 0)")
+               .Define("KKCandidates_K1py",   "myUtils::getFCCAnalysesComposite_p(KKCandidates, VertexObject, RecoPartPIDAtVertex, 0, 1)")
+               .Define("KKCandidates_K1pz",   "myUtils::getFCCAnalysesComposite_p(KKCandidates, VertexObject, RecoPartPIDAtVertex, 0, 2)")
+               .Define("KKCandidates_K1p",    "myUtils::getFCCAnalysesComposite_p(KKCandidates, VertexObject, RecoPartPIDAtVertex, 0, -1)")
+               .Define("KKCandidates_K1q",    "myUtils::getFCCAnalysesComposite_q(KKCandidates, VertexObject, RecoPartPIDAtVertex, 0)")
+               .Define("KKCandidates_K1m",    "myUtils::getFCCAnalysesComposite_mass(KKCandidates, VertexObject, RecoPartPIDAtVertex, 0)")
+               .Define("KKCandidates_K1type", "myUtils::getFCCAnalysesComposite_type(KKCandidates, VertexObject, RecoPartPIDAtVertex, 0)")
+               .Define("KKCandidates_K1d0",   "myUtils::getFCCAnalysesComposite_d0(KKCandidates, VertexObject, 0)")
+               .Define("KKCandidates_K1z0",   "myUtils::getFCCAnalysesComposite_z0(KKCandidates, VertexObject, 0)")
                
-               .Define("KPiCandidates_h2px",   "myUtils::getFCCAnalysesComposite_p(KPiCandidates, VertexObject, RecoPartPIDAtVertex, 1, 0)")
-               .Define("KPiCandidates_h2py",   "myUtils::getFCCAnalysesComposite_p(KPiCandidates, VertexObject, RecoPartPIDAtVertex, 1, 1)")
-               .Define("KPiCandidates_h2pz",   "myUtils::getFCCAnalysesComposite_p(KPiCandidates, VertexObject, RecoPartPIDAtVertex, 1, 2)")
-               .Define("KPiCandidates_h2p",    "myUtils::getFCCAnalysesComposite_p(KPiCandidates, VertexObject, RecoPartPIDAtVertex, 1, -1)")
-               .Define("KPiCandidates_h2q",    "myUtils::getFCCAnalysesComposite_q(KPiCandidates, VertexObject, RecoPartPIDAtVertex, 1)")
-               .Define("KPiCandidates_h2m",    "myUtils::getFCCAnalysesComposite_mass(KPiCandidates, VertexObject, RecoPartPIDAtVertex, 1)")
-               .Define("KPiCandidates_h2type", "myUtils::getFCCAnalysesComposite_type(KPiCandidates, VertexObject, RecoPartPIDAtVertex, 1)")
-               .Define("KPiCandidates_h2d0",   "myUtils::getFCCAnalysesComposite_d0(KPiCandidates, VertexObject, 1)")
-               .Define("KPiCandidates_h2z0",   "myUtils::getFCCAnalysesComposite_z0(KPiCandidates, VertexObject, 1)")
+               .Define("KKCandidates_K2px",   "myUtils::getFCCAnalysesComposite_p(KKCandidates, VertexObject, RecoPartPIDAtVertex, 1, 0)")
+               .Define("KKCandidates_K2py",   "myUtils::getFCCAnalysesComposite_p(KKCandidates, VertexObject, RecoPartPIDAtVertex, 1, 1)")
+               .Define("KKCandidates_K2pz",   "myUtils::getFCCAnalysesComposite_p(KKCandidates, VertexObject, RecoPartPIDAtVertex, 1, 2)")
+               .Define("KKCandidates_K2p",    "myUtils::getFCCAnalysesComposite_p(KKCandidates, VertexObject, RecoPartPIDAtVertex, 1, -1)")
+               .Define("KKCandidates_K2q",    "myUtils::getFCCAnalysesComposite_q(KKCandidates, VertexObject, RecoPartPIDAtVertex, 1)")
+               .Define("KKCandidates_K2m",    "myUtils::getFCCAnalysesComposite_mass(KKCandidates, VertexObject, RecoPartPIDAtVertex, 1)")
+               .Define("KKCandidates_K2type", "myUtils::getFCCAnalysesComposite_type(KKCandidates, VertexObject, RecoPartPIDAtVertex, 1)")
+               .Define("KKCandidates_K2d0",   "myUtils::getFCCAnalysesComposite_d0(KKCandidates, VertexObject, 1)")
+               .Define("KKCandidates_K2z0", "myUtils::getFCCAnalysesComposite_z0(KKCandidates, VertexObject, 1)")
                
-               .Define("TrueKPiBd_vertex",        "myUtils::get_trueVertex(MCVertexObject,Particle,Particle0, 313, 511)")
-               .Define("TrueKPiBd_track",         "myUtils::get_truetrack(TrueKPiBd_vertex, MCVertexObject, Particle)")
-               .Define("TrueKPiBd_d0",            "myUtils::get_trackd0(TrueKPiBd_track)")
-               .Define("TrueKPiBd_z0",            "myUtils::get_trackz0(TrueKPiBd_track)")
+               .Define("TrueKKBs_vertex",        "myUtils::get_trueVertex(MCVertexObject,Particle,Particle0, 333, 531)")
+               .Define("TrueKKBs_track",         "myUtils::get_truetrack(TrueKKBs_vertex, MCVertexObject, Particle)")
+               .Define("TrueKKBs_d0",            "myUtils::get_trackd0(TrueKKBs_track)")
+               .Define("TrueKKBs_z0",            "myUtils::get_trackz0(TrueKKBs_track)")
+
 
            )
         # select branches for output file
@@ -275,7 +276,7 @@ class analysis():
                 "EVT_Thrust_Y",  "EVT_Thrust_YErr",
                 "EVT_Thrust_Z",  "EVT_Thrust_ZErr",
 
-                "EVT_NtracksPV", "EVT_NVertex", "EVT_NKPi",
+                "EVT_NtracksPV", "EVT_NVertex", "EVT_NKK",
                 
                 "EVT_dPV2DVmin","EVT_dPV2DVmax","EVT_dPV2DVave",
 
@@ -294,18 +295,18 @@ class analysis():
                 "Vertex_mass",
                 "DV_d0","DV_z0",
                 
-                "TrueKPiBd_vertex", "TrueKPiBd_d0", "TrueKPiBd_z0", 
+                "TrueKKBs_vertex", "TrueKKBs_d0", "TrueKKBs_z0", 
                 
-                "KPiCandidates_mass", "KPiCandidates_vertex", "KPiCandidates_mcvertex", "KPiCandidates_B",
-                "KPiCandidates_px", "KPiCandidates_py", "KPiCandidates_pz", "KPiCandidates_p", "KPiCandidates_q",
-                "KPiCandidates_d0",  "KPiCandidates_z0","KPiCandidates_anglethrust",
+                "KKCandidates_mass", "KKCandidates_vertex", "KKCandidates_mcvertex", "KKCandidates_B",
+                "KKCandidates_px", "KKCandidates_py", "KKCandidates_pz", "KKCandidates_p", "KKCandidates_q",
+                "KKCandidates_d0",  "KKCandidates_z0","KKCandidates_anglethrust",
                 
-                "KPiCandidates_h1px", "KPiCandidates_h1py", "KPiCandidates_h1pz",
-                "KPiCandidates_h1p", "KPiCandidates_h1q", "KPiCandidates_h1m", "KPiCandidates_h1type",
-                "KPiCandidates_h1d0", "KPiCandidates_h1z0",
-                "KPiCandidates_h2px", "KPiCandidates_h2py", "KPiCandidates_h2pz",
-                "KPiCandidates_h2p", "KPiCandidates_h2q", "KPiCandidates_h2m", "KPiCandidates_h2type",
-                "KPiCandidates_h2d0", "KPiCandidates_h2z0",
+                "KKCandidates_K1px", "KKCandidates_K1py", "KKCandidates_K1pz",
+                "KKCandidates_K1p", "KKCandidates_K1q", "KKCandidates_K1m", "KKCandidates_K1type", 
+                "KKCandidates_K1d0", "KKCandidates_K1z0",
+                "KKCandidates_K2px", "KKCandidates_K2py", "KKCandidates_K2pz",
+                "KKCandidates_K2p", "KKCandidates_K2q", "KKCandidates_K2m", "KKCandidates_K2type",
+                "KKCandidates_K2d0", "KKCandidates_K2z0",
                 
                 ]:
             branchList.push_back(branchName)
@@ -318,10 +319,7 @@ class analysis():
         df2.Snapshot("events", self.outname, branchList)
 
 # example call for standalone file
-# python examples/FCCee/flavour/Bd2KstNuNu/analysis_stage1.py p8_ee_Zbb_Bd2KstNuNu_stage1.root /eos/experiment/fcc/ee/generation/DelphesEvents/spring2021/IDEA/p8_ee_Zbb_ecm91_EvtGen_Bd2KstNuNu/events_035370064.root
-
-
-
+# python examples/FCCee/flavour/Bs2PhiNuNu/analysis_stage1.py p8_ee_Zbb_Bs2PhiNuNu_stage1.root /eos/experiment/fcc/ee/generation/DelphesEvents/spring2021/IDEA/p8_ee_Zbb_ecm91_EvtGen_Bs2PhiNuNu/events_028655206.root 
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This request removes hardcoding of the pion mass in a couple of places in `myUtils.cc`. In particular this appeared in two functions:

  -  `myUtils::getFCCAnalysesComposite_mass()` - this has now been replaced by the mass that is already assigned to the RecoParticle
  - `myUtils::get_RP_atVertex()` - before this was overwriting the current RecoParticle mass with the pion mass, this now does not touch the RecoParticle mass but leaves it as is (the line has been commented but should probably be removed entirely to avoid confusion
  
A few other additions have been included:

  - new functions in `myUtils` which retrieve Combined candidate daughter mass and PDG id (type), this is useful for checking what hypothesis has been used in different hadron combinations (e.g. which daughter is assigned which mass in kaon+pion combinations)
  - added example `analysis_stage1.py` script for `Bs2PhiNuNu` and modified the equivalent for `Bd2KstNuNu`