### PR TITLE
MCParticle::get_indices_InclusiveDecay

### DIFF
--- a/analyzers/dataframe/MCParticle.cc
+++ b/analyzers/dataframe/MCParticle.cc
@@ -657,6 +657,141 @@ ROOT::VecOps::RVec<int>  MCParticle::get_indices_ExclusiveDecay::operator() ( RO
  return result;
 }
 
+// ----------------------------------------------------------------------------------------------------------------------------------
+
+ROOT::VecOps::RVec<int>  MCParticle::get_indices_InclusiveDecay_MotherByIndex ( int imother,
+										std::vector<int> m_pdg_daughters,
+										bool m_stableDaughters,
+										ROOT::VecOps::RVec<edm4hep::MCParticleData> in,
+										ROOT::VecOps::RVec<int> ind) {
+
+  // Look for a specific decay specified by the mother index in the Particle block,
+  // and by the PDG_ids of the daughters
+  // At least this list of daughters must be included in the decay
+  // Returns a vector with the indicess, in the Particle block, of the mother and of
+  // the daughters - in the order defined by std::vector<int> pdg_daughters.
+
+
+  ROOT::VecOps::RVec<int>  result;
+
+  //bool debug = true;
+  bool debug = false;
+  // check :
+  if (debug) {
+    std::cout << " --- in get_indices_InclusiveDecay_MotherByIndex " << std::endl;
+    std::cout << "  PDG daughters : " << std::endl;
+    for (int i=0; i < m_pdg_daughters.size(); i++) {
+      std::cout << "     a daughter : " << m_pdg_daughters[i] << std::endl;
+    }
+  }
+
+
+  if (debug) {
+    std::vector<int> unstable_products = get_list_of_particles_from_decay( imother, in, ind ) ;
+    for ( auto & k: unstable_products) {
+      std::cout << " ......... unstable daughter PDG = " << in[k].PDG << std::endl;
+    }
+  }
+
+  std::vector<int> products ;
+  if ( m_stableDaughters ) {
+    products = get_list_of_stable_particles_from_decay( imother, in, ind ) ;
+  }
+  else {
+    products = get_list_of_particles_from_decay( imother, in, ind ) ;
+  }
+
+  if (debug) {
+    for (auto& idx: products ) {
+      std::cout << " ........... decay PDG = " << in[idx].PDG << std::endl;
+    }
+  }
+  std::vector<int> found;
+  for (auto & pdg_d: m_pdg_daughters ) {
+    if (debug) std::cout << " -- looking for PDG = " << pdg_d << std::endl;
+    for (auto & idx_d: products) {
+      if ( in[idx_d].PDG == pdg_d ) {
+	// careful, there can be several particles with the same PDG !
+	if (std::find(found.begin(), found.end(), idx_d) == found.end())  {  // idx_d has NOT already been "used"
+	  found.push_back( idx_d );
+	  if (debug) std::cout << "       found PDG = " << pdg_d << std::endl;
+	}
+      }
+    }
+  }
+  if ( found.size() >= m_pdg_daughters.size()  && products.size() >= m_pdg_daughters.size()) {  // all daughters have been found. That's the decay mode looked for.
+    result.push_back( imother );
+    for ( auto & idx_d: found) {   // use "found" and not "products", to get the right ordering
+      result.push_back( idx_d );
+    }
+
+    if (debug) {
+      std::cout << " --- found the decay mode requested " << std::endl;
+      for ( auto & id: result ) {
+	std::cout << " idx = " << id << " PDG = " << in[id].PDG << std::endl;
+      }
+    }
+  }
+
+  return result;
+
+}
+
+
+// ----------------------------------------------------------------------------------------------------------------------------------
+
+MCParticle::get_indices_InclusiveDecay::get_indices_InclusiveDecay( int pdg_mother, std::vector<int> pdg_daughters, bool stableDaughters, bool chargeConjugate) {
+  m_pdg_mother = pdg_mother;
+  m_pdg_daughters = pdg_daughters;
+  m_stableDaughters = stableDaughters;
+  m_chargeConjugate = chargeConjugate;
+} ;
+
+ROOT::VecOps::RVec<int>  MCParticle::get_indices_InclusiveDecay::operator() ( ROOT::VecOps::RVec<edm4hep::MCParticleData> in, ROOT::VecOps::RVec<int> ind) {
+
+  // Look for a specific decay specified by the mother PDG_id and
+  // the PDG_ids of the daughters
+  // Returns a vector with the indicess, in the Particle block, of the mother and of
+  // the daughters - in the order defined by std::vector<int> pdg_daughters.
+  //
+  // In case there are several such decays in the event, keep only the first one.
+
+  ROOT::VecOps::RVec<int>  result;
+
+  //bool debug = true;
+  bool debug = false;
+  // check :
+  if (debug) {
+    std::cout << " --- in get_indices_InclusiveDecay " << std::endl;
+    std::cout << "  PDG mother = " << m_pdg_mother << std::endl;
+    std::cout << "  PDG daughters : " << std::endl;
+    std::cout << " m_stableDaughters = "  << m_stableDaughters << std::endl;
+    for (int i=0; i < m_pdg_daughters.size(); i++) {
+      std::cout << "     a daughter : " << m_pdg_daughters[i] << std::endl;
+    }
+  }
+
+  for ( int imother =0; imother < in.size(); imother ++){
+    int pdg = in[imother].PDG ;
+    bool found_a_mother = false;
+    if ( ! m_chargeConjugate ) found_a_mother = ( pdg == m_pdg_mother );
+    if ( m_chargeConjugate )   found_a_mother = ( abs(pdg) == abs(m_pdg_mother) ) ;
+    if ( ! found_a_mother ) continue;
+
+    if (debug) std::cout << " --- found a mother " << std::endl;
+
+    //if ( pdg != m_pdg_mother ) continue;
+
+    ROOT::VecOps::RVec<int> a = get_indices_InclusiveDecay_MotherByIndex( imother, m_pdg_daughters, m_stableDaughters, in, ind );
+    if ( a.size() != 0 ) {
+      result = a;
+      break;    // return the first decay found
+    }
+
+  }
+  return result;
+}
+
 
 // --------------------------------------------------------------------------------------------------
 

--- a/analyzers/dataframe/MCParticle.h
+++ b/analyzers/dataframe/MCParticle.h
@@ -93,11 +93,12 @@ namespace MCParticle{
 
   ///same as above, except the list of daughters is the minimum required for the mother's decay
   struct get_indices_InclusiveDecay{
-    get_indices_InclusiveDecay( int pdg_mother, std::vector<int> pdg_daughters, bool stableDaughters, bool chargeConjugate ) ;
+    get_indices_InclusiveDecay( int pdg_mother, std::vector<int> pdg_daughters, bool stableDaughters, bool chargeConjugateMother, bool chargeConjugateDaughters ) ;
     int m_pdg_mother;
     std::vector<int> m_pdg_daughters;
     bool m_stableDaughters;
-    bool m_chargeConjugate;
+    bool m_chargeConjugateMother;
+    bool m_chargeConjugateDaughters;
     ROOT::VecOps::RVec<int>   operator() ( ROOT::VecOps::RVec<edm4hep::MCParticleData> in , ROOT::VecOps::RVec<int> ind);
   };
 
@@ -105,6 +106,7 @@ namespace MCParticle{
   ROOT::VecOps::RVec<int>  get_indices_InclusiveDecay_MotherByIndex( int imother,
 								     std::vector<int> m_pdg_daughters,
 								     bool m_stableDaughters,
+								     bool m_chargeConjugateDaughters,
 								     ROOT::VecOps::RVec<edm4hep::MCParticleData> in,
 								     ROOT::VecOps::RVec<int> ind);
 

--- a/analyzers/dataframe/MCParticle.h
+++ b/analyzers/dataframe/MCParticle.h
@@ -91,6 +91,23 @@ namespace MCParticle{
                                         			     ROOT::VecOps::RVec<edm4hep::MCParticleData> in , 
 								     ROOT::VecOps::RVec<int> ind);
 
+  ///same as above, except the list of daughters is the minimum required for the mother's decay
+  struct get_indices_InclusiveDecay{
+    get_indices_InclusiveDecay( int pdg_mother, std::vector<int> pdg_daughters, bool stableDaughters, bool chargeConjugate ) ;
+    int m_pdg_mother;
+    std::vector<int> m_pdg_daughters;
+    bool m_stableDaughters;
+    bool m_chargeConjugate;
+    ROOT::VecOps::RVec<int>   operator() ( ROOT::VecOps::RVec<edm4hep::MCParticleData> in , ROOT::VecOps::RVec<int> ind);
+  };
+
+  /// return a list of indices that correspond to a given MC decay
+  ROOT::VecOps::RVec<int>  get_indices_InclusiveDecay_MotherByIndex( int imother,
+								     std::vector<int> m_pdg_daughters,
+								     bool m_stableDaughters,
+								     ROOT::VecOps::RVec<edm4hep::MCParticleData> in,
+								     ROOT::VecOps::RVec<int> ind);
+
 
   /// return the parent index of a given list of MC particles
   ROOT::VecOps::RVec<int> get_parentid(ROOT::VecOps::RVec<int> mcind, ROOT::VecOps::RVec<edm4hep::MCParticleData> mc, ROOT::VecOps::RVec<int> parents);


### PR DESCRIPTION
This PR adds a function, MCParticle::get_indices_InclusiveDecay, which is similar to MCParticle::get_indices_ExclusiveDecay. The main difference is that this new function looks at the MCParticles for the provided set of daughter pdgids, regardless if those are all of the decay products or not. I also added a boolean for this new function such that you can also look for the charge conjugates of the daughter particles. I've tested that this function behaves as I expect in two different decay chains.