### PR TITLE
Jet tagging fix from gm

### DIFF
--- a/analyzers/dataframe/JetTaggingUtils.cc
+++ b/analyzers/dataframe/JetTaggingUtils.cc
@@ -1,16 +1,22 @@
 #include "JetTaggingUtils.h"
 using namespace JetTaggingUtils;
 
-ROOT::VecOps::RVec<int> JetTaggingUtils::get_flavour(ROOT::VecOps::RVec<fastjet::PseudoJet> in, ROOT::VecOps::RVec<edm4hep::MCParticleData> MCin){
+ROOT::VecOps::RVec<int>
+JetTaggingUtils::get_flavour(ROOT::VecOps::RVec<fastjet::PseudoJet> in,
+                             ROOT::VecOps::RVec<edm4hep::MCParticleData> MCin)
+{
   ROOT::VecOps::RVec<int> result(in.size(),0);
 
   int loopcount =0;
   for (size_t i = 0; i < MCin.size(); ++i) {
     auto & parton = MCin[i];
-    //Select partons only (for pythia 71-79):
-    if (parton.generatorStatus>80 || parton.generatorStatus<70) continue;
-    if (parton.PDG > 5) continue;
-    ROOT::Math::PxPyPzMVector lv(parton.momentum.x, parton.momentum.y, parton.momentum.z, parton.mass);
+    //Select partons only (for pythia8 71-79, for pythia6 2):
+    if ((parton.generatorStatus>80 ||
+         parton.generatorStatus<70) &&
+        parton.generatorStatus != 2 ) continue;
+    if (std::abs(parton.PDG) > 5 && parton.PDG!=21) continue;
+    ROOT::Math::PxPyPzMVector lv(parton.momentum.x, parton.momentum.y,
+                                 parton.momentum.z, parton.mass);
 
     for (size_t j = 0; j < in.size(); ++j) {
       auto & p = in[j];
@@ -19,32 +25,105 @@ ROOT::VecOps::RVec<int> JetTaggingUtils::get_flavour(ROOT::VecOps::RVec<fastjet:
       //float deltaR = sqrt(dEta*dEta+dPhi*dPhi);
       //if (deltaR <= 0.5 && gRandom->Uniform() <= efficiency) result[j] = true;
       
-      Float_t dot = p.px()*parton.momentum.x+p.py()*parton.momentum.y+p.pz()*parton.momentum.z;
-      Float_t lenSq1 = p.px()*p.px()+p.py()*p.py()+p.pz()*p.pz();
-      Float_t lenSq2 = parton.momentum.x*parton.momentum.x+parton.momentum.y*parton.momentum.y+parton.momentum.z*parton.momentum.z;
+      Float_t dot = p.px() * parton.momentum.x
+                  + p.py() * parton.momentum.y
+                  + p.pz() * parton.momentum.z;
+      Float_t lenSq1 = p.px() * p.px()
+                     + p.py() * p.py()
+                     + p.pz() * p.pz();
+      Float_t lenSq2 = parton.momentum.x * parton.momentum.x
+                     + parton.momentum.y * parton.momentum.y
+                     + parton.momentum.z * parton.momentum.z;
       Float_t norm = sqrt(lenSq1*lenSq2);
       Float_t angle = acos(dot/norm);
-      if (angle <= 0.3) result[j] = std::max(result[j], std::abs ( parton.PDG ));
+      if (angle <= 0.3) {
+        if (result[j]==21)
+          result[j] = std::abs ( parton.PDG );
+        else
+          result[j] = std::max(result[j], std::abs ( parton.PDG ));
+      }
     }
   }
 
   return result;
 }
 
-ROOT::VecOps::RVec<int> JetTaggingUtils::get_btag(ROOT::VecOps::RVec<int> in, float efficiency) {
+ROOT::VecOps::RVec<int>
+JetTaggingUtils::get_btag(ROOT::VecOps::RVec<int> in,
+                          float efficiency, float mistag_c,
+                          float mistag_l, float mistag_g) {
+
   ROOT::VecOps::RVec<int> result(in.size(),0);
 
   for (size_t j = 0; j < in.size(); ++j) {
-    if (in.at(j)==5 && gRandom->Uniform() <= efficiency) result[j] = 1;
+    if (in.at(j) ==  5 && gRandom->Uniform() <= efficiency) result[j] = 1;
+    if (in.at(j) ==  4 && gRandom->Uniform() <= mistag_c) result[j] = 1;
+    if (in.at(j)  <  4 && gRandom->Uniform() <= mistag_l) result[j] = 1;
+    if (in.at(j) == 21 && gRandom->Uniform() <= mistag_g) result[j] = 1;
   }
   return result;
 }
 
-ROOT::VecOps::RVec<int>	JetTaggingUtils::get_ctag(ROOT::VecOps::RVec<int> in, float efficiency) {
+ROOT::VecOps::RVec<int>
+JetTaggingUtils::get_ctag(ROOT::VecOps::RVec<int> in,
+                          float efficiency, float mistag_b,
+                          float mistag_l, float mistag_g) {
+
   ROOT::VecOps::RVec<int> result(in.size(),0);
 
   for (size_t j = 0; j < in.size(); ++j) {
-    if (in.at(j)==4 && gRandom->Uniform() <= efficiency) result[j] = 1;
+    if (in.at(j) ==  4 && gRandom->Uniform() <= efficiency) result[j] = 1;
+    if (in.at(j) ==  5 && gRandom->Uniform() <= mistag_b) result[j] = 1;
+    if (in.at(j)  <  4 && gRandom->Uniform() <= mistag_l) result[j] = 1;
+    if (in.at(j) == 21 && gRandom->Uniform() <= mistag_g) result[j] = 1;
+  }
+  return result;
+}
+
+ROOT::VecOps::RVec<int>
+JetTaggingUtils::get_ltag(ROOT::VecOps::RVec<int> in,
+                          float efficiency, float mistag_b,
+                          float mistag_c, float mistag_g) {
+
+  ROOT::VecOps::RVec<int> result(in.size(),0);
+
+  for (size_t j = 0; j < in.size(); ++j) {
+    if (in.at(j) <  4  && gRandom->Uniform() <= efficiency) result[j] = 1;
+    if (in.at(j) ==  5 && gRandom->Uniform() <= mistag_b) result[j] = 1;
+    if (in.at(j) ==  4 && gRandom->Uniform() <= mistag_c) result[j] = 1;
+    if (in.at(j) == 21 && gRandom->Uniform() <= mistag_g) result[j] = 1;
+  }
+  return result;
+}
+
+ROOT::VecOps::RVec<int>
+JetTaggingUtils::get_gtag(ROOT::VecOps::RVec<int> in,
+                          float efficiency, float mistag_b,
+                          float mistag_c, float mistag_l) {
+
+  ROOT::VecOps::RVec<int> result(in.size(),0);
+
+  for (size_t j = 0; j < in.size(); ++j) {
+    if (in.at(j) == 21 && gRandom->Uniform() <= efficiency) result[j] = 1;
+    if (in.at(j) ==  5 && gRandom->Uniform() <= mistag_b) result[j] = 1;
+    if (in.at(j) ==  4 && gRandom->Uniform() <= mistag_c) result[j] = 1;
+    if (in.at(j)  <  4 && gRandom->Uniform() <= mistag_l) result[j] = 1;
+  }
+  return result;
+}
+
+JetTaggingUtils::sel_tag::sel_tag(bool arg_pass): m_pass(arg_pass) {};
+ROOT::VecOps::RVec<fastjet::PseudoJet>
+JetTaggingUtils::sel_tag::operator()(ROOT::VecOps::RVec<bool> tags,
+                                     ROOT::VecOps::RVec<fastjet::PseudoJet> in){
+  ROOT::VecOps::RVec<fastjet::PseudoJet> result;
+  for (size_t i = 0; i < in.size(); ++i) {
+    if (m_pass) {
+      if (tags.at(i)) result.push_back(in.at(i));
+    }
+    else {
+      if (!tags.at(i)) result.push_back(in.at(i));
+    }
   }
   return result;
 }

--- a/analyzers/dataframe/JetTaggingUtils.cc
+++ b/analyzers/dataframe/JetTaggingUtils.cc
@@ -36,12 +36,25 @@ JetTaggingUtils::get_flavour(ROOT::VecOps::RVec<fastjet::PseudoJet> in,
                      + parton.momentum.z * parton.momentum.z;
       Float_t norm = sqrt(lenSq1*lenSq2);
       Float_t angle = acos(dot/norm);
+
       if (angle <= 0.3) {
-        if (result[j]==21)
+        if (result[j]==21 or result[j]==0) {
+          // if no match before, or matched to gluon, match to
+          // this particle (favour quarks over gluons)
           result[j] = std::abs ( parton.PDG );
-        else
+        }
+        else if (parton.PDG!=21) {
+          // if matched to quark, and this is a quark, favour
+          // heavier flavours
           result[j] = std::max(result[j], std::abs ( parton.PDG ));
-      }
+        } else {
+          // if matched to quark, and this is a gluon, keep
+          // previous result (favour quark)
+           ;
+        }       
+       }
+
+
     }
   }
 

--- a/analyzers/dataframe/JetTaggingUtils.h
+++ b/analyzers/dataframe/JetTaggingUtils.h
@@ -21,12 +21,22 @@ namespace JetTaggingUtils{
   //Get flavour association of jet 
   ROOT::VecOps::RVec<int> get_flavour(ROOT::VecOps::RVec<fastjet::PseudoJet> in, ROOT::VecOps::RVec<edm4hep::MCParticleData> MCin);
   //Get b-tags with an efficiency applied
-  ROOT::VecOps::RVec<int> get_btag(ROOT::VecOps::RVec<int> in, float efficiency);
+  ROOT::VecOps::RVec<int> get_btag(ROOT::VecOps::RVec<int> in, float efficiency, float mistag_c=0., float mistag_l=0., float mistag_g=0.);
   //Get c-tags with an efficiency applied
-  ROOT::VecOps::RVec<int> get_ctag(ROOT::VecOps::RVec<int> in, float efficiency);
+  ROOT::VecOps::RVec<int> get_ctag(ROOT::VecOps::RVec<int> in, float efficiency, float mistag_b=0., float mistag_l=0., float mistag_g=0.);
+  //Get l-tags with an efficiency applied
+  ROOT::VecOps::RVec<int> get_ltag(ROOT::VecOps::RVec<int> in, float efficiency, float mistag_b=0., float mistag_c=0., float mistag_g=0.);
+  //Get g-tags with an efficiency applied
+  ROOT::VecOps::RVec<int> get_gtag(ROOT::VecOps::RVec<int> in, float efficiency, float mistag_b=0., float mistag_c=0., float mistag_l=0.);
 
-    ///@}                                                                                                                                                                              
+  /// select a list of jets depending on the status of a certain boolean flag (corresponding to its tagging state)
+  struct sel_tag {
+    bool m_pass; // if pass is true, select tagged jets. Otherwise select anti-tagged ones
+    sel_tag(bool arg_pass);
+    ROOT::VecOps::RVec<fastjet::PseudoJet> operator() (ROOT::VecOps::RVec<bool> tags, ROOT::VecOps::RVec<fastjet::PseudoJet> in);
+  };
+
+  ///@}
 }
-
 
 #endif


### PR DESCRIPTION
Update of JetTaggingUtils from Giovanni Marchiori

- change the selection of parton status codes such that the tagging can also run over Pythia6 (e.g. Whizard + Pythia6) files. The previous version worked only for Pythia8.
- adds misidentification efficiencies
- also tags jets matched to light quarks / gluons
