### PR TITLE
Bug fix in ReconstructedParticle::remove (a break statement had been …

### DIFF
--- a/analyzers/dataframe/ReconstructedParticle.cc
+++ b/analyzers/dataframe/ReconstructedParticle.cc
@@ -209,7 +209,7 @@ ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> ReconstructedParticle::re
 	   abs(py1-py2) < epsilon &&
 	   abs(pz1-pz2) < epsilon ) {
         result.erase(it);
-        //break;
+        break;
       }
     }
   }


### PR DESCRIPTION
…commented, to deal with cases where the collections contain several instances of the same object, but that would require to revisit the logics)