### PR TITLE
cmake: remove LINKDD4HEP option 

### DIFF
--- a/analyzers/dataframe/CMakeLists.txt
+++ b/analyzers/dataframe/CMakeLists.txt
@@ -71,11 +71,8 @@ target_link_libraries(FCCAnalyses
 		      ${CPU-KERNELS} ${LIBDL})
 
 
-option(LINKDD4HEP "Switch ON if you plan to use DD4hep geometry information" OFF)
-if(LINKDD4HEP)
-    find_package(DD4hep)
-    target_link_libraries(FCCAnalyses DD4hep::DDCore)
-endif()
+find_package(DD4hep)
+target_link_libraries(FCCAnalyses DD4hep::DDCore)
 
 
 set_target_properties(FCCAnalyses PROPERTIES


### PR DESCRIPTION
The build fails if it is OFF.