### PR TITLE
FCCAnalyses::MCParticle::get_indices, for exclusive and inclusive decays

### DIFF
--- a/analyzers/dataframe/MCParticle.cc
+++ b/analyzers/dataframe/MCParticle.cc
@@ -528,136 +528,93 @@ std::vector<int> list_of_particles_from_decay(int i, ROOT::VecOps::RVec<edm4hep:
 
 // ----------------------------------------------------------------------------------------------------------------------------------
 
-ROOT::VecOps::RVec<int>  get_indices_ExclusiveDecay_MotherByIndex ( int imother,
-								      std::vector<int> m_pdg_daughters,
-								      bool m_stableDaughters,
-                                                	              ROOT::VecOps::RVec<edm4hep::MCParticleData> in,
-								      ROOT::VecOps::RVec<int> ind) {
+ROOT::VecOps::RVec<int>  get_indices_MotherByIndex ( int imother,
+						     std::vector<int> m_pdg_daughters,
+						     bool m_stableDaughters,
+						     bool m_chargeConjugateDaughters,
+						     bool m_inclusiveDecay,
+						     ROOT::VecOps::RVec<edm4hep::MCParticleData> in,
+						     ROOT::VecOps::RVec<int> ind) {
 
    // Look for a specific decay specified by the mother index in the Particle block,
    // and by the PDG_ids of the daughters
-   // Returns a vector with the indicess, in the Particle block, of the mother and of
+   // If m_inclusiveDecay is true, then at least this list of daughters must be included in the decay
+   // Returns a vector with the indices, in the Particle block, of the mother and of
    // the daughters - in the order defined by std::vector<int> pdg_daughters.
 
 
   ROOT::VecOps::RVec<int>  result;
 
-  //bool debug = true;
-  bool debug = false;
-        // check :
-        if (debug) {
-        std::cout << " --- in get_indices_ExclusiveDecay_MotherByIndex " << std::endl;
-        std::cout << "  PDG daughters : " << std::endl;
-        for (int i=0; i < m_pdg_daughters.size(); i++) {
-                std::cout << "     a daughter : " << m_pdg_daughters[i] << std::endl;
-        }
-        }
+  std::vector<int> products ;
+  if ( m_stableDaughters ) {
+    products = get_list_of_stable_particles_from_decay( imother, in, ind ) ;
+  }
+  else {
+    products = get_list_of_particles_from_decay( imother, in, ind ) ;
+  }
 
-
-    if (debug) {
-     std::vector<int> unstable_products = get_list_of_particles_from_decay( imother, in, ind ) ;
-      for ( auto & k: unstable_products) {
-           std::cout << " ......... unstable daughter PDG = " << in[k].PDG << std::endl;
+  std::vector<int> found;
+  for (auto & pdg_d: m_pdg_daughters ) {
+    for (auto & idx_d: products) {
+      if ( (m_chargeConjugateDaughters && abs(in[idx_d].PDG) == abs(pdg_d)) || in[idx_d].PDG == pdg_d) {
+	// careful, there can be several particles with the same PDG !
+	if (std::find(found.begin(), found.end(), idx_d) == found.end())  {  // idx_d has NOT already been "used"
+	  found.push_back( idx_d );
+	}
+      }
+    }
+  }
+  if ( (m_inclusiveDecay && found.size() >= m_pdg_daughters.size()  && products.size() >= m_pdg_daughters.size()) || //for inclusive decay: at least this list of daughters
+       (!m_inclusiveDecay && found.size() == m_pdg_daughters.size()  && products.size() == m_pdg_daughters.size()) ) //for exclusive decay: exactly this list of daughters
+    { // all daughters have been found. That's the decay mode looked for.
+      result.push_back( imother );
+      for ( auto & idx_d: found) {   // use "found" and not "products", to get the right ordering
+	result.push_back( idx_d );
       }
     }
 
-     std::vector<int> products ;
-     if ( m_stableDaughters ) {
-        products = get_list_of_stable_particles_from_decay( imother, in, ind ) ;
-     }
-     else {
-        products = get_list_of_particles_from_decay( imother, in, ind ) ;
-     }
-
-     if (debug) {
-           for (auto& idx: products ) {
-               std::cout << " ........... decay PDG = " << in[idx].PDG << std::endl;
-           }
-     }
-     std::vector<int> found;
-     for (auto & pdg_d: m_pdg_daughters ) {
-        if (debug) std::cout << " -- looking for PDG = " << pdg_d << std::endl;
-        for (auto & idx_d: products) {
-            if ( in[idx_d].PDG == pdg_d ) {
-                // careful, there can be several particles with the same PDG !
-                if (std::find(found.begin(), found.end(), idx_d) == found.end())  {  // idx_d has NOT already been "used"
-                    found.push_back( idx_d );
-                    if (debug) std::cout << "       found PDG = " << pdg_d << std::endl;
-                }
-            }
-        }
-     }
-     if ( found.size() == m_pdg_daughters.size()  && products.size() == m_pdg_daughters.size()) {  // all daughters have been found. That's the decay mode looked for.
-        result.push_back( imother );
-        for ( auto & idx_d: found) {   // use "found" and not "products", to get the right ordering
-           result.push_back( idx_d );
-        }
-
-             if (debug) {
-                std::cout << " --- found the decay mode requested " << std::endl;
-                for ( auto & id: result ) {
-                    std::cout << " idx = " << id << " PDG = " << in[id].PDG << std::endl;
-                }
-             }
-     }
-
-return result;
+  return result;
 
 }
 
 
 // ----------------------------------------------------------------------------------------------------------------------------------
 
-get_indices_ExclusiveDecay::get_indices_ExclusiveDecay( int pdg_mother, std::vector<int> pdg_daughters, bool stableDaughters, bool chargeConjugate) {
+get_indices::get_indices( int pdg_mother, std::vector<int> pdg_daughters, bool stableDaughters, bool chargeConjugateMother, bool chargeConjugateDaughters, bool inclusiveDecay) {
   m_pdg_mother = pdg_mother;
   m_pdg_daughters = pdg_daughters;
   m_stableDaughters = stableDaughters;
-  m_chargeConjugate = chargeConjugate;
+  m_chargeConjugateMother = chargeConjugateMother;
+  m_chargeConjugateDaughters = chargeConjugateDaughters;
+  m_inclusiveDecay = inclusiveDecay;
 } ;
 
-ROOT::VecOps::RVec<int>  get_indices_ExclusiveDecay::operator() ( ROOT::VecOps::RVec<edm4hep::MCParticleData> in, ROOT::VecOps::RVec<int> ind) {
+ROOT::VecOps::RVec<int>  get_indices::operator() ( ROOT::VecOps::RVec<edm4hep::MCParticleData> in, ROOT::VecOps::RVec<int> ind) {
 
    // Look for a specific decay specified by the mother PDG_id and
    // the PDG_ids of the daughters
-   // Returns a vector with the indicess, in the Particle block, of the mother and of
+   // Returns a vector with the indices, in the Particle block, of the mother and of
    // the daughters - in the order defined by std::vector<int> pdg_daughters.
    //
    // In case there are several such decays in the event, keep only the first one.
 
    ROOT::VecOps::RVec<int>  result;
 
-   //bool debug = true;
-   bool debug = false;
-        // check :
-        if (debug) {
-        std::cout << " --- in get_indices_ExclusiveDecay " << std::endl;
-        std::cout << "  PDG mother = " << m_pdg_mother << std::endl;
-        std::cout << "  PDG daughters : " << std::endl;
-        std::cout << " m_stableDaughters = "  << m_stableDaughters << std::endl;
-        for (int i=0; i < m_pdg_daughters.size(); i++) {
-                std::cout << "     a daughter : " << m_pdg_daughters[i] << std::endl;
-        }
-        }
-
    for ( int imother =0; imother < in.size(); imother ++){
      int pdg = in[imother].PDG ;
      bool found_a_mother = false;
-     if ( ! m_chargeConjugate ) found_a_mother = ( pdg == m_pdg_mother );
-     if ( m_chargeConjugate )   found_a_mother = ( abs(pdg) == abs(m_pdg_mother) ) ;
+     if ( ! m_chargeConjugateMother ) found_a_mother = ( pdg == m_pdg_mother );
+     if ( m_chargeConjugateMother )   found_a_mother = ( abs(pdg) == abs(m_pdg_mother) ) ;
      if ( ! found_a_mother ) continue;
 
-     if (debug) std::cout << " --- found a mother " << std::endl;
-
-     //if ( pdg != m_pdg_mother ) continue;
-
-     ROOT::VecOps::RVec<int> a = get_indices_ExclusiveDecay_MotherByIndex( imother, m_pdg_daughters, m_stableDaughters, in, ind );
+     ROOT::VecOps::RVec<int> a = get_indices_MotherByIndex( imother, m_pdg_daughters, m_stableDaughters, m_chargeConjugateDaughters, m_inclusiveDecay, in, ind );
      if ( a.size() != 0 ) {
         result = a;
         break;    // return the first decay found
      }
 
    }
- return result;
+   return result;
 }
 
 

--- a/analyzers/dataframe/MCParticle.h
+++ b/analyzers/dataframe/MCParticle.h
@@ -75,22 +75,26 @@ namespace MCParticle{
   };
 
 
- /// return a list of indices that correspond to a given MC decay. The list contains the index of the mother, followed by the indices of the daughters, in the order specified. In case there are several such decays in the event, keep only the first one.
-  struct get_indices_ExclusiveDecay{
-     get_indices_ExclusiveDecay( int pdg_mother, std::vector<int> pdg_daughters, bool stableDaughters, bool chargeConjugate ) ;
-     int m_pdg_mother;
-     std::vector<int> m_pdg_daughters;
-     bool m_stableDaughters;
-     bool m_chargeConjugate;
-     ROOT::VecOps::RVec<int>   operator() ( ROOT::VecOps::RVec<edm4hep::MCParticleData> in , ROOT::VecOps::RVec<int> ind);
+ /// return a list of indices that correspond to a given MC decay. The list contains the index of the mother, followed by the indices of the daughters, in the order specified. If m_inclusiveDecay is true, the list of daughters is the minimum required for the mother's decay (otherwise, the list is the exact daughters required for the mother's decay). In case there are several such decays in the event, keep only the first one.
+  struct get_indices{
+    get_indices( int pdg_mother, std::vector<int> pdg_daughters, bool stableDaughters, bool chargeConjugateMother, bool chargeConjugateDaughters, bool inclusiveDecay ) ;
+    int m_pdg_mother;
+    std::vector<int> m_pdg_daughters;
+    bool m_stableDaughters;
+    bool m_chargeConjugateMother;
+    bool m_chargeConjugateDaughters;
+    bool m_inclusiveDecay;
+    ROOT::VecOps::RVec<int>   operator() ( ROOT::VecOps::RVec<edm4hep::MCParticleData> in , ROOT::VecOps::RVec<int> ind);
   };
 
   /// return a list of indices that correspond to a given MC decay
-  ROOT::VecOps::RVec<int>  get_indices_ExclusiveDecay_MotherByIndex( int imother,
-								     std::vector<int> m_pdg_daughters,
-								     bool m_stableDaughters,
-                                        			     ROOT::VecOps::RVec<edm4hep::MCParticleData> in ,
-								     ROOT::VecOps::RVec<int> ind);
+  ROOT::VecOps::RVec<int>  get_indices_MotherByIndex( int imother,
+						      std::vector<int> m_pdg_daughters,
+						      bool m_stableDaughters,
+						      bool m_chargeConjugateDaughters,
+						      bool m_inclusiveDecay,
+						      ROOT::VecOps::RVec<edm4hep::MCParticleData> in ,
+						      ROOT::VecOps::RVec<int> ind);
 
 
   /// return the parent index of a given list of MC particles

--- a/examples/FCCee/flavour/Bc2TauNu/analysis_B2TauNu_truth.py
+++ b/examples/FCCee/flavour/Bc2TauNu/analysis_B2TauNu_truth.py
@@ -97,8 +97,10 @@ class analysis():
                #     - the cases Bs -> Bsbar -> mu mu K K are included here
                #   first boolean: if true, look at the stable daughters, otherwise at the intermediate daughters
                #   second boolean: if true, include the charge conjugate decays
-               .Define("B2NuNuPiPiPi_indices",   "FCCAnalyses::MCParticle::get_indices_ExclusiveDecay( %s, { 16, -16, 211, -211, 211 }, true, false)( Particle, Particle1)"%(PDGID))
-               .Define("Bbar2NuNuPiPiPi_indices","FCCAnalyses::MCParticle::get_indices_ExclusiveDecay( -%s, { -16, 16, -211, 211, -211 }, true, false)( Particle, Particle1)"%(PDGID))
+               #   third boolean: if true, include charge conjugates of daughters
+               #   fourth boolena: if true, do the inclusive decay
+               .Define("B2NuNuPiPiPi_indices",   "FCCAnalyses::MCParticle::get_indices( %s, { 16, -16, 211, -211, 211 }, true, false, false, false)( Particle, Particle1)"%(PDGID))
+               .Define("Bbar2NuNuPiPiPi_indices","FCCAnalyses::MCParticle::get_indices( -%s, { -16, 16, -211, 211, -211 }, true, false, false, false)( Particle, Particle1)"%(PDGID))
 
                .Define("Piminus", "selMC_leg(4) ( B2NuNuPiPiPi_indices , Particle)" )
                .Define("Piplus",  "selMC_leg(4) ( Bbar2NuNuPiPiPi_indices , Particle)" )


### PR DESCRIPTION
This PR replaces MCParticle::get_indices_ExclusiveDecay with MCParticle::get_indices. The new function has the ability to look at exclusive decays (it requires that it finds the exact list of daughter pdgids) or inclusive decays (it looks at the MCParticles for the provided set of daughter pdgids, regardless if those are all of the decay products or not). I also added a boolean for this new function such that you can also look for the charge conjugates of the daughter particles. I've tested that this function behaves as I expect in two different decay chains.

This PR should take the place of #114 , which I messed up :/

When we last left #114, @vvolkl asked me to add a template parameter and explicitly instantiate both explicit and implicit, in order to not break the analyses that use get_indices_ExclusiveDecay. He started to show me how to do this, but I didn't fully understand how to incorporate the chargeConjugateDaughters parameter, see https://github.com/HEP-FCC/FCCAnalyses/pull/114#issuecomment-1014617219. I hope @vvolkl  can finish showing me what to do, and then I can update this PR.