### PR TITLE
cmake: export targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 find_package(FastJet)
 find_package( Acts COMPONENTS Core )
 
-# Offer the user the choice of overriding the installation directoriesy
+# Offer the user the choice of overriding the installation directories
 set(INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
 set(INSTALL_BIN_DIR bin CACHE PATH "Installation directory for executables")
 set(INSTALL_INCLUDE_DIR include CACHE PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,11 +51,17 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 find_package(FastJet)
 find_package( Acts COMPONENTS Core )
 
-# Offer the user the choice of overriding the installation directories
+# Offer the user the choice of overriding the installation directoriesy
 set(INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
 set(INSTALL_BIN_DIR bin CACHE PATH "Installation directory for executables")
 set(INSTALL_INCLUDE_DIR include CACHE PATH
   "Installation directory for header files")
+
+
+
+
+#--- add CMake infrastructure --------------------------------------------------
+include(cmake/FCCAnalysesCreateConfig.cmake)
 
 
 file(GLOB _run_python_files config/*.py)

--- a/analyzers/dataframe/CMakeLists.txt
+++ b/analyzers/dataframe/CMakeLists.txt
@@ -39,7 +39,8 @@ ROOT_GENERATE_DICTIONARY(G__FCCAnalyses
 
 add_library(FCCAnalyses SHARED ${sources} ${headers} G__FCCAnalyses.cxx )
 target_include_directories(FCCAnalyses  PUBLIC
-                           ${CMAKE_SOURCE_DIR}/analyzers/dataframe
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
                            ${FCCEDM_INCLUDE_DIRS}
                            ${FASTJET_INCLUDE_DIR}
                            ${acts_INCLUDE_DIR}
@@ -63,6 +64,7 @@ target_link_libraries(FCCAnalyses
                       ${LIBAWKWARD}
                       ${CPU-KERNELS}
                       ${LIBDL}
+                      gfortran # todo: why necessary?
                       )
 
 if(${WITH_DD4HEP})
@@ -70,11 +72,11 @@ if(${WITH_DD4HEP})
   target_link_libraries(FCCAnalyses DD4hep::DDCore)
 endif()
 
-
 set_target_properties(FCCAnalyses PROPERTIES
   PUBLIC_HEADER "${headers}")
 
 install(TARGETS FCCAnalyses
+    EXPORT FCCAnalysesTargets
     RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
     LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT shlib
     PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}/FCCAnalyses"

--- a/cmake/FCCAnalysesConfig.cmake.in
+++ b/cmake/FCCAnalysesConfig.cmake.in
@@ -1,0 +1,29 @@
+# - Config file for the FCCANALYSES package
+
+# - Define exported version
+set(FCCANALYSES_VERSION "@PROJECT_VERSION@")
+
+# - Init CMakePackageConfigHelpers
+@PACKAGE_INIT@
+
+# - Create relocatable paths to headers.
+# NOTE: Do not strictly need paths as all usage requirements are encoded in
+# the imported targets created later.
+set_and_check(FCCANALYSES_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+
+include(CMakeFindDependencyMacro)
+find_dependency(EDM4HEP REQUIRED)
+find_dependency(podio)
+find_dependency(Acts)
+find_dependency(ROOT COMPONENTS ROOTDataFrame)
+
+
+
+# - Include the targets file to create the imported targets that a client can
+# link to (libraries) or execute (programs)
+include("${CMAKE_CURRENT_LIST_DIR}/FCCAnalysesTargets.cmake")
+
+# print the default "Found:" message and check library location
+include(FindPackageHandleStandardArgs)
+get_property(TEST_FCCANALYSES_LIBRARY TARGET FCCAnalyses::FCCAnalyses PROPERTY LOCATION)
+find_package_handle_standard_args(FCCAnalyses DEFAULT_MSG CMAKE_CURRENT_LIST_FILE TEST_FCCANALYSES_LIBRARY)

--- a/cmake/FCCAnalysesCreateConfig.cmake
+++ b/cmake/FCCAnalysesCreateConfig.cmake
@@ -1,0 +1,24 @@
+# - Use CMake's module to help generating relocatable config files
+include(CMakePackageConfigHelpers)
+
+
+# - Install time config and target files
+configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/FCCAnalysesConfig.cmake.in
+  "${PROJECT_BINARY_DIR}/FCCAnalysesConfig.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/FCCAnalyses"
+  PATH_VARS
+    CMAKE_INSTALL_BINDIR
+    CMAKE_INSTALL_INCLUDEDIR
+    CMAKE_INSTALL_LIBDIR
+  )
+
+# - install and export
+install(FILES
+  "${PROJECT_BINARY_DIR}/FCCAnalysesConfig.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/FCCAnalyses"
+  )
+install(EXPORT FCCAnalysesTargets
+  NAMESPACE FCCAnalyses::
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/FCCAnalyses"
+  )
+


### PR DESCRIPTION
This lets downstream project `find_package(FCCAnalyses)` and link to `FCCAnalyses::FCCAnalyses`