### PR TITLE
Jets add dmerge 2

### DIFF
--- a/analyzers/dataframe/JetClustering.cc
+++ b/analyzers/dataframe/JetClustering.cc
@@ -31,7 +31,10 @@ JetClusteringUtils::FCCAnalysesJet JetClustering::clustering_kt::operator() (std
 
   std::vector<fastjet::PseudoJet> pjets = JetClusteringUtils::build_jets(cs, m_exclusive, m_cut, m_sorted);
   
-  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets);
+  std::vector<float> dmerge = JetClusteringUtils::exclusive_dmerge( cs, 0);
+  std::vector<float> dmerge_max = JetClusteringUtils::exclusive_dmerge( cs, 1);
+
+  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets, dmerge, dmerge_max);
   if (recomb_scheme == fastjet::RecombinationScheme::external_scheme) def.delete_recombiner_when_unused();
   return result;
 }
@@ -56,7 +59,10 @@ JetClusteringUtils::FCCAnalysesJet JetClustering::clustering_antikt::operator() 
 
   std::vector<fastjet::PseudoJet> pjets = JetClusteringUtils::build_jets(cs, m_exclusive, m_cut, m_sorted);
  
-  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets);
+  std::vector<float> dmerge = JetClusteringUtils::exclusive_dmerge( cs, 0);
+  std::vector<float> dmerge_max = JetClusteringUtils::exclusive_dmerge( cs, 1);
+
+  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets, dmerge, dmerge_max );
   if (recomb_scheme == fastjet::RecombinationScheme::external_scheme) def.delete_recombiner_when_unused();
   return result;
 }
@@ -80,7 +86,10 @@ JetClusteringUtils::FCCAnalysesJet JetClustering::clustering_cambridge::operator
 
   std::vector<fastjet::PseudoJet> pjets = JetClusteringUtils::build_jets(cs, m_exclusive, m_cut, m_sorted);
   
-  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets);
+  std::vector<float> dmerge = JetClusteringUtils::exclusive_dmerge( cs, 0);
+  std::vector<float> dmerge_max = JetClusteringUtils::exclusive_dmerge( cs, 1);
+
+  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets, dmerge, dmerge_max);
   if (recomb_scheme == fastjet::RecombinationScheme::external_scheme) def.delete_recombiner_when_unused();
   return result;
 }
@@ -107,7 +116,10 @@ JetClusteringUtils::FCCAnalysesJet JetClustering::clustering_ee_kt::operator() (
 
   std::vector<fastjet::PseudoJet> pjets = JetClusteringUtils::build_jets(cs, m_exclusive, m_cut, m_sorted);
  
-  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets);
+  std::vector<float> dmerge = JetClusteringUtils::exclusive_dmerge( cs, 0);
+  std::vector<float> dmerge_max = JetClusteringUtils::exclusive_dmerge( cs, 1);
+
+  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets, dmerge, dmerge_max );
   if (recomb_scheme == fastjet::RecombinationScheme::external_scheme) def.delete_recombiner_when_unused();
   return result;
 }
@@ -133,7 +145,10 @@ JetClusteringUtils::FCCAnalysesJet JetClustering::clustering_ee_genkt::operator(
 
   std::vector<fastjet::PseudoJet> pjets = JetClusteringUtils::build_jets(cs, m_exclusive, m_cut, m_sorted);
  
-  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets);
+  std::vector<float> dmerge = JetClusteringUtils::exclusive_dmerge( cs, 0);
+  std::vector<float> dmerge_max = JetClusteringUtils::exclusive_dmerge( cs, 1);
+
+  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets, dmerge, dmerge_max);
   if (recomb_scheme == fastjet::RecombinationScheme::external_scheme) def.delete_recombiner_when_unused();
   return result;
 }
@@ -158,7 +173,10 @@ JetClusteringUtils::FCCAnalysesJet JetClustering::clustering_genkt::operator() (
 
   std::vector<fastjet::PseudoJet> pjets = JetClusteringUtils::build_jets(cs, m_exclusive, m_cut, m_sorted);
  
-  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets);
+  std::vector<float> dmerge = JetClusteringUtils::exclusive_dmerge( cs, 0);
+  std::vector<float> dmerge_max = JetClusteringUtils::exclusive_dmerge( cs, 1);
+
+  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets, dmerge, dmerge_max );
   if (recomb_scheme == fastjet::RecombinationScheme::external_scheme) def.delete_recombiner_when_unused();
   return result;
 }
@@ -184,7 +202,10 @@ JetClusteringUtils::FCCAnalysesJet JetClustering::clustering_valencia::operator(
 
   std::vector<fastjet::PseudoJet> pjets = JetClusteringUtils::build_jets(cs, m_exclusive, m_cut, m_sorted);
  
-  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets);
+  std::vector<float> dmerge = JetClusteringUtils::exclusive_dmerge( cs, 0);
+  std::vector<float> dmerge_max = JetClusteringUtils::exclusive_dmerge( cs, 1);
+
+  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets, dmerge, dmerge_max );
 
   delete static_cast<fastjet::JetDefinition::Plugin *>(jetAlgorithm);
   if (recomb_scheme == fastjet::RecombinationScheme::external_scheme) def.delete_recombiner_when_unused();
@@ -211,7 +232,10 @@ JetClusteringUtils::FCCAnalysesJet JetClustering::clustering_jade::operator() (s
 
   std::vector<fastjet::PseudoJet> pjets = JetClusteringUtils::build_jets(cs, m_exclusive, m_cut, m_sorted);
 
-  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets);
+  std::vector<float> dmerge = JetClusteringUtils::exclusive_dmerge( cs, 0);
+  std::vector<float> dmerge_max = JetClusteringUtils::exclusive_dmerge( cs, 1);
+
+  JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::build_FCCAnalysesJet(pjets, dmerge, dmerge_max );
   
   delete static_cast<fastjet::JetDefinition::Plugin *>(jetAlgorithm);
   if (recomb_scheme == fastjet::RecombinationScheme::external_scheme) def.delete_recombiner_when_unused();

--- a/analyzers/dataframe/JetClusteringUtils.cc
+++ b/analyzers/dataframe/JetClusteringUtils.cc
@@ -11,6 +11,21 @@ std::vector<std::vector<int>> JetClusteringUtils::get_constituents(FCCAnalysesJe
   return jets.constituents;
 }
 
+
+float get_exclusive_dmerge( FCCAnalysesJet in, int n ) {
+  float d = -1;
+  if ( n >= 1 &&  n <= 10) d= in.exclusive_dmerge[n] ;
+  return d;
+}
+
+float get_exclusive_dmerge_max( FCCAnalysesJet in, int n ) {
+  float d = -1;
+  if ( n >= 1 &&  n <= 10) d= in.exclusive_dmerge_max[n] ;
+  return d;
+}
+
+
+
 std::vector<fastjet::PseudoJet> JetClusteringUtils::set_pseudoJets(ROOT::VecOps::RVec<float> px, 
 								   ROOT::VecOps::RVec<float> py, 
 								   ROOT::VecOps::RVec<float> pz, 
@@ -129,10 +144,18 @@ FCCAnalysesJet JetClusteringUtils::initialise_FCCAnalysesJet(){
   result.jets = jets;
   result.constituents = constituents;
 
+  std::vector<float> exclusive_dmerge;
+  std::vector<float> exclusive_dmerge_max;
+  exclusive_dmerge.reserve(10);
+  exclusive_dmerge_max.reserve(10);
+
+  result.exclusive_dmerge = exclusive_dmerge;
+  result.exclusive_dmerge_max = exclusive_dmerge_max;
+
   return result;
 };
 
-FCCAnalysesJet JetClusteringUtils::build_FCCAnalysesJet(std::vector<fastjet::PseudoJet> in){
+FCCAnalysesJet JetClusteringUtils::build_FCCAnalysesJet(std::vector<fastjet::PseudoJet> in, std::vector<float> dmerge, std::vector<float> dmerge_max ){
   JetClusteringUtils::FCCAnalysesJet result = JetClusteringUtils::initialise_FCCAnalysesJet();
   for (const auto& pjet : in) {
     result.jets.push_back(pjet);
@@ -144,6 +167,8 @@ FCCAnalysesJet JetClusteringUtils::build_FCCAnalysesJet(std::vector<fastjet::Pse
     }
     result.constituents.push_back(tmpvec);
   }
+  result.exclusive_dmerge = dmerge;
+  result.exclusive_dmerge_max = dmerge_max;
   return result;
 }
 
@@ -167,6 +192,20 @@ std::vector<fastjet::PseudoJet> JetClusteringUtils::build_jets(fastjet::ClusterS
     else if( exclusive ==  4)  pjets = fastjet::sorted_by_E(cs.exclusive_jets_ycut(cut));
   }
   return pjets;
+}
+
+std::vector<float> JetClusteringUtils::exclusive_dmerge( fastjet::ClusterSequence & cs, int do_dmarge_max) {
+
+  const int Nmax = 10;
+  std::vector<float>  result;
+  for (int i=1; i <= Nmax; i++) {
+     	float  d;
+	const int j = i;
+     	if ( do_dmarge_max == 0) d = cs.exclusive_dmerge( j );
+	else d = cs.exclusive_dmerge_max( j ) ;
+	result.push_back( d );
+  }
+  return result;
 }
 
 

--- a/analyzers/dataframe/JetClusteringUtils.cc
+++ b/analyzers/dataframe/JetClusteringUtils.cc
@@ -12,15 +12,15 @@ std::vector<std::vector<int>> JetClusteringUtils::get_constituents(FCCAnalysesJe
 }
 
 
-float get_exclusive_dmerge( FCCAnalysesJet in, int n ) {
+float JetClusteringUtils::get_exclusive_dmerge( FCCAnalysesJet in, int n ) {
   float d = -1;
-  if ( n >= 1 &&  n <= 10) d= in.exclusive_dmerge[n] ;
+  if ( n >= 1 &&  n <= Nmax_dmerge) d= in.exclusive_dmerge[n-1] ;
   return d;
 }
 
-float get_exclusive_dmerge_max( FCCAnalysesJet in, int n ) {
+float JetClusteringUtils::get_exclusive_dmerge_max( FCCAnalysesJet in, int n ) {
   float d = -1;
-  if ( n >= 1 &&  n <= 10) d= in.exclusive_dmerge_max[n] ;
+  if ( n >= 1 &&  n <= Nmax_dmerge) d= in.exclusive_dmerge_max[n-1] ;
   return d;
 }
 
@@ -146,8 +146,8 @@ FCCAnalysesJet JetClusteringUtils::initialise_FCCAnalysesJet(){
 
   std::vector<float> exclusive_dmerge;
   std::vector<float> exclusive_dmerge_max;
-  exclusive_dmerge.reserve(10);
-  exclusive_dmerge_max.reserve(10);
+  exclusive_dmerge.reserve(Nmax_dmerge);
+  exclusive_dmerge_max.reserve(Nmax_dmerge);
 
   result.exclusive_dmerge = exclusive_dmerge;
   result.exclusive_dmerge_max = exclusive_dmerge_max;
@@ -196,7 +196,7 @@ std::vector<fastjet::PseudoJet> JetClusteringUtils::build_jets(fastjet::ClusterS
 
 std::vector<float> JetClusteringUtils::exclusive_dmerge( fastjet::ClusterSequence & cs, int do_dmarge_max) {
 
-  const int Nmax = 10;
+  const int Nmax = Nmax_dmerge;
   std::vector<float>  result;
   for (int i=1; i <= Nmax; i++) {
      	float  d;

--- a/analyzers/dataframe/JetClusteringUtils.h
+++ b/analyzers/dataframe/JetClusteringUtils.h
@@ -20,12 +20,13 @@ namespace JetClusteringUtils{
   */
   ///@{
   
+  const int Nmax_dmerge = 10;  // maximum number of d_{n, n+1} that are kept in FCCAnalysesJet
 
   /** Structure to keep useful informations for the jets*/
   struct FCCAnalysesJet{
     ROOT::VecOps::RVec<fastjet::PseudoJet> jets;
     std::vector<std::vector<int>> constituents;
-    std::vector<float> exclusive_dmerge;   // vector of 10 values associated with merging from n + 1 to n jets, for n =1, 2, ... 10
+    std::vector<float> exclusive_dmerge;   // vector of Nmax_dmerge  values associated with merging from n + 1 to n jets, for n =1, 2, ... 10
     std::vector<float> exclusive_dmerge_max ;
   };
 

--- a/analyzers/dataframe/JetClusteringUtils.h
+++ b/analyzers/dataframe/JetClusteringUtils.h
@@ -25,6 +25,8 @@ namespace JetClusteringUtils{
   struct FCCAnalysesJet{
     ROOT::VecOps::RVec<fastjet::PseudoJet> jets;
     std::vector<std::vector<int>> constituents;
+    std::vector<float> exclusive_dmerge;   // vector of 10 values associated with merging from n + 1 to n jets, for n =1, 2, ... 10
+    std::vector<float> exclusive_dmerge_max ;
   };
 
   /** Set fastjet pseudoJet for later reconstruction*/
@@ -51,6 +53,12 @@ namespace JetClusteringUtils{
 
   /** Get fastjet constituents after reconstruction from FCCAnalyses jets*/
   std::vector<std::vector<int>> get_constituents(FCCAnalysesJet);
+
+
+  /// return the dmin corresponding to the recombination that went from n+1 to n jets
+  float get_exclusive_dmerge( FCCAnalysesJet in, int n );
+  float get_exclusive_dmerge_max( FCCAnalysesJet in, int n );
+
   
   /** Get jet px. Details. */
   ROOT::VecOps::RVec<float> get_px(ROOT::VecOps::RVec<fastjet::PseudoJet> in);
@@ -86,13 +94,15 @@ namespace JetClusteringUtils{
   ///Internal methods
   FCCAnalysesJet initialise_FCCAnalysesJet();
 
-  FCCAnalysesJet build_FCCAnalysesJet(std::vector<fastjet::PseudoJet> in);
+  FCCAnalysesJet build_FCCAnalysesJet(std::vector<fastjet::PseudoJet> in, std::vector<float> dmerge, std::vector<float> dmerge_max );
   
   std::vector<fastjet::PseudoJet> build_jets(fastjet::ClusterSequence & cs, int exclusive, float cut, int sorted);
 
   bool check(unsigned int n, int exclusive, float cut);
 
   fastjet::RecombinationScheme recomb_scheme(int recombination);
+
+  std::vector<float> exclusive_dmerge( fastjet::ClusterSequence & cs, int do_dmarge_max)  ;
   
   ///@}
 }


### PR DESCRIPTION
( That's a repeat of PR#135, as the code of PR#135 was merged into the "optimisation" branch, with the idea of merging this branch into "master" quickly afterwards. As the merging of "optimisation" into "master" seems to require still a bit of work, I open this new PR such that the corresponding code can be made available in the master branch. )

Update of JetClustering and JetClusteringUtils such that one can retrieve the d_min values associated with merging from n+1 to n jets. See FastJet manual, section 3.3.2.
The structure FCCAnalysesJet is extended by two vectors, one corresponding to the method exclusive_dmerge of FastJet, the other one to exclusive_dmerge_max.

Example usage:
.Define("FCCAnalysesJets", "JetClustering::clustering_ee_genkt(1.5, 2, 2, 1, 0, 1)(pseudo_jets)")
.Define("jets", "JetClusteringUtils::get_pseudoJets( FCCAnalysesJets )")
.Define("dmerge_23", "JetClusteringUtils::get_exclusive_dmerge( FCCAnalysesJets, 2)" )

For a given event, dmerge_23 is the value such that: if the clustering is run with d_cut > dmerge_23, the jet algorithm returns 2 jets ; if it is run with d_cut < dmerge_23, the algorithm returns 3 jets.