### PR TITLE
Do 'using namespace FCCAnalyses;' by default, for backwards incompatibility

### DIFF
--- a/config/FCCAnalysisRun.py
+++ b/config/FCCAnalysisRun.py
@@ -292,6 +292,8 @@ def runPreprocess(df):
     return df
 #__________________________________________________________
 def runRDF(rdfModule, inputlist, outFile, nevt):
+    # for convenience and compatibility with user code
+    ROOT.gInterpreter.Declare("using namespace FCCAnalyses;")
 
     # cannot use MT with Range()
     if args.nevents < 0:


### PR DESCRIPTION
This makes the changes from https://github.com/HEP-FCC/FCCAnalyses/pull/142 backwards compatible so as to avoid massive changes in user code like https://github.com/HEP-FCC/FCCeePhysicsPerformance/pull/41/files