### PR TITLE
cmake: set CMAKE_PREFIX_PATH in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,7 @@ if [ "${0}" != "${BASH_SOURCE}" ]; then
   fi
   export PYTHONPATH=$PWD:$PYTHONPATH
   export LD_LIBRARY_PATH=$PWD/install/lib:$LD_LIBRARY_PATH
+  export CMAKE_PREFIX_PATH=$PWD/install:$CMAKE_PREFIX_PATH
   export ROOT_INCLUDE_PATH=$PWD/install/include/FCCAnalyses:$ROOT_INCLUDE_PATH
   export LOCAL_DIR=$PWD
   export LD_LIBRARY_PATH=`python -m awkward.config --libdir`:$LD_LIBRARY_PATH


### PR DESCRIPTION
This will be useful for user code to be able to do `find_package('FCCAnalyses')` and pick up the local installation