### PR TITLE
adapt to time-extended edm4hep::Track

### DIFF
--- a/analyzers/dataframe/src/VertexingUtils.cc
+++ b/analyzers/dataframe/src/VertexingUtils.cc
@@ -102,7 +102,7 @@ get_trackParam( edm4hep::TrackState & atrack) {
 
 TMatrixDSym
 get_trackCov( edm4hep::TrackState &  atrack) {
-  std::array<float, 15> covMatrix = atrack.covMatrix;
+  auto covMatrix = atrack.covMatrix;
   TMatrixDSym covM(5);
 
   double scale0 = 1e-3;


### PR DESCRIPTION
`auto` should make this work both with edm4hep 4.x and 5.x 

See https://github.com/key4hep/EDM4hep/pull/138