### PR TITLE
cmake: fix minimum required version, cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
          mkdir -p build install;\
          source ${{ matrix.SETUP }};\
          cd build;\
-         cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17  -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -DWITH_ONNX=ON -G Ninja ..;'
+         cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17  -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -DWITH_DD4HEP=ON -DWITH_ACTS=ON -DWITH_ONNX=ON -G Ninja ..;'
     - name: Compile
       run: |
         docker exec CI_container /bin/bash -c 'cd ./Package;\

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.1...3.16)
-#cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.16.9)
 
 
 project(FCCAnalyses CXX)
 
-#needed for ACTS
-cmake_policy(SET CMP0057 NEW)
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "RPATH USE LINK PATH")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,24 +3,45 @@ cmake_minimum_required(VERSION 3.16.9)
 
 project(FCCAnalyses CXX)
 
+#--- RPATH settings -----------------------------------------------------------
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "RPATH USE LINK PATH")
 
-#--- enable unit testing capabilities ------------------------------------------
+#--- enable unit testing capabilities -----------------------------------------
 include(CTest)
-option(USE_EXTERNAL_CATCH2 "Link against an external Catch2 v3 static library, otherwise build it locally" ON)
 
 
+#--- options ------------------------------------------------------------------
 
-option(WITH_DD4HEP "Build analyzers that need DD4hep" OFF)
+
+set(WITH_ACTS AUTO CACHE STRING "Build analyzers that need Acts")
+set_property(CACHE WITH_ACTS PROPERTY STRINGS AUTO ON OFF)
+
+set(WITH_DD4HEP AUTO CACHE STRING "Build analyzers that need DD4hep")
+set_property(CACHE WITH_DD4HEP PROPERTY STRINGS AUTO ON OFF)
+
 set(WITH_ONNX AUTO CACHE STRING "Build analyzers that need ONNXRuntime")
 set_property(CACHE WITH_ONNX PROPERTY STRINGS AUTO ON OFF)
+
+option(FCCANALYSES_CASESTUDIES "Build the case studies" OFF)
+
+option(USE_EXTERNAL_CATCH2 "Link against an external Catch2 v3 static library, otherwise build it locally" ON)
+
+option(FCCANALYSES_DOCUMENTATION "Whether or not to create doxygen doc target." ON)
 
 #--- Set a better default for installation directory---------------------------
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}/install" CACHE PATH "default install path" FORCE)
 endif()
 
+# Use GNU-style hierarchy for installing build products
+include(GNUInstallDirs)
+
+# Offer the user the choice of overriding the installation directories
+set(INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
+set(INSTALL_BIN_DIR bin CACHE PATH "Installation directory for executables")
+set(INSTALL_INCLUDE_DIR include CACHE PATH
+  "Installation directory for header files")
 
 
 #--- Declare C++ Standard -----------------------------------------------------
@@ -31,45 +52,73 @@ if(NOT CMAKE_CXX_STANDARD MATCHES "17")
 endif()
 message (STATUS "C++ standard: ${CMAKE_CXX_STANDARD}")
 
+#--- Dependencies -------------------------------------------------------------
 
-
-find_package(ROOT COMPONENTS ROOTDataFrame)
-include(${ROOT_USE_FILE})
-
-find_package(EDM4HEP)
+find_package(ROOT COMPONENTS ROOTVecOps ROOTDataFrame REQUIRED)
+find_package(EDM4HEP REQUIRED)
 find_package(podio)
 
-
-# Define basic build settings
-# Use GNU-style hierarchy for installing build products
-include(GNUInstallDirs)
-
-
-
+# need to use our own FindFastJet.cmake
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 find_package(FastJet)
-find_package( Acts COMPONENTS Core )
-
-# Offer the user the choice of overriding the installation directories
-set(INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
-set(INSTALL_BIN_DIR bin CACHE PATH "Installation directory for executables")
-set(INSTALL_INCLUDE_DIR include CACHE PATH
-  "Installation directory for header files")
 
 
-# Grab the test files into a cached directory
-if(NOT DEFINED CACHE{TEST_INPUT_DATA_DIR})
-  message(STATUS "Getting test input files")
-  execute_process(COMMAND bash ${CMAKE_CURRENT_LIST_DIR}/tests/get_test_inputs.sh
-                  OUTPUT_VARIABLE test_input_data_dir
-                  RESULT_VARIABLE test_inputs_available)
-  if(NOT "${test_inputs_available}" STREQUAL "0")
-    message(WARNING "Failed to retrieve input test files. Some tests will need to be skipped.")
-    unset(TEST_INPUT_DATA_DIR CACHE)
+if(WITH_ACTS)
+  find_package( Acts COMPONENTS Core )
+  if(Acts_FOUND)
+
+  elseif(WITH_ACTS STREQUAL AUTO)
+    message(WARNING "Acts not found. Skipping Acts-dependent analyzers.")
+    set(WITH_ACTS OFF)
   else()
-    message(STATUS "Test input files stored in ${test_input_data_dir}")
-    set(TEST_INPUT_DATA_DIR ${test_input_data_dir} CACHE INTERNAL "directory for input test files")
-    mark_as_advanced(TEST_INPUT_DATA_DIR)
+    message(FATAL_ERROR "Failed to locate Acts!")
+  endif()
+endif()
+
+
+if(WITH_ONNX)
+  find_package(ONNXRuntime)
+  find_package(nlohmann_json)
+  if(ONNXRuntime_FOUND AND nlohmann_json_FOUND)
+    message(STATUS "includes-------------------------- dataframe onnxruntime: ${ONNXRUNTIME_INCLUDE_DIRS}")
+    message(STATUS "includes-------------------------- dataframe nlohmann_json")
+  elseif(WITH_ONNX STREQUAL AUTO)
+    message(WARNING "ONNXRuntime and/or nlohmann's JSON libraries not found. Skipping ONNX-dependent analyzers.")
+    set(WITH_ONNX OFF)
+  else()
+    message(FATAL_ERROR "Failed to locate ONNXRuntime and/or nlohmann's JSON library!")
+  endif()
+endif()
+
+
+if(WITH_DD4HEP)
+  find_package(DD4hep)
+  if(DD4hep_FOUND)
+
+  elseif(WITH_DD4HEP STREQUAL AUTO)
+    message(WARNING "DD4hep not found. Skipping DD4hep-dependent analyzers.")
+    set(WITH_DD4HEP OFF)
+  else()
+    message(FATAL_ERROR "Failed to locate DD4hep!")
+  endif()
+endif()
+
+
+if(WITH_ONNX AND BUILD_TESTING) # currently these files are only needed by ONNX-parts
+# Grab the test files into a cached directory
+  if(NOT DEFINED CACHE{TEST_INPUT_DATA_DIR})
+    message(STATUS "Getting test input files")
+    execute_process(COMMAND bash ${CMAKE_CURRENT_LIST_DIR}/tests/get_test_inputs.sh
+                    OUTPUT_VARIABLE test_input_data_dir
+                    RESULT_VARIABLE test_inputs_available)
+    if(NOT "${test_inputs_available}" STREQUAL "0")
+      message(WARNING "Failed to retrieve input test files. Some tests will need to be skipped.")
+      unset(TEST_INPUT_DATA_DIR CACHE)
+    else()
+      message(STATUS "Test input files stored in ${test_input_data_dir}")
+      set(TEST_INPUT_DATA_DIR ${test_input_data_dir} CACHE INTERNAL "directory for input test files")
+      mark_as_advanced(TEST_INPUT_DATA_DIR)
+    endif()
   endif()
 endif()
 
@@ -88,9 +137,7 @@ file(GLOB _run_python_files config/*.py)
 install(FILES ${_run_python_files} DESTINATION ${CMAKE_INSTALL_PREFIX}/python/config)
 install(FILES config/doPlots.py PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ DESTINATION ${CMAKE_INSTALL_PREFIX}/python/config)
 
-#install(DIRECTORY FCCeeAnalyses DESTINATION ${CMAKE_INSTALL_PREFIX}/python)
-#install(DIRECTORY FCChhAnalyses DESTINATION ${CMAKE_INSTALL_PREFIX}/python)
-
+#--- Awkward setup ------------------------------------------------------------
 
 execute_process(COMMAND python -m awkward.config --incdir OUTPUT_VARIABLE _AWKWARD_INCLUDE OUTPUT_STRIP_TRAILING_WHITESPACE)
 set(AWKWARD_INCLUDE ${_AWKWARD_INCLUDE})
@@ -98,8 +145,6 @@ execute_process(COMMAND python -m awkward.config --libdir OUTPUT_VARIABLE _AWKWA
 set(AWKWARD_LIBRARIES ${_AWKWARD_LIBRARIES})
 
 include_directories(BEFORE "${AWKWARD_INCLUDE}")
-
-
 
 find_library(CPU-KERNELS awkward-cpu-kernels REQUIRED HINTS ${AWKWARD_LIBRARIES})
 find_library(LIBAWKWARD awkward REQUIRED HINTS ${AWKWARD_LIBRARIES})
@@ -109,16 +154,15 @@ message(STATUS "Libraries: ${CPU-KERNELS} ${LIBAWKWARD} ${LIBDL}")
 message(STATUS "includes--------------------- main: ${AWKWARD_INCLUDE}")
 message(STATUS "Library---------------------- main: ${AWKWARD_LIBRARIES}")
 
+#--- Descend into subdirectories ----------------------------------------------
 
 add_subdirectory(analyzers/dataframe)
 
 
-option(FCCANALYSES_CASESTUDIES "Build the case studies" OFF)
 if(FCCANALYSES_CASESTUDIES)
   add_subdirectory(analyzers/dataframe/case-studies FCCANALYSES_CASESTUDIES)
 endif()
 
-option(FCCANALYSES_DOCUMENTATION "Whether or not to create doxygen doc target." ON)
 
 if(FCCANALYSES_DOCUMENTATION)
   include(cmake/FCCANALYSESDoxygen.cmake)

--- a/analyzers/dataframe/CMakeLists.txt
+++ b/analyzers/dataframe/CMakeLists.txt
@@ -60,11 +60,6 @@ target_include_directories(FCCAnalyses  PUBLIC
                            ${EXTRA_INCLUDE_DIRS}
                            )
 
-if(WITH_ACTS)
-#  target_include_directories(FCCAnalyses  PUBLIC
-#                             ${acts_INCLUDE_DIR}
-#                             )
-endif()
 
 
 target_link_libraries(FCCAnalyses
@@ -90,7 +85,7 @@ if(WITH_DD4HEP)
 endif()
 
 if(WITH_ACTS)
-  target_link_libraries(FCCAnalyses ActsCore )# ${acts_LIBRARY} )
+  target_link_libraries(FCCAnalyses ActsCore)
 endif()
 
 set_target_properties(FCCAnalyses PROPERTIES

--- a/analyzers/dataframe/CMakeLists.txt
+++ b/analyzers/dataframe/CMakeLists.txt
@@ -1,21 +1,8 @@
 
-find_package(ROOT REQUIRED COMPONENTS ROOTDataFrame ROOTVecOps)
-include(${ROOT_USE_FILE})
-#include("${ROOT_DIR}/modules/RootNewMacros.cmake")
 
+# workaround for ROOT not properly exporting the VDT includes
 find_package(Vdt)
 
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
-
-get_target_property(EDM4HEP_INCLUDE_DIRS EDM4HEP::edm4hep INTERFACE_INCLUDE_DIRECTORIES)
-
-include_directories(${EDM4HEP_INCLUDE_DIRS}
-                    ${podio_INCLUDE_DIR}
-                    ${FASTJET_INCLUDE_DIR}
-                    ${acts_INCLUDE_DIR}
-                    ${AWKWARD_INCLUDE}
-                    ${VDT_INCLUDE_DIR}
-                    )
 
 message(STATUS "includes-------------------------- dataframe awkward:     ${AWKWARD_INCLUDE}")
 message(STATUS "includes-------------------------- dataframe edm4hep:     ${EDM4HEP_INCLUDE_DIRS}")
@@ -25,20 +12,10 @@ message(STATUS "includes-------------------------- dataframe fastjet:     ${FAST
 set(EXTRA_INCLUDE_DIRS)
 set(EXTRA_LIBRARIES)
 
-if(WITH_ONNX STREQUAL AUTO OR WITH_ONNX)
-  find_package(ONNXRuntime QUIET)
-  find_package(nlohmann_json QUIET)
-  if(ONNXRuntime_FOUND AND nlohmann_json_FOUND)
-    message(STATUS "includes-------------------------- dataframe onnxruntime: ${ONNXRUNTIME_INCLUDE_DIRS}")
-    message(STATUS "includes-------------------------- dataframe nlohmann_json")
+if(WITH_ONNX)
     list(APPEND EXTRA_INCLUDE_DIRS ${ONNXRUNTIME_INCLUDE_DIRS})
     list(APPEND EXTRA_LIBRARIES ${ONNXRUNTIME_LIBRARIES} nlohmann_json::nlohmann_json)
     include_directories(${ONNXRUNTIME_INCLUDE_DIRS})
-  elseif(WITH_ONNX STREQUAL AUTO)
-    message(WARNING "ONNXRuntime and/or nlohmann's JSON libraries not found.")
-  else()
-    message(FATAL_ERROR "Failed to locate ONNXRuntime and/or nlohmann's JSON library!")
-  endif()
 endif()
 
 
@@ -49,17 +26,24 @@ message(STATUS "includes headers ${headers}")
 message(STATUS "includes sources ${sources}")
 
 list(FILTER headers EXCLUDE REGEX "LinkDef.h")
-if(NOT ${WITH_DD4HEP})
+if(NOT WITH_DD4HEP)
   list(FILTER headers EXCLUDE REGEX "CaloNtupleizer.h")
   list(FILTER sources EXCLUDE REGEX "CaloNtupleizer.cc")
 endif()
-if(NOT ${WITH_ONNX})
+if(NOT WITH_ONNX)
   list(FILTER headers EXCLUDE REGEX "JetFlavourUtils.h")
   list(FILTER sources EXCLUDE REGEX "JetFlavourUtils.cc")
   list(FILTER headers EXCLUDE REGEX "ONNXRuntime.h")
   list(FILTER sources EXCLUDE REGEX "ONNXRuntime.cc")
   list(FILTER headers EXCLUDE REGEX "WeaverInterface.h")
   list(FILTER sources EXCLUDE REGEX "WeaverInterface.cc")
+endif()
+
+if(NOT WITH_ACTS)
+  list(FILTER headers EXCLUDE REGEX "VertexFitterActs.h")
+  list(FILTER sources EXCLUDE REGEX "VertexFitterActs.cc")
+  list(FILTER headers EXCLUDE REGEX "VertexFinderActs.h")
+  list(FILTER sources EXCLUDE REGEX "VertexFinderActs.cc")
 endif()
 
 
@@ -71,10 +55,17 @@ target_include_directories(FCCAnalyses  PUBLIC
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                            $<INSTALL_INTERFACE:include>
                            ${FASTJET_INCLUDE_DIR}
-                           ${acts_INCLUDE_DIR}
+                           ${VDT_INCLUDE_DIR}
                            ${AWKWARD_INCLUDE}
                            ${EXTRA_INCLUDE_DIRS}
                            )
+
+if(WITH_ACTS)
+#  target_include_directories(FCCAnalyses  PUBLIC
+#                             ${acts_INCLUDE_DIR}
+#                             )
+endif()
+
 
 target_link_libraries(FCCAnalyses
                       ROOT::Physics
@@ -86,8 +77,6 @@ target_link_libraries(FCCAnalyses
                       podio::podio
                       ${FASTJET_LIBRARY}
                       ${FASTJET_LIBRARY_DIRS}/libfastjetplugins.so
-                      ${acts_LIBRARY}
-                      ActsCore
                       #${AWKWARD_LIBRARIES}
                       ${LIBAWKWARD}
                       ${CPU-KERNELS}
@@ -96,9 +85,12 @@ target_link_libraries(FCCAnalyses
                       gfortran # todo: why necessary?
                       )
 
-if(${WITH_DD4HEP})
-  find_package(DD4hep)
+if(WITH_DD4HEP)
   target_link_libraries(FCCAnalyses DD4hep::DDCore)
+endif()
+
+if(WITH_ACTS)
+  target_link_libraries(FCCAnalyses ActsCore )# ${acts_LIBRARY} )
 endif()
 
 set_target_properties(FCCAnalyses PROPERTIES

--- a/analyzers/dataframe/src/Algorithms.cc
+++ b/analyzers/dataframe/src/Algorithms.cc
@@ -101,7 +101,7 @@ float thrustFit::operator()(const double *pars){
   double mag = sqrt(pars[0]*pars[0] + pars[1]*pars[1] + pars[2]*pars[2]);
 
   for (unsigned int i =0; i<_px.size(); i++){
-    num += abs(_px[i]*(pars[0]/mag) + _py[i]*(pars[1]/mag) + _pz[i]*(pars[2]/mag));
+    num += std::abs(_px[i]*(pars[0]/mag) + _py[i]*(pars[1]/mag) + _pz[i]*(pars[2]/mag));
     den += sqrt(_px[i]*_px[i] + _py[i]*_py[i] + _pz[i]*_pz[i]);
   }
   if (den>0.){
@@ -359,12 +359,12 @@ ROOT::VecOps::RVec<float>  getAxisEnergy::operator() (const ROOT::VecOps::RVec<f
   for (size_t i = 0; i < angle.size(); ++i) {
     if (_pos==1 && angle[i]>0.){
       result[0]+=energy[i];
-      if (abs(charge[i])>0) result[1]+=energy[i];
+      if (std::abs(charge[i])>0) result[1]+=energy[i];
       else result[2]+=energy[i];
     }
     if (_pos==0 && angle[i]<0.){
       result[0]+=energy[i];
-      if (abs(charge[i])>0) result[1]+=energy[i];
+      if (std::abs(charge[i])>0) result[1]+=energy[i];
       else result[2]+=energy[i];
     }
   }
@@ -381,12 +381,12 @@ ROOT::VecOps::RVec<int>  getAxisN::operator() (const ROOT::VecOps::RVec<float> &
   for (size_t i = 0; i < angle.size(); ++i) {
     if (_pos==1 && angle[i]>0.){
       result[0]+=1;
-      if (abs(charge[i])>0) result[1]+=1;
+      if (std::abs(charge[i])>0) result[1]+=1;
       else result[2]+=1;
     }
     if (_pos==0 && angle[i]<0.){
       result[0]+=1;
-      if (abs(charge[i])>0) result[1]+=1;
+      if (std::abs(charge[i])>0) result[1]+=1;
       else result[2]+=1;
     }
   }

--- a/analyzers/dataframe/src/VertexFitterSimple.cc
+++ b/analyzers/dataframe/src/VertexFitterSimple.cc
@@ -714,8 +714,8 @@ VertexingUtils::FCCAnalysesVertex  VertexFitter_Tk( int Primary,
     }
   */
 
-  delete final_chi2;
-  delete final_phases;
+  delete[] final_chi2;
+  delete[] final_phases;
 
   return TheVertex;
 }

--- a/analyzers/dataframe/src/myUtils.cc
+++ b/analyzers/dataframe/src/myUtils.cc
@@ -12,7 +12,6 @@
 #include "awkward/builder/ArrayBuilderOptions.h"
 
 #include "FCCAnalyses/myUtils.h"
-#include "FCCAnalyses/VertexFitterActs.h"
 #include "FCCAnalyses/VertexFitterSimple.h"
 #include "FCCAnalyses/ReconstructedParticle.h"
 #include "FCCAnalyses/MCParticle.h"
@@ -1824,7 +1823,6 @@ ROOT::VecOps::RVec<float> awkwardtest(ROOT::VecOps::RVec<edm4hep::ReconstructedP
       thetracks.push_back(tracks.at(tmpvec_tk.at(k)));
     }
 
-    //VertexingUtils::FCCAnalysesVertex TheVertexActs = VertexFitterActs::VertexFitterFullBilloir(recoparticles, tracks );
     VertexingUtils::FCCAnalysesVertex TheVertex = VertexFitterSimple::VertexFitter(0,recoparticles, tracks);
     float chi2 = TheVertex.vertex.chi2;
 


### PR DESCRIPTION
Use 3.16, as imposed by ROOT. Older cmake versions have trouble with generator expression they have to parse when finding ROOT and will error out with:

```
CMake Error at /cvmfs/sw.hsf.org/spackages5/root/6.26.02/x86_64-ubuntu20.04-gcc9.4.0-opt/4uthe/cmake/RootMacros.cmake:639 (add_custom_command):
  Error evaluating generator expression:

    $<REMOVE_DUPLICATES:$<TARGET_PROPERTY:FCCAnalyses,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>>

  Expression did not evaluate to a known generator expression
```

Even older CMake versions won't even reach this point, because of issues with the FindPython module.