### PR TITLE
Jet constituents: passing collections by references

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
@@ -11,20 +11,21 @@ namespace FCCAnalyses {
     using FCCAnalysesJetConstituentsData = rv::RVec<float>;
 
     /// Build the collection of constituents (mapping jet -> reconstructed particles) for all jets in event
-    rv::RVec<FCCAnalysesJetConstituents> build_constituents(rv::RVec<edm4hep::ReconstructedParticleData>,
-                                                            rv::RVec<edm4hep::ReconstructedParticleData>);
+    rv::RVec<FCCAnalysesJetConstituents> build_constituents(const rv::RVec<edm4hep::ReconstructedParticleData>&,
+                                                            const rv::RVec<edm4hep::ReconstructedParticleData>&);
 
     /// Retrieve the constituents of an indexed jet in event
-    FCCAnalysesJetConstituents get_jet_constituents(rv::RVec<FCCAnalysesJetConstituents>, int);
+    FCCAnalysesJetConstituents get_jet_constituents(const rv::RVec<FCCAnalysesJetConstituents>&, int);
     /// Retrieve the constituents of a collection of indexed jets in event
-    rv::RVec<FCCAnalysesJetConstituents> get_constituents(rv::RVec<FCCAnalysesJetConstituents>, rv::RVec<int>);
+    rv::RVec<FCCAnalysesJetConstituents> get_constituents(const rv::RVec<FCCAnalysesJetConstituents>&,
+                                                          const rv::RVec<int>&);
 
-    rv::RVec<FCCAnalysesJetConstituentsData> get_pt(rv::RVec<FCCAnalysesJetConstituents>);
-    rv::RVec<FCCAnalysesJetConstituentsData> get_e(rv::RVec<FCCAnalysesJetConstituents>);
-    rv::RVec<FCCAnalysesJetConstituentsData> get_theta(rv::RVec<FCCAnalysesJetConstituents>);
-    rv::RVec<FCCAnalysesJetConstituentsData> get_phi(rv::RVec<FCCAnalysesJetConstituents>);
-    rv::RVec<FCCAnalysesJetConstituentsData> get_type(rv::RVec<FCCAnalysesJetConstituents>);
-    rv::RVec<FCCAnalysesJetConstituentsData> get_charge(rv::RVec<FCCAnalysesJetConstituents>);
+    rv::RVec<FCCAnalysesJetConstituentsData> get_pt(const rv::RVec<FCCAnalysesJetConstituents>&);
+    rv::RVec<FCCAnalysesJetConstituentsData> get_e(const rv::RVec<FCCAnalysesJetConstituents>&);
+    rv::RVec<FCCAnalysesJetConstituentsData> get_theta(const rv::RVec<FCCAnalysesJetConstituents>&);
+    rv::RVec<FCCAnalysesJetConstituentsData> get_phi(const rv::RVec<FCCAnalysesJetConstituents>&);
+    rv::RVec<FCCAnalysesJetConstituentsData> get_type(const rv::RVec<FCCAnalysesJetConstituents>&);
+    rv::RVec<FCCAnalysesJetConstituentsData> get_charge(const rv::RVec<FCCAnalysesJetConstituents>&);
   }  // namespace JetConstituentsUtils
 }  // namespace FCCAnalyses
 

--- a/analyzers/dataframe/src/JetConstituentsUtils.cc
+++ b/analyzers/dataframe/src/JetConstituentsUtils.cc
@@ -3,8 +3,8 @@
 
 namespace FCCAnalyses {
   namespace JetConstituentsUtils {
-    rv::RVec<FCCAnalysesJetConstituents> build_constituents(rv::RVec<edm4hep::ReconstructedParticleData> jets,
-                                                            rv::RVec<edm4hep::ReconstructedParticleData> rps) {
+    rv::RVec<FCCAnalysesJetConstituents> build_constituents(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+                                                            const rv::RVec<edm4hep::ReconstructedParticleData>& rps) {
       rv::RVec<FCCAnalysesJetConstituents> jcs;
       for (const auto& jet : jets) {
         auto& jc = jcs.emplace_back();
@@ -14,14 +14,14 @@ namespace FCCAnalyses {
       return jcs;
     }
 
-    FCCAnalysesJetConstituents get_jet_constituents(rv::RVec<FCCAnalysesJetConstituents> csts, int jet) {
+    FCCAnalysesJetConstituents get_jet_constituents(const rv::RVec<FCCAnalysesJetConstituents>& csts, int jet) {
       if (jet < 0)
         return FCCAnalysesJetConstituents();
       return csts.at(jet);
     }
 
-    rv::RVec<FCCAnalysesJetConstituents> get_constituents(rv::RVec<FCCAnalysesJetConstituents> csts,
-                                                          rv::RVec<int> jets) {
+    rv::RVec<FCCAnalysesJetConstituents> get_constituents(const rv::RVec<FCCAnalysesJetConstituents>& csts,
+                                                          const rv::RVec<int>& jets) {
       rv::RVec<FCCAnalysesJetConstituents> jcs;
       for (size_t i = 0; i < jets.size(); ++i)
         if (jets.at(i) >= 0)
@@ -39,27 +39,27 @@ namespace FCCAnalyses {
       return out;
     };
 
-    rv::RVec<FCCAnalysesJetConstituentsData> get_pt(rv::RVec<FCCAnalysesJetConstituents> jcs) {
+    rv::RVec<FCCAnalysesJetConstituentsData> get_pt(const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
       return cast_constituent(jcs, ReconstructedParticle::get_pt);
     }
 
-    rv::RVec<FCCAnalysesJetConstituentsData> get_e(rv::RVec<FCCAnalysesJetConstituents> jcs) {
+    rv::RVec<FCCAnalysesJetConstituentsData> get_e(const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
       return cast_constituent(jcs, ReconstructedParticle::get_e);
     }
 
-    rv::RVec<FCCAnalysesJetConstituentsData> get_theta(rv::RVec<FCCAnalysesJetConstituents> jcs) {
+    rv::RVec<FCCAnalysesJetConstituentsData> get_theta(const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
       return cast_constituent(jcs, ReconstructedParticle::get_theta);
     }
 
-    rv::RVec<FCCAnalysesJetConstituentsData> get_phi(rv::RVec<FCCAnalysesJetConstituents> jcs) {
+    rv::RVec<FCCAnalysesJetConstituentsData> get_phi(const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
       return cast_constituent(jcs, ReconstructedParticle::get_phi);
     }
 
-    rv::RVec<FCCAnalysesJetConstituentsData> get_type(rv::RVec<FCCAnalysesJetConstituents> jcs) {
+    rv::RVec<FCCAnalysesJetConstituentsData> get_type(const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
       return cast_constituent(jcs, ReconstructedParticle::get_type);
     }
 
-    rv::RVec<FCCAnalysesJetConstituentsData> get_charge(rv::RVec<FCCAnalysesJetConstituents> jcs) {
+    rv::RVec<FCCAnalysesJetConstituentsData> get_charge(const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
       return cast_constituent(jcs, ReconstructedParticle::get_charge);
     }
   }  // namespace JetConstituentsUtils


### PR DESCRIPTION
This PR allows jet constituents retrieval helpers to get a const reference to the collection instead of a copy at each call.