### PR TITLE
Fix CI crashes in ONNXRuntime/Weaver integration test

### DIFF
--- a/addons/ONNXRuntime/WeaverInterface.h
+++ b/addons/ONNXRuntime/WeaverInterface.h
@@ -4,71 +4,69 @@
 #include "ONNXRuntime/ONNXRuntime.h"
 #include "ROOT/RVec.hxx"
 
-namespace FCCAnalyses {
-  namespace rv = ROOT::VecOps;
+namespace rv = ROOT::VecOps;
 
-  class WeaverInterface {
-  public:
-    using ConstituentVars = rv::RVec<float>;
+class WeaverInterface {
+public:
+  using ConstituentVars = rv::RVec<float>;
 
-    /// Initialise an inference model from Weaver output ONNX/JSON files and
-    /// a list of variables to be provided for each event/jet
-    explicit WeaverInterface(const std::string& onnx_filename = "",
-                             const std::string& json_filename = "",
-                             const rv::RVec<std::string>& vars = {});
+  /// Initialise an inference model from Weaver output ONNX/JSON files and
+  /// a list of variables to be provided for each event/jet
+  explicit WeaverInterface(const std::string& onnx_filename = "",
+                           const std::string& json_filename = "",
+                           const rv::RVec<std::string>& vars = {});
 
-    /// Run inference given a list of jet constituents variables
-    rv::RVec<float> run(const rv::RVec<ConstituentVars>&);
+  /// Run inference given a list of jet constituents variables
+  rv::RVec<float> run(const rv::RVec<ConstituentVars>&);
 
-  private:
-    struct PreprocessParams {
-      struct VarInfo {
-        VarInfo() {}
-        VarInfo(float imedian,
-                float inorm_factor,
-                float ireplace_inf_value,
-                float ilower_bound,
-                float iupper_bound,
-                float ipad)
-            : center(imedian),
-              norm_factor(inorm_factor),
-              replace_inf_value(ireplace_inf_value),
-              lower_bound(ilower_bound),
-              upper_bound(iupper_bound),
-              pad(ipad) {}
+private:
+  struct PreprocessParams {
+    struct VarInfo {
+      VarInfo() {}
+      VarInfo(float imedian,
+              float inorm_factor,
+              float ireplace_inf_value,
+              float ilower_bound,
+              float iupper_bound,
+              float ipad)
+          : center(imedian),
+            norm_factor(inorm_factor),
+            replace_inf_value(ireplace_inf_value),
+            lower_bound(ilower_bound),
+            upper_bound(iupper_bound),
+            pad(ipad) {}
 
-        float center{0.};
-        float norm_factor{1.};
-        float replace_inf_value{0.};
-        float lower_bound{-5.};
-        float upper_bound{5.};
-        float pad{0.};
-      };
-      std::string name;
-      size_t min_length{0}, max_length{0};
-      std::vector<std::string> var_names;
-      std::unordered_map<std::string, VarInfo> var_info_map;
-      VarInfo info(const std::string& name) const { return var_info_map.at(name); }
-      void dumpVars() const;
+      float center{0.};
+      float norm_factor{1.};
+      float replace_inf_value{0.};
+      float lower_bound{-5.};
+      float upper_bound{5.};
+      float pad{0.};
     };
-    std::vector<float> center_norm_pad(const rv::RVec<float>& input,
-                                       float center,
-                                       float scale,
-                                       size_t min_length,
-                                       size_t max_length,
-                                       float pad_value = 0,
-                                       float replace_inf_value = 0,
-                                       float min = 0,
-                                       float max = -1);
-    size_t variablePos(const std::string&) const;
-
-    std::unique_ptr<ONNXRuntime> onnx_;
-    std::vector<std::string> variables_names_;
-    ONNXRuntime::Tensor<long> input_shapes_;
-    std::vector<unsigned int> input_sizes_;
-    std::unordered_map<std::string, PreprocessParams> prep_info_map_;
-    ONNXRuntime::Tensor<float> data_;
+    std::string name;
+    size_t min_length{0}, max_length{0};
+    std::vector<std::string> var_names;
+    std::unordered_map<std::string, VarInfo> var_info_map;
+    VarInfo info(const std::string& name) const { return var_info_map.at(name); }
+    void dumpVars() const;
   };
-}  // namespace FCCAnalyses
+  std::vector<float> center_norm_pad(const rv::RVec<float>& input,
+                                     float center,
+                                     float scale,
+                                     size_t min_length,
+                                     size_t max_length,
+                                     float pad_value = 0,
+                                     float replace_inf_value = 0,
+                                     float min = 0,
+                                     float max = -1);
+  size_t variablePos(const std::string&) const;
+
+  std::unique_ptr<ONNXRuntime> onnx_;
+  std::vector<std::string> variables_names_;
+  ONNXRuntime::Tensor<long> input_shapes_;
+  std::vector<unsigned int> input_sizes_;
+  std::unordered_map<std::string, PreprocessParams> prep_info_map_;
+  ONNXRuntime::Tensor<float> data_;
+};
 
 #endif

--- a/addons/ONNXRuntime/src/ONNXRuntime.cc
+++ b/addons/ONNXRuntime/src/ONNXRuntime.cc
@@ -7,6 +7,8 @@
 
 ONNXRuntime::ONNXRuntime(const std::string& model_path, const std::vector<std::string>& input_names)
     : env_(new Ort::Env(OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING, "onnx_runtime")), input_names_(input_names) {
+  if (model_path.empty())
+    throw std::runtime_error("Path to ONNX model cannot be empty!");
   Ort::SessionOptions options;
   options.SetIntraOpNumThreads(1);
   auto model = model_path;  // fixes a poor Ort experimental API

--- a/addons/ONNXRuntime/src/ONNXRuntime.cc
+++ b/addons/ONNXRuntime/src/ONNXRuntime.cc
@@ -15,24 +15,20 @@ ONNXRuntime::ONNXRuntime(const std::string& model_path, const std::vector<std::s
   session_ = std::make_unique<Ort::Experimental::Session>(*env_, model, options);
 
   // get input names and shapes
-  const auto num_input_nodes = session_->GetInputCount();
-  input_node_strings_.resize(num_input_nodes);
+  input_node_strings_ = session_->GetInputNames();
   input_node_dims_.clear();
-  for (size_t i = 0; i < num_input_nodes; ++i) {
-    const auto input_name = session_->GetInputNames()[i];  // copy is required
-    input_node_strings_[i] = input_name;
+  for (size_t i = 0; i < session_->GetInputCount(); ++i) {
+    const auto input_name = input_node_strings_.at(i);
     // get input shapes
     input_node_dims_[input_name] = session_->GetInputShapes()[i];
   }
 
   // get output names and shapes
-  const auto num_output_nodes = session_->GetOutputCount();
-  output_node_strings_.resize(num_output_nodes);
+  output_node_strings_ = session_->GetOutputNames();
   output_node_dims_.clear();
-  for (size_t i = 0; i < num_output_nodes; i++) {
+  for (size_t i = 0; i < session_->GetOutputCount(); ++i) {
     // get output node names
-    const auto& output_name = session_->GetOutputNames()[i];
-    output_node_strings_[i] = output_name;
+    const auto output_name = output_node_strings_.at(i);
     // get output node types
     output_node_dims_[output_name] = session_->GetOutputShapes()[i];
     // the 0th dim depends on the batch size

--- a/addons/ONNXRuntime/src/ONNXRuntime.cc
+++ b/addons/ONNXRuntime/src/ONNXRuntime.cc
@@ -11,7 +11,7 @@ ONNXRuntime::ONNXRuntime(const std::string& model_path, const std::vector<std::s
     throw std::runtime_error("Path to ONNX model cannot be empty!");
   Ort::SessionOptions options;
   options.SetIntraOpNumThreads(1);
-  auto model = model_path;  // fixes a poor Ort experimental API
+  std::string model{model_path};  // fixes a poor Ort experimental API
   session_ = std::make_unique<Ort::Experimental::Session>(*env_, model, options);
 
   // get input names and shapes

--- a/addons/ONNXRuntime/src/WeaverInterface.cc
+++ b/addons/ONNXRuntime/src/WeaverInterface.cc
@@ -9,6 +9,8 @@ namespace FCCAnalyses {
                                    const std::string& json_filename,
                                    const rv::RVec<std::string>& vars)
       : variables_names_(vars.begin(), vars.end()) {
+    if (onnx_filename.empty())
+      throw std::runtime_error("ONNX modeld input file not specified!");
     if (json_filename.empty())
       throw std::runtime_error("JSON preprocessed input file not specified!");
 

--- a/addons/ONNXRuntime/src/WeaverInterface.cc
+++ b/addons/ONNXRuntime/src/WeaverInterface.cc
@@ -4,130 +4,128 @@
 #include <fstream>
 #include <iostream>
 
-namespace FCCAnalyses {
-  WeaverInterface::WeaverInterface(const std::string& onnx_filename,
-                                   const std::string& json_filename,
-                                   const rv::RVec<std::string>& vars)
-      : variables_names_(vars.begin(), vars.end()) {
-    if (onnx_filename.empty())
-      throw std::runtime_error("ONNX modeld input file not specified!");
-    if (json_filename.empty())
-      throw std::runtime_error("JSON preprocessed input file not specified!");
+WeaverInterface::WeaverInterface(const std::string& onnx_filename,
+                                 const std::string& json_filename,
+                                 const rv::RVec<std::string>& vars)
+    : variables_names_(vars.begin(), vars.end()) {
+  if (onnx_filename.empty())
+    throw std::runtime_error("ONNX modeld input file not specified!");
+  if (json_filename.empty())
+    throw std::runtime_error("JSON preprocessed input file not specified!");
 
-    // the preprocessing JSON was found ; extract the variables listing and all useful information
-    std::ifstream json_file(json_filename);
-    std::vector<std::string> input_names;
-    try {
-      const auto json = nlohmann::json::parse(json_file);
-      json.at("input_names").get_to(input_names);
-      for (const auto& input : input_names) {
-        const auto& group_params = json.at(input);
-        auto& info = prep_info_map_[input];
-        info.name = input;
-        // retrieve the variables names
-        group_params.at("var_names").get_to(info.var_names);
-        // retrieve the shapes for all variables
-        if (group_params.contains("var_length")) {
-          info.min_length = info.max_length = group_params.at("var_length");
-          input_shapes_.push_back({1, (int64_t)info.var_names.size(), (int64_t)info.min_length});
-        } else {
-          info.min_length = group_params.at("min_length");
-          info.max_length = group_params.at("max_length");
-          input_shapes_.push_back({1, (int64_t)info.var_names.size(), -1});
-        }
-        // for all variables, retrieve the allowed range
-        const auto& var_info_params = group_params.at("var_infos");
-        for (const auto& name : info.var_names) {
-          const auto& var_params = var_info_params.at(name);
-          info.var_info_map[name] =
-              PreprocessParams::VarInfo(var_params.at("median"),
-                                        var_params.at("norm_factor"),
-                                        var_params.at("replace_inf_value"),
-                                        var_params.at("lower_bound"),
-                                        var_params.at("upper_bound"),
-                                        var_params.contains("pad") ? (double)var_params.at("pad") : 0.);
-        }
-        // create data storage with a fixed size vector initialised with 0's
-        const auto& len = input_sizes_.emplace_back(info.max_length * info.var_names.size());
-        data_.emplace_back(len, 0);
+  // the preprocessing JSON was found ; extract the variables listing and all useful information
+  std::ifstream json_file(json_filename);
+  std::vector<std::string> input_names;
+  try {
+    const auto json = nlohmann::json::parse(json_file);
+    json.at("input_names").get_to(input_names);
+    for (const auto& input : input_names) {
+      const auto& group_params = json.at(input);
+      auto& info = prep_info_map_[input];
+      info.name = input;
+      // retrieve the variables names
+      group_params.at("var_names").get_to(info.var_names);
+      // retrieve the shapes for all variables
+      if (group_params.contains("var_length")) {
+        info.min_length = info.max_length = group_params.at("var_length");
+        input_shapes_.push_back({1, (int64_t)info.var_names.size(), (int64_t)info.min_length});
+      } else {
+        info.min_length = group_params.at("min_length");
+        info.max_length = group_params.at("max_length");
+        input_shapes_.push_back({1, (int64_t)info.var_names.size(), -1});
       }
-    } catch (const nlohmann::json::exception& exc) {
-      throw std::runtime_error("Failed to parse input JSON file '" + json_filename + "'.\n" + exc.what());
-    }
-    onnx_ = std::make_unique<ONNXRuntime>(onnx_filename, input_names);
-  }
-
-  std::vector<float> WeaverInterface::center_norm_pad(const rv::RVec<float>& input,
-                                                      float center,
-                                                      float scale,
-                                                      size_t min_length,
-                                                      size_t max_length,
-                                                      float pad_value,
-                                                      float replace_inf_value,
-                                                      float min,
-                                                      float max) {
-    if (min > pad_value || pad_value > max)
-      throw std::runtime_error("Pad value not within (min, max) range");
-    if (min_length > max_length)
-      throw std::runtime_error("Variable length mismatch (min_length >= max_length)");
-
-    auto ensure_finitude = [](const float in, const float replace_val) {
-      if (!std::isfinite(in))
-        return replace_val;
-      return in;
-    };
-
-    size_t target_length = std::clamp(input.size(), min_length, max_length);
-    std::vector<float> out(target_length, pad_value);
-    for (size_t i = 0; i < input.size() && i < target_length; ++i)
-      out[i] = std::clamp((ensure_finitude(input[i], replace_inf_value) - center) * scale, min, max);
-    return out;
-  }
-
-  size_t WeaverInterface::variablePos(const std::string& var_name) const {
-    auto var_it = std::find(variables_names_.begin(), variables_names_.end(), var_name);
-    if (var_it == variables_names_.end())
-      throw std::runtime_error("Unable to find variable with name '" + var_name +
-                               "' in the list of registered variables");
-    return var_it - variables_names_.begin();
-  }
-
-  rv::RVec<float> WeaverInterface::run(const rv::RVec<ConstituentVars>& constituents) {
-    size_t i = 0;
-    for (const auto& name : onnx_->inputNames()) {
-      const auto& params = prep_info_map_.at(name);
-      auto& values = data_[i];
-      values.resize(input_sizes_.at(i));
-      std::fill(values.begin(), values.end(), 0);
-      size_t it_pos = 0;
-      ConstituentVars jc;
-      for (size_t j = 0; j < params.var_names.size(); ++j) {  // transform and add the proper amount of padding
-        const auto& var_name = params.var_names.at(j);
-        if (std::find(variables_names_.begin(), variables_names_.end(), "pfcand_mask") == variables_names_.end())
-          jc = ConstituentVars(constituents.at(0).size(), 1.f);
-        else
-          jc = constituents.at(variablePos(var_name));
-        const auto& var_info = params.info(var_name);
-        auto val = center_norm_pad(jc,
-                                   var_info.center,
-                                   var_info.norm_factor,
-                                   params.min_length,
-                                   params.max_length,
-                                   var_info.pad,
-                                   var_info.replace_inf_value,
-                                   var_info.lower_bound,
-                                   var_info.upper_bound);
-        std::copy(val.begin(), val.end(), values.begin() + it_pos);
-        it_pos += val.size();
+      // for all variables, retrieve the allowed range
+      const auto& var_info_params = group_params.at("var_infos");
+      for (const auto& name : info.var_names) {
+        const auto& var_params = var_info_params.at(name);
+        info.var_info_map[name] =
+            PreprocessParams::VarInfo(var_params.at("median"),
+                                      var_params.at("norm_factor"),
+                                      var_params.at("replace_inf_value"),
+                                      var_params.at("lower_bound"),
+                                      var_params.at("upper_bound"),
+                                      var_params.contains("pad") ? (double)var_params.at("pad") : 0.);
       }
-      values.resize(it_pos);
-      ++i;
+      // create data storage with a fixed size vector initialised with 0's
+      const auto& len = input_sizes_.emplace_back(info.max_length * info.var_names.size());
+      data_.emplace_back(len, 0);
     }
-    return onnx_->run<float>(data_, input_shapes_)[0];
+  } catch (const nlohmann::json::exception& exc) {
+    throw std::runtime_error("Failed to parse input JSON file '" + json_filename + "'.\n" + exc.what());
   }
+  onnx_ = std::make_unique<ONNXRuntime>(onnx_filename, input_names);
+}
 
-  void WeaverInterface::PreprocessParams::dumpVars() const {
-    std::cout << "List of variables for preprocessing parameter '" << name
-              << "': " << rv::RVec<std::string>(var_names.begin(), var_names.end()) << "." << std::endl;
+std::vector<float> WeaverInterface::center_norm_pad(const rv::RVec<float>& input,
+                                                    float center,
+                                                    float scale,
+                                                    size_t min_length,
+                                                    size_t max_length,
+                                                    float pad_value,
+                                                    float replace_inf_value,
+                                                    float min,
+                                                    float max) {
+  if (min > pad_value || pad_value > max)
+    throw std::runtime_error("Pad value not within (min, max) range");
+  if (min_length > max_length)
+    throw std::runtime_error("Variable length mismatch (min_length >= max_length)");
+
+  auto ensure_finitude = [](const float in, const float replace_val) {
+    if (!std::isfinite(in))
+      return replace_val;
+    return in;
+  };
+
+  size_t target_length = std::clamp(input.size(), min_length, max_length);
+  std::vector<float> out(target_length, pad_value);
+  for (size_t i = 0; i < input.size() && i < target_length; ++i)
+    out[i] = std::clamp((ensure_finitude(input[i], replace_inf_value) - center) * scale, min, max);
+  return out;
+}
+
+size_t WeaverInterface::variablePos(const std::string& var_name) const {
+  auto var_it = std::find(variables_names_.begin(), variables_names_.end(), var_name);
+  if (var_it == variables_names_.end())
+    throw std::runtime_error("Unable to find variable with name '" + var_name +
+                             "' in the list of registered variables");
+  return var_it - variables_names_.begin();
+}
+
+rv::RVec<float> WeaverInterface::run(const rv::RVec<ConstituentVars>& constituents) {
+  size_t i = 0;
+  for (const auto& name : onnx_->inputNames()) {
+    const auto& params = prep_info_map_.at(name);
+    auto& values = data_[i];
+    values.resize(input_sizes_.at(i));
+    std::fill(values.begin(), values.end(), 0);
+    size_t it_pos = 0;
+    ConstituentVars jc;
+    for (size_t j = 0; j < params.var_names.size(); ++j) {  // transform and add the proper amount of padding
+      const auto& var_name = params.var_names.at(j);
+      if (std::find(variables_names_.begin(), variables_names_.end(), "pfcand_mask") == variables_names_.end())
+        jc = ConstituentVars(constituents.at(0).size(), 1.f);
+      else
+        jc = constituents.at(variablePos(var_name));
+      const auto& var_info = params.info(var_name);
+      auto val = center_norm_pad(jc,
+                                 var_info.center,
+                                 var_info.norm_factor,
+                                 params.min_length,
+                                 params.max_length,
+                                 var_info.pad,
+                                 var_info.replace_inf_value,
+                                 var_info.lower_bound,
+                                 var_info.upper_bound);
+      std::copy(val.begin(), val.end(), values.begin() + it_pos);
+      it_pos += val.size();
+    }
+    values.resize(it_pos);
+    ++i;
   }
-}  // namespace FCCAnalyses
+  return onnx_->run<float>(data_, input_shapes_)[0];
+}
+
+void WeaverInterface::PreprocessParams::dumpVars() const {
+  std::cout << "List of variables for preprocessing parameter '" << name
+            << "': " << rv::RVec<std::string>(var_names.begin(), var_names.end()) << "." << std::endl;
+}


### PR DESCRIPTION
This PR fixes the memory corruption crash frequently observed in `weaver_inference.py` test since its introduction in #188.
The vector of variables as extracted from the ONNX file is now directly assigned to the `ONNXRuntime` variables collection member instead of the previous filling method by pre-booking+accessors.
It subsequently simplifies the API for this latter object.

Additionally, a leftover `FCCAnalyses` namespace-enclosing of the `WeaverInterface` object is removed for consistency.

Fixes #193 