### PR TITLE
Adding documentation generation for add-ons

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -744,6 +744,7 @@ WARN_LOGFILE           = @CMAKE_BINARY_DIR@/doxygen-warnings.log
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @CMAKE_SOURCE_DIR@/analyzers/dataframe
+INPUT                 += @CMAKE_SOURCE_DIR@/addons
 INPUT                 += @CMAKE_SOURCE_DIR@/README.md
 USE_MDFILE_AS_MAINPAGE = @CMAKE_SOURCE_DIR@/README.md
 


### PR DESCRIPTION
Added the new `addons` directory introduced in #194 to the sources search path.