### PR TITLE
testing: disable case study test to fix nightlies

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,4 +10,5 @@ add_integration_test("examples/FCCee/higgs/mH-recoil/mumu/analysis_stage1.py")
 add_integration_test("examples/FCCee/flavour/Bc2TauNu/analysis_B2TauNu_truth.py")
 add_integration_test("examples/FCCee/test/jet_constituents.py")
 
-add_generic_test(build_new_case_study "tests/build_new_case_study.sh")
+# TODO: make this test run in the spack build environment
+#add_generic_test(build_new_case_study "tests/build_new_case_study.sh")


### PR DESCRIPTION
I think the `build_new_case_study` utility still needs some discussion and possibly some rework - a lot of the template should be refactored as a CMake macro.

Right now, I'm just disabling the test as it is not adapted to run in the spack build environment.