### PR TITLE
fix cmake

### DIFF
--- a/config/templates/CMakeLists.txt
+++ b/config/templates/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(${lib_name} SHARED ${sources} ${headers} lib${lib_name}.cxx)
 target_include_directories(${lib_name} PUBLIC include
                                               ${FCCANALYSES_DIR}
                                               ${FCCANALYSES_DIR}/addons
+                                              ${FCCANALYSES_DIR}/analyzers/dataframe
                                               $<INSTALL_INTERFACE:include>)
 target_link_directories(${lib_name} PUBLIC ${FCCANALYSES_DIR}
                                            ${FCCANALYSES_DIR}/install/lib)


### PR DESCRIPTION
This is to allow the usage of FCCAnalyses includes in standalone mode. Thanks @kjvbrt, also tagging @vvolkl and @forthommel 