### PR TITLE
Jet Flavour data pre-processing and inference

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
@@ -3,6 +3,13 @@
 
 #include "ROOT/RVec.hxx"
 #include "edm4hep/ReconstructedParticle.h"
+#include "edm4hep/MCParticle.h"
+#include "fastjet/JetDefinition.hh"
+
+#include "TMath.h"
+#include "TVector3.h"
+#include "TRotation.h"
+#include "TLorentzVector.h"
 
 namespace FCCAnalyses {
   namespace JetConstituentsUtils {
@@ -14,11 +21,23 @@ namespace FCCAnalyses {
     rv::RVec<FCCAnalysesJetConstituents> build_constituents(const rv::RVec<edm4hep::ReconstructedParticleData>&,
                                                             const rv::RVec<edm4hep::ReconstructedParticleData>&);
 
+    rv::RVec<FCCAnalysesJetConstituents> build_constituents_cluster(const rv::RVec<edm4hep::ReconstructedParticleData>& rps,
+                                                                    const std::vector<std::vector<int>>& indices);
+
     /// Retrieve the constituents of an indexed jet in event
     FCCAnalysesJetConstituents get_jet_constituents(const rv::RVec<FCCAnalysesJetConstituents>&, int);
     /// Retrieve the constituents of a collection of indexed jets in event
     rv::RVec<FCCAnalysesJetConstituents> get_constituents(const rv::RVec<FCCAnalysesJetConstituents>&,
                                                           const rv::RVec<int>&);
+
+
+    //sorting jets
+    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> jets_sorting_on_nconst(const rv::RVec<edm4hep::ReconstructedParticleData>&);
+    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> jets_sorting_on_energy(const rv::RVec<edm4hep::ReconstructedParticleData>&);
+
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Bz(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                    const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
 
     rv::RVec<FCCAnalysesJetConstituentsData> get_pt(const rv::RVec<FCCAnalysesJetConstituents>&);
     rv::RVec<FCCAnalysesJetConstituentsData> get_e(const rv::RVec<FCCAnalysesJetConstituents>&);
@@ -26,6 +45,280 @@ namespace FCCAnalyses {
     rv::RVec<FCCAnalysesJetConstituentsData> get_phi(const rv::RVec<FCCAnalysesJetConstituents>&);
     rv::RVec<FCCAnalysesJetConstituentsData> get_type(const rv::RVec<FCCAnalysesJetConstituents>&);
     rv::RVec<FCCAnalysesJetConstituentsData> get_charge(const rv::RVec<FCCAnalysesJetConstituents>&);
+    
+    //displacement
+    rv::RVec<FCCAnalysesJetConstituentsData> get_d0(const rv::RVec<FCCAnalysesJetConstituents>&,
+						    const ROOT::VecOps::RVec<edm4hep::TrackState>&);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_z0(const rv::RVec<FCCAnalysesJetConstituents>& ,
+                                                    const ROOT::VecOps::RVec<edm4hep::TrackState>&);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_phi0(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+						      const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_omega(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+						       const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_tanLambda(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							   const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+    /*    
+    rv::RVec< rv::RVec< rv::RVec<float> > > XPtoPar(const rv::RVec<FCCAnalysesJetConstituents>&,
+						    const ROOT::VecOps::RVec<edm4hep::TrackState>&,
+						    const TVector3&, 
+						    const float&);
+    */
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_dxy(const rv::RVec<FCCAnalysesJetConstituents>&,
+							 const ROOT::VecOps::RVec<edm4hep::TrackState>&,
+							 const TVector3&,
+							 const float&);
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_dz(const rv::RVec<FCCAnalysesJetConstituents>&,
+							const ROOT::VecOps::RVec<edm4hep::TrackState>&,
+							const TVector3&,
+							const float&);
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_phi(const rv::RVec<FCCAnalysesJetConstituents>&,
+                                                         const ROOT::VecOps::RVec<edm4hep::TrackState>&,
+                                                         const TVector3&,
+                                                         const float&);
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_C(const rv::RVec<FCCAnalysesJetConstituents>&,
+						       const ROOT::VecOps::RVec<edm4hep::TrackState>&,
+						       const TVector3&,
+						       const float&);
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_ct(const rv::RVec<FCCAnalysesJetConstituents>&,
+							const ROOT::VecOps::RVec<edm4hep::TrackState>&,
+							const TVector3&,
+							const float&);
+    //rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_dxy(const rv::RVec<rv::RVec<TVectorD> >& par);
+    //rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_dz(const rv::RVec<rv::RVec<TVectorD> >& par);
+    //rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_phi0(const rv::RVec<rv::RVec<TVectorD> >& par);
+    //rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_C(const rv::RVec<rv::RVec<TVectorD> >& par);
+    //rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_ct(const rv::RVec<rv::RVec<TVectorD> >& par);
+
+    //covariance matrix
+    //diagonal
+    rv::RVec<FCCAnalysesJetConstituentsData> get_omega_cov(const rv::RVec<FCCAnalysesJetConstituents>&,
+							   const ROOT::VecOps::RVec<edm4hep::TrackState>&);
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_d0_cov(const rv::RVec<FCCAnalysesJetConstituents>&,
+							const ROOT::VecOps::RVec<edm4hep::TrackState>& );
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_z0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_phi0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							  const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_tanlambda_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							       const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+    //off-diag
+    rv::RVec<FCCAnalysesJetConstituentsData> get_d0_z0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							  const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_phi0_d0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							    const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_phi0_z0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							    const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_tanlambda_phi0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								   const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_tanlambda_d0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								 const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_tanlambda_z0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								 const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_omega_tanlambda_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								    const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_omega_phi0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							       const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_omega_d0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							     const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_omega_z0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							     const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+ 
+    rv::RVec<FCCAnalysesJetConstituentsData> get_dndx(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                      const rv::RVec<edm4hep::Quantity>& dNdx,
+						      const rv::RVec<edm4hep::TrackData>& trackdata,
+						      const rv::RVec<FCCAnalysesJetConstituentsData> JetsConstituents_isChargedHad);
+
+    //-------------
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dVal(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+                                                          const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                          const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dVal_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+                                                                  const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                                  const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dVal_clusterV(const rv::RVec<fastjet::PseudoJet>& jets,
+                                                                   const rv::RVec<FCCAnalysesJetConstituentsData>& D0,
+                                                                   const rv::RVec<FCCAnalysesJetConstituentsData>& phi0,
+                                                                   const TVector3& V,
+                                                                   const float Bz);
+
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dSig(const rv::RVec<FCCAnalysesJetConstituentsData>& Sip2dVals,
+                                                          const rv::RVec<FCCAnalysesJetConstituentsData>& err2_D0);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip3dVal(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+                                                          const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                          const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip3dVal_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+                                                                  const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                                  const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip3dVal_clusterV(const rv::RVec<fastjet::PseudoJet>& jets,
+                                                                   const rv::RVec<FCCAnalysesJetConstituentsData>& D0,
+                                                                   const rv::RVec<FCCAnalysesJetConstituentsData>& Z0,
+                                                                   const rv::RVec<FCCAnalysesJetConstituentsData>& phi0,
+                                                                   const TVector3& V,
+                                                                   const float Bz);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip3dSig(const rv::RVec<FCCAnalysesJetConstituentsData>& Sip3dVals,
+                                                          const rv::RVec<FCCAnalysesJetConstituentsData>& err2_D0,
+                                                          const rv::RVec<FCCAnalysesJetConstituentsData>& err2_Z0);
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_JetDistVal(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+                                                            const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                            const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_JetDistVal_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+                                                                    const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                                    const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_JetDistVal_clusterV(const rv::RVec<fastjet::PseudoJet>& jets,
+                                                                     const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                                     const rv::RVec<FCCAnalysesJetConstituentsData>& D0,
+                                                                     const rv::RVec<FCCAnalysesJetConstituentsData>& Z0,
+                                                                     const rv::RVec<FCCAnalysesJetConstituentsData>& phi0,
+                                                                     const TVector3& V,
+                                                                     const float Bz);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_JetDistSig(const rv::RVec<FCCAnalysesJetConstituentsData>& JetDistVal,
+                                                            const rv::RVec<FCCAnalysesJetConstituentsData>& err2_D0,
+                                                            const rv::RVec<FCCAnalysesJetConstituentsData>& err2_Z0);
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_mtof(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                      const rv::RVec<float>& track_L,
+                                                      const rv::RVec<edm4hep::TrackData>& trackdata,
+                                                      const rv::RVec<edm4hep::TrackerHitData>& trackerhits,
+						      const rv::RVec<FCCAnalysesJetConstituentsData> JetsConstituents_isChargedHad);
+
+    //Identification
+    /*rv::RVec<FCCAnalysesJetConstituentsData> get_MC_PIDs(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                         const rv::RVec<edm4hep::MCParticleData> Particle);
+    */
+
+    /*FCCAnalysesJetConstituentsData get_PIDs(const ROOT::VecOps::RVec< int > recin,
+					    const ROOT::VecOps::RVec< int > mcin,
+					    //const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+					    const rv::RVec<edm4hep::ReconstructedParticleData>& jcs,
+					    const rv::RVec<edm4hep::MCParticleData> Particle);
+    */
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_PIDs(const ROOT::VecOps::RVec< int > recin,
+						      const ROOT::VecOps::RVec< int > mcin,                                                                                 
+						      const rv::RVec<edm4hep::ReconstructedParticleData>& RecPart,
+						      const rv::RVec<edm4hep::MCParticleData>& Particle,
+						      const rv::RVec<edm4hep::ReconstructedParticleData>& Jets);
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_PIDs_cluster(const ROOT::VecOps::RVec< int > recin,
+                                                              const ROOT::VecOps::RVec< int > mcin,
+                                                              //const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                              const rv::RVec<edm4hep::ReconstructedParticleData>& RecPart,
+                                                              const rv::RVec<edm4hep::MCParticleData>& Particle,
+                                                              const std::vector<std::vector<int>>& indices);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isMu(const rv::RVec<FCCAnalysesJetConstituentsData>&);
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isEl(const rv::RVec<FCCAnalysesJetConstituentsData>&);
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isChargedHad(const rv::RVec<FCCAnalysesJetConstituentsData>& PIDs,
+                                                               const rv::RVec<FCCAnalysesJetConstituents>& jcs);
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isGamma(const rv::RVec<FCCAnalysesJetConstituentsData>&);
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isNeutralHad(const rv::RVec<FCCAnalysesJetConstituentsData>& PIDs,
+                                                               const rv::RVec<FCCAnalysesJetConstituents>& jcs);
+
+    //countings
+    int count_jets(rv::RVec<FCCAnalysesJetConstituents> jets);
+    rv::RVec<int> count_consts(rv::RVec<FCCAnalysesJetConstituents> jets);
+    rv::RVec<int> count_type(const rv::RVec<FCCAnalysesJetConstituentsData>& isType);
+
+    /*
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isMu(const ROOT::VecOps::RVec< int > recin,
+                                                      const ROOT::VecOps::RVec< int > mcin,
+						      const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                      const rv::RVec<edm4hep::MCParticleData>& Particle);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isEl(const ROOT::VecOps::RVec< int > recin,
+                                                      const ROOT::VecOps::RVec< int > mcin,
+						      const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                      //const vector<edm4hep::ParticleIDData> PIDs,                                     
+                                                      const rv::RVec<edm4hep::MCParticleData>& Particle);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isChargedHad(const ROOT::VecOps::RVec< int > recin,
+							      const ROOT::VecOps::RVec< int > mcin,
+							      const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                              const rv::RVec<edm4hep::MCParticleData>& Particle);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isGamma(const ROOT::VecOps::RVec< int > recin,
+							 const ROOT::VecOps::RVec< int > mcin,
+							 const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                         const rv::RVec<edm4hep::MCParticleData>& Particle);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isNeutralHad(const ROOT::VecOps::RVec< int > recin,
+								 const ROOT::VecOps::RVec< int > mcin,
+								 const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                                 const rv::RVec<edm4hep::MCParticleData>& Particle);
+
+    //rv::RVec<FCCAnalysesJetConstituentsData> get_dptdpt(const rv::RVec<FCCAnalysesJetConstituents>&);
+    */
+
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_erel(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+						      const rv::RVec<FCCAnalysesJetConstituents>& jcs);
+    rv::RVec<FCCAnalysesJetConstituentsData> get_erel_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+                                                              const rv::RVec<FCCAnalysesJetConstituents>& jcs);
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_erel_log(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+                                                          const rv::RVec<FCCAnalysesJetConstituents>& jcs);
+    rv::RVec<FCCAnalysesJetConstituentsData> get_erel_log_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+								  const rv::RVec<FCCAnalysesJetConstituents>& jcs);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_thetarel(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+                                                          const rv::RVec<FCCAnalysesJetConstituents>& jcs);
+    rv::RVec<FCCAnalysesJetConstituentsData> get_thetarel_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+                                                              const rv::RVec<FCCAnalysesJetConstituents>& jcs);
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_phirel(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+                                                        const rv::RVec<FCCAnalysesJetConstituents>& jcs);
+    rv::RVec<FCCAnalysesJetConstituentsData> get_phirel_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+                                                              const rv::RVec<FCCAnalysesJetConstituents>& jcs);
+							
+    //residues
+    rv::RVec<TLorentzVector> compute_tlv_jets(const rv::RVec<fastjet::PseudoJet>& jets);
+    rv::RVec<TLorentzVector> sum_tlv_constituents(const rv::RVec<FCCAnalysesJetConstituents>& jets);
+    float InvariantMass(const TLorentzVector& tlv1, const TLorentzVector& tlv2);
+    rv::RVec<double> compute_residue_energy(const rv::RVec<TLorentzVector>& tlv_jet, 
+					    const rv::RVec<TLorentzVector>& sum_tlv_jcs);
+    rv::RVec<double> compute_residue_pt(const rv::RVec<TLorentzVector>& tlv_jet, 
+					const rv::RVec<TLorentzVector>& sum_tlv_jcs);
+    rv::RVec<double> compute_residue_phi(const rv::RVec<TLorentzVector>& tlv_jet, 
+					 const rv::RVec<TLorentzVector>& sum_tlv_jcs);
+    rv::RVec<double> compute_residue_theta(const rv::RVec<TLorentzVector>& tlv_jet, 
+					 const rv::RVec<TLorentzVector>& sum_tlv_jcs);
+    rv::RVec<double> compute_residue_px(const rv::RVec<TLorentzVector>& tlv_jet, const rv::RVec<TLorentzVector>& sum_tlv_jcs);
+    rv::RVec<double> compute_residue_py(const rv::RVec<TLorentzVector>& tlv_jet, const rv::RVec<TLorentzVector>& sum_tlv_jcs);
+    rv::RVec<double> compute_residue_pz(const rv::RVec<TLorentzVector>& tlv_jet, const rv::RVec<TLorentzVector>& sum_tlv_jcs); 
+
   }  // namespace JetConstituentsUtils
 }  // namespace FCCAnalyses
 

--- a/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
@@ -62,12 +62,6 @@ namespace FCCAnalyses {
     rv::RVec<FCCAnalysesJetConstituentsData> get_tanLambda(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
 							   const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
 
-    /*    
-    rv::RVec< rv::RVec< rv::RVec<float> > > XPtoPar(const rv::RVec<FCCAnalysesJetConstituents>&,
-						    const ROOT::VecOps::RVec<edm4hep::TrackState>&,
-						    const TVector3&, 
-						    const float&);
-    */
     
     rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_dxy(const rv::RVec<FCCAnalysesJetConstituents>&,
 							 const ROOT::VecOps::RVec<edm4hep::TrackState>&,
@@ -89,11 +83,6 @@ namespace FCCAnalyses {
 							const ROOT::VecOps::RVec<edm4hep::TrackState>&,
 							const TVector3&,
 							const float&);
-    //rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_dxy(const rv::RVec<rv::RVec<TVectorD> >& par);
-    //rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_dz(const rv::RVec<rv::RVec<TVectorD> >& par);
-    //rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_phi0(const rv::RVec<rv::RVec<TVectorD> >& par);
-    //rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_C(const rv::RVec<rv::RVec<TVectorD> >& par);
-    //rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_ct(const rv::RVec<rv::RVec<TVectorD> >& par);
 
     //covariance matrix
     //diagonal
@@ -148,7 +137,6 @@ namespace FCCAnalyses {
 						      const rv::RVec<edm4hep::TrackData>& trackdata,
 						      const rv::RVec<FCCAnalysesJetConstituentsData> JetsConstituents_isChargedHad);
 
-    //-------------
     rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dVal(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
                                                           const rv::RVec<FCCAnalysesJetConstituents>& jcs,
                                                           const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks);
@@ -214,17 +202,6 @@ namespace FCCAnalyses {
                                                       const rv::RVec<edm4hep::TrackerHitData>& trackerhits,
 						      const rv::RVec<FCCAnalysesJetConstituentsData> JetsConstituents_isChargedHad);
 
-    //Identification
-    /*rv::RVec<FCCAnalysesJetConstituentsData> get_MC_PIDs(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
-                                                         const rv::RVec<edm4hep::MCParticleData> Particle);
-    */
-
-    /*FCCAnalysesJetConstituentsData get_PIDs(const ROOT::VecOps::RVec< int > recin,
-					    const ROOT::VecOps::RVec< int > mcin,
-					    //const rv::RVec<FCCAnalysesJetConstituents>& jcs,
-					    const rv::RVec<edm4hep::ReconstructedParticleData>& jcs,
-					    const rv::RVec<edm4hep::MCParticleData> Particle);
-    */
 
     rv::RVec<FCCAnalysesJetConstituentsData> get_PIDs(const ROOT::VecOps::RVec< int > recin,
 						      const ROOT::VecOps::RVec< int > mcin,                                                                                 
@@ -234,7 +211,6 @@ namespace FCCAnalyses {
     
     rv::RVec<FCCAnalysesJetConstituentsData> get_PIDs_cluster(const ROOT::VecOps::RVec< int > recin,
                                                               const ROOT::VecOps::RVec< int > mcin,
-                                                              //const rv::RVec<FCCAnalysesJetConstituents>& jcs,
                                                               const rv::RVec<edm4hep::ReconstructedParticleData>& RecPart,
                                                               const rv::RVec<edm4hep::MCParticleData>& Particle,
                                                               const std::vector<std::vector<int>>& indices);
@@ -252,35 +228,6 @@ namespace FCCAnalyses {
     rv::RVec<int> count_consts(rv::RVec<FCCAnalysesJetConstituents> jets);
     rv::RVec<int> count_type(const rv::RVec<FCCAnalysesJetConstituentsData>& isType);
 
-    /*
-    rv::RVec<FCCAnalysesJetConstituentsData> get_isMu(const ROOT::VecOps::RVec< int > recin,
-                                                      const ROOT::VecOps::RVec< int > mcin,
-						      const rv::RVec<FCCAnalysesJetConstituents>& jcs,
-                                                      const rv::RVec<edm4hep::MCParticleData>& Particle);
-
-    rv::RVec<FCCAnalysesJetConstituentsData> get_isEl(const ROOT::VecOps::RVec< int > recin,
-                                                      const ROOT::VecOps::RVec< int > mcin,
-						      const rv::RVec<FCCAnalysesJetConstituents>& jcs,
-                                                      //const vector<edm4hep::ParticleIDData> PIDs,                                     
-                                                      const rv::RVec<edm4hep::MCParticleData>& Particle);
-
-    rv::RVec<FCCAnalysesJetConstituentsData> get_isChargedHad(const ROOT::VecOps::RVec< int > recin,
-							      const ROOT::VecOps::RVec< int > mcin,
-							      const rv::RVec<FCCAnalysesJetConstituents>& jcs,
-                                                              const rv::RVec<edm4hep::MCParticleData>& Particle);
-
-    rv::RVec<FCCAnalysesJetConstituentsData> get_isGamma(const ROOT::VecOps::RVec< int > recin,
-							 const ROOT::VecOps::RVec< int > mcin,
-							 const rv::RVec<FCCAnalysesJetConstituents>& jcs,
-                                                         const rv::RVec<edm4hep::MCParticleData>& Particle);
-
-    rv::RVec<FCCAnalysesJetConstituentsData> get_isNeutralHad(const ROOT::VecOps::RVec< int > recin,
-								 const ROOT::VecOps::RVec< int > mcin,
-								 const rv::RVec<FCCAnalysesJetConstituents>& jcs,
-                                                                 const rv::RVec<edm4hep::MCParticleData>& Particle);
-
-    //rv::RVec<FCCAnalysesJetConstituentsData> get_dptdpt(const rv::RVec<FCCAnalysesJetConstituents>&);
-    */
 
     
     rv::RVec<FCCAnalysesJetConstituentsData> get_erel(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,

--- a/analyzers/dataframe/FCCAnalyses/ReconstructedParticle2Track.h
+++ b/analyzers/dataframe/FCCAnalyses/ReconstructedParticle2Track.h
@@ -8,10 +8,59 @@
 #include "ROOT/RVec.hxx"
 #include "edm4hep/ReconstructedParticleData.h"
 #include "edm4hep/TrackState.h"
+#include <TVectorD.h>
+#include <TVector3.h>
+#include <TMath.h>
+#include <iostream>
 
 namespace FCCAnalyses{
 
 namespace ReconstructedParticle2Track{
+
+  //compute the magnetic field Bz
+  ROOT::VecOps::RVec<float> getRP2TRK_Bz(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& rps, 
+					 const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks); //here computed for all particles passed
+
+  float Bz(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& rps, 
+	   const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks); //here only computed for the first charged particle encountered
+
+  /*
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > XPtoPar(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
+							 const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+							 const TVector3& x, 
+							 const float& Bz);
+  */
+  
+  ROOT::VecOps::RVec<float> XPtoPar_dxy(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in, 
+					const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+					const TVector3& x,
+					const float& Bz); 
+
+  ROOT::VecOps::RVec<float> XPtoPar_dz(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
+                                        const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+                                        const TVector3& V,
+                                        const float& Bz);
+
+  ROOT::VecOps::RVec<float> XPtoPar_phi(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
+					const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+                                        const TVector3& V,
+                                        const float& Bz);
+
+  ROOT::VecOps::RVec<float> XPtoPar_C(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
+					const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+                                        const TVector3& V,
+                                        const float& Bz);
+
+  ROOT::VecOps::RVec<float> XPtoPar_ct(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
+					const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+                                        const TVector3& V,
+                                        const float& Bz);
+
+  //ROOT::VecOps::RVec<float> XPtoPar_dxy(const ROOT::VecOps::RVec<TVectorD>& in);
+  //ROOT::VecOps::RVec<float> XPtoPar_dz(const ROOT::VecOps::RVec<TVectorD>& in);
+  //ROOT::VecOps::RVec<float> XPtoPar_phi0(const ROOT::VecOps::RVec<TVectorD>& in);
+  //ROOT::VecOps::RVec<float> XPtoPar_C(const ROOT::VecOps::RVec<TVectorD>& in);
+  //ROOT::VecOps::RVec<float> XPtoPar_ct(const ROOT::VecOps::RVec<TVectorD>& in);
 
   /// Return the D0 of a track to a reconstructed particle
   ROOT::VecOps::RVec<float> getRP2TRK_D0 (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,

--- a/analyzers/dataframe/FCCAnalyses/ReconstructedParticle2Track.h
+++ b/analyzers/dataframe/FCCAnalyses/ReconstructedParticle2Track.h
@@ -24,12 +24,6 @@ namespace ReconstructedParticle2Track{
   float Bz(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& rps, 
 	   const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks); //here only computed for the first charged particle encountered
 
-  /*
-  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > XPtoPar(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
-							 const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
-							 const TVector3& x, 
-							 const float& Bz);
-  */
   
   ROOT::VecOps::RVec<float> XPtoPar_dxy(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in, 
 					const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
@@ -55,12 +49,6 @@ namespace ReconstructedParticle2Track{
 					const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
                                         const TVector3& V,
                                         const float& Bz);
-
-  //ROOT::VecOps::RVec<float> XPtoPar_dxy(const ROOT::VecOps::RVec<TVectorD>& in);
-  //ROOT::VecOps::RVec<float> XPtoPar_dz(const ROOT::VecOps::RVec<TVectorD>& in);
-  //ROOT::VecOps::RVec<float> XPtoPar_phi0(const ROOT::VecOps::RVec<TVectorD>& in);
-  //ROOT::VecOps::RVec<float> XPtoPar_C(const ROOT::VecOps::RVec<TVectorD>& in);
-  //ROOT::VecOps::RVec<float> XPtoPar_ct(const ROOT::VecOps::RVec<TVectorD>& in);
 
   /// Return the D0 of a track to a reconstructed particle
   ROOT::VecOps::RVec<float> getRP2TRK_D0 (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,

--- a/analyzers/dataframe/src/JetConstituentsUtils.cc
+++ b/analyzers/dataframe/src/JetConstituentsUtils.cc
@@ -85,7 +85,6 @@ namespace FCCAnalyses {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
       for (const auto& jc : jcs) {
         out.emplace_back(meth(jc, coll));
-        //out.emplace_back(meth(jc));
       }
       return out;
     };
@@ -93,7 +92,6 @@ namespace FCCAnalyses {
     auto cast_constituent_4 = [](const auto& jcs, const auto& coll1, const auto& coll2, const auto& coll3,auto&& meth) {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
       for (const auto& jc : jcs) {
-        //std::cout<<"new jet:  " <<jc.size()<<std::endl;
         out.emplace_back(meth(jc, coll1, coll2, coll3));
       }
       return out;

--- a/analyzers/dataframe/src/JetConstituentsUtils.cc
+++ b/analyzers/dataframe/src/JetConstituentsUtils.cc
@@ -1,5 +1,27 @@
 #include "FCCAnalyses/JetConstituentsUtils.h"
 #include "FCCAnalyses/ReconstructedParticle.h"
+#include "FCCAnalyses/ReconstructedParticle2Track.h"
+#include "FCCAnalyses/ReconstructedParticle2MC.h"
+#include "edm4hep/MCParticleData.h"
+#include "edm4hep/Track.h"
+#include "edm4hep/TrackerHitData.h"
+#include "edm4hep/TrackData.h"
+#include "edm4hep/ReconstructedParticleData.h"
+
+
+
+#include "FCCAnalyses/JetClusteringUtils.h"
+//#include "FCCAnalyses/ExternalRecombiner.h"
+#include "fastjet/JetDefinition.hh"
+#include "fastjet/PseudoJet.hh"
+#include "fastjet/Selector.hh"
+
+/* *************************
+//COMMENTS
+1. Neutral particles (Clusters??)
+2. units of measurement?
+
+************************ */
 
 namespace FCCAnalyses {
   namespace JetConstituentsUtils {
@@ -8,11 +30,31 @@ namespace FCCAnalyses {
       rv::RVec<FCCAnalysesJetConstituents> jcs;
       for (const auto& jet : jets) {
         auto& jc = jcs.emplace_back();
-        for (auto it = jet.particles_begin; it < jet.particles_end; ++it)
+	float energy_jet = jet.energy;
+	float energy_const = 0;
+        for (auto it = jet.particles_begin; it < jet.particles_end; ++it) {
           jc.emplace_back(rps.at(it));
+	  energy_const += rps.at(it).energy;
+	}
+	std::cout << "-> jet_e: " << energy_jet << "  ;  const_e : " << energy_const << std::endl;
       }
       return jcs;
     }
+
+    rv::RVec<FCCAnalysesJetConstituents> build_constituents_cluster(const rv::RVec<edm4hep::ReconstructedParticleData>& rps,
+								    const std::vector<std::vector<int>>& indices) {
+      //std::cout << "... Building jets-constituents after clustering " << std::endl;
+      rv::RVec<FCCAnalysesJetConstituents> jcs;
+      for (const auto& jet_index : indices) {
+	FCCAnalysesJetConstituents jc;
+	for(const auto& const_index : jet_index) {
+	  jc.push_back(rps.at(const_index));
+	}
+	jcs.push_back(jc);
+      }
+      return jcs;
+    }
+
 
     FCCAnalysesJetConstituents get_jet_constituents(const rv::RVec<FCCAnalysesJetConstituents>& csts, int jet) {
       if (jet < 0)
@@ -39,14 +81,45 @@ namespace FCCAnalyses {
       return out;
     };
 
+
+    //Questa funzione semplicemente applica le funzioni a 2 args per vett di rec part a un vettore di vett di rec part
+    auto cast_constituent_2 = [](const auto& jcs, const auto& coll, auto&& meth) {
+      //auto cast_constituent_2 = [](const auto& jcs, auto&& meth) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for (const auto& jc : jcs) {
+        //std::cout<<"new jet:  " <<jc.size()<<std::endl;
+        out.emplace_back(meth(jc, coll));
+        //out.emplace_back(meth(jc));
+      }
+      return out;
+    };
+
+    auto cast_constituent_4 = [](const auto& jcs, const auto& coll1, const auto& coll2, const auto& coll3,auto&& meth) {
+      //auto cast_constituent_2 = [](const auto& jcs, auto&& meth) { 
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for (const auto& jc : jcs) {
+        //std::cout<<"new jet:  " <<jc.size()<<std::endl;
+        out.emplace_back(meth(jc, coll1, coll2, coll3));
+        //out.emplace_back(meth(jc));         
+      }
+      return out;
+    };
+    
+ 
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Bz(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                    const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Bz);
+    }
+    
+    
     rv::RVec<FCCAnalysesJetConstituentsData> get_pt(const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
       return cast_constituent(jcs, ReconstructedParticle::get_pt);
     }
-
+    
     rv::RVec<FCCAnalysesJetConstituentsData> get_e(const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
       return cast_constituent(jcs, ReconstructedParticle::get_e);
     }
-
+    
     rv::RVec<FCCAnalysesJetConstituentsData> get_theta(const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
       return cast_constituent(jcs, ReconstructedParticle::get_theta);
     }
@@ -62,5 +135,1071 @@ namespace FCCAnalyses {
     rv::RVec<FCCAnalysesJetConstituentsData> get_charge(const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
       return cast_constituent(jcs, ReconstructedParticle::get_charge);
     }
+
+
+    //sorting
+    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> jets_sorting_on_nconst(const rv::RVec<edm4hep::ReconstructedParticleData>& jets){
+      ROOT::VecOps::RVec<int> nconst;
+      ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> out;
+      for (const auto& jet : jets) {
+	nconst.push_back(jet.particles_end - jet.particles_begin);
+      }
+      auto indices = ROOT::VecOps::Argsort(nconst);
+      for (int index = 0; index < jets.size(); ++index) {
+	out.push_back( jets.at( indices.at(indices.size()-1-index) ) );
+      }
+      return out;
+    }
+
+    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> jets_sorting_on_energy(const rv::RVec<edm4hep::ReconstructedParticleData>& jets){
+      ROOT::VecOps::RVec<float> energy;
+      ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> out;
+      for (const auto& jet : jets) {
+        energy.push_back(jet.energy);
+      }
+      auto indices = ROOT::VecOps::Argsort(energy);
+      for (int index = 0; index < jets.size(); ++index) {
+        out.push_back( jets.at( indices.at(indices.size()-1-index) ) );
+      }
+      return out;
+    }
+
+    //displacement (wrt (0,0,0))
+    rv::RVec<FCCAnalysesJetConstituentsData> get_d0(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+						    const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
+    }
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_z0(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+						    const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Z0);
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_phi0(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                    const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_omega(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                    const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_omega);
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_tanLambda(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							   const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_tanLambda);
+    }
+
+    //displacement (wrt Vertex)
+
+    /*
+    rv::RVec< rv::RVec< rv::RVec<float>  > > XPtoPar(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+						     const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+						     const TVector3& V,
+						     const float& Bz) {
+      rv::RVec<rv::RVec<rv::RVec<float> > > out;
+      for(const auto & jc : jcs) {
+	out.emplace_back(ReconstructedParticle2Track::XPtoPar(jc, tracks, V, Bz));
+      }
+      return out;
+      //return cast_constituent_4(jcs, tracks, V, Bz, ReconstructedParticle2Track::XPtoPar);
+    }
+    */
+ 
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_dxy(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							 const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+							 const TVector3& V,
+							 const float& Bz) {
+      
+      return cast_constituent_4(jcs, tracks, V, Bz, ReconstructedParticle2Track::XPtoPar_dxy); 
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_dz(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+							const TVector3& V,
+							const float& Bz) {
+
+      return cast_constituent_4(jcs, tracks, V, Bz, ReconstructedParticle2Track::XPtoPar_dz);
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_phi(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							 const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+							 const TVector3& V,
+							 const float& Bz) {
+
+      return cast_constituent_4(jcs, tracks, V, Bz, ReconstructedParticle2Track::XPtoPar_phi);
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_C(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+						       const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+						       const TVector3& V,
+						       const float& Bz) {
+      
+      return cast_constituent_4(jcs, tracks, V, Bz, ReconstructedParticle2Track::XPtoPar_C);
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_ct(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+							const TVector3& V,
+							const float& Bz) {
+      
+      return cast_constituent_4(jcs, tracks, V, Bz, ReconstructedParticle2Track::XPtoPar_ct);
+    }
+
+    /*      
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_dxy(const rv::RVec< rv::RVec<TVectorD> >& par) {
+      return cast_constituent(par, ReconstructedParticle2Track::XPtoPar_dxy);
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_dz(const rv::RVec<rv::RVec<TVectorD> >& par) {
+      return cast_constituent(par, ReconstructedParticle2Track::XPtoPar_dz);
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_phi0(const rv::RVec< rv::RVec<TVectorD> >& par) {
+      return cast_constituent(par, ReconstructedParticle2Track::XPtoPar_phi0);
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_C(const rv::RVec<rv::RVec<TVectorD> >& par) {
+      return cast_constituent(par, ReconstructedParticle2Track::XPtoPar_C);
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_ct(const rv::RVec< rv::RVec<TVectorD> >& par) {
+      return cast_constituent(par, ReconstructedParticle2Track::XPtoPar_ct);
+    }
+    */
+   
+    //Covariance matrix elements of tracks parameters
+    //diagonal
+    rv::RVec<FCCAnalysesJetConstituentsData> get_omega_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							   const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_omega_cov);
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_d0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                        const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0_cov);
+    }
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_z0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Z0_cov);
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_phi0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							  const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi_cov);
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_tanlambda_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							       const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_tanLambda_cov);
+    }
+    //off-diagonal
+    rv::RVec<FCCAnalysesJetConstituentsData> get_d0_z0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							   const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_d0_z0_cov);
+    }
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_phi0_d0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							     const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_d0_phi0_cov);
+    }
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_phi0_z0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							     const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi0_z0_cov);
+    }
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_tanlambda_phi0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								    const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi0_tanlambda_cov);
+    }
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_tanlambda_d0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								  const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_d0_tanlambda_cov);
+    }
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_tanlambda_z0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								  const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_z0_tanlambda_cov);
+    }
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_omega_tanlambda_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								     const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_omega_tanlambda_cov);
+    }
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_omega_phi0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi0_omega_cov);
+    }
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_omega_d0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							      const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_d0_omega_cov);
+    }
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_omega_z0_cov(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							      const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_omega_z0_cov);
+    }
+    
+
+    //neutrals are set to 0; muons and electrons are also set to 0; 
+    // only charged hads are considered (mtof used to disctriminate charged kaons and pions)
+    rv::RVec<FCCAnalysesJetConstituentsData> get_dndx(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+						      const rv::RVec<edm4hep::Quantity>& dNdx, //ETrackFlow_2 
+						      const rv::RVec<edm4hep::TrackData>& trackdata,  //Eflowtrack
+						      const rv::RVec<FCCAnalysesJetConstituentsData> JetsConstituents_isChargedHad) { 
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for(int i = 0; i < jcs.size(); ++i){
+	FCCAnalysesJetConstituents ct = jcs.at(i);
+	FCCAnalysesJetConstituentsData isChargedHad = JetsConstituents_isChargedHad.at(i);
+	FCCAnalysesJetConstituentsData tmp;
+	for(int j = 0; j < ct.size(); ++j) {
+	  if (ct.at(j).tracks_begin < trackdata.size() && (int)isChargedHad.at(j) == 1) {
+	    tmp.push_back( dNdx.at( trackdata.at(ct.at(j).tracks_begin).dxQuantities_begin).value ); 
+	  } else {
+	    tmp.push_back(0.);
+	  }
+	}
+	out.push_back(tmp);
+      }
+      return out;
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dVal(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+							  const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							  const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
+      rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
+      
+      //for (size_t i = 0; i < jets.size(); ++i){
+      //	TVector2 jetP3();
+      //}
+
+      //for (auto & j: jets) {
+      //	TVector2 p(j.momentum.x, j.momentum.y);
+      //FCCAnalysesJetConstituentsData projs;
+      //for(size_t i = 0; i < )
+      //result.push_back(tlv.Eta());
+      //}
+      
+      for(int i = 0; i < jets.size(); ++i){
+	TVector2 p(jets[i].momentum.x, jets[i].momentum.y);
+	FCCAnalysesJetConstituentsData cprojs;
+	for (int j = 0; j < jcs[i].size(); ++j) {
+	  if (D0.at(i).at(j) != -9) {
+	    TVector2 d0( - D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)) , D0.at(i).at(j) * TMath::Cos(phi0.at(i).at(j))  );
+	    cprojs.push_back( TMath::Sign(1, d0*p) * fabs(D0.at(i).at(j))  );
+	  } else {
+	    cprojs.push_back(-9.);
+	  }
+	}
+	out.push_back(cprojs);
+      }
+      return out;
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dVal_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+								  const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								  const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
+      rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
+
+      for(int i = 0; i < jets.size(); ++i){
+        TVector2 p(jets[i].px(), jets[i].py());
+        FCCAnalysesJetConstituentsData cprojs;
+        for (int j = 0; j < jcs[i].size(); ++j) {
+          if (D0.at(i).at(j) != -9) {
+            TVector2 d0( - D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)) , D0.at(i).at(j) * TMath::Cos(phi0.at(i).at(j))  );
+            cprojs.push_back( TMath::Sign(1, d0*p) * fabs(D0.at(i).at(j))  );
+          } else {
+            cprojs.push_back(-9.);
+          }
+        }
+        out.push_back(cprojs);
+      }
+      return out;
+    }
+
+    /*
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dVal_clusterV(const rv::RVec<fastjet::PseudoJet>& jets,
+								   const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								   const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+								   const TVector3& V) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+
+      float Bz = ReconstructedParticle2Track::Bz(jcs, tracks);
+      rv::RVec<FCCAnalysesJetConstituentsData> D0 = XPtoPar_dxy(jcs, tracks, V, Bz);
+      rv::RVec<FCCAnalysesJetConstituentsData> phi0 = XPtoPar_phi(jcs, tracks, V, Bz);
+      
+      for(int i = 0; i < jets.size(); ++i){
+        TVector2 p(jets[i].px(), jets[i].py());
+        FCCAnalysesJetConstituentsData cprojs;
+        for (int j = 0; j < jcs[i].size(); ++j) {
+          if (D0.at(i).at(j) != -9) {
+            TVector2 d0( - D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)) , D0.at(i).at(j) * TMath::Cos(phi0.at(i).at(j))  );
+            cprojs.push_back( TMath::Sign(1, d0*p) * fabs(D0.at(i).at(j))  );
+          } else {
+            cprojs.push_back(-9.);
+          }
+        }
+        out.push_back(cprojs);
+      }
+      return out;
+    }
+    */
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dVal_clusterV(const rv::RVec<fastjet::PseudoJet>& jets,
+								   const rv::RVec<FCCAnalysesJetConstituentsData>& D0,
+								   const rv::RVec<FCCAnalysesJetConstituentsData>& phi0,
+                                                                   const TVector3& V,
+								   const float Bz) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+
+      for(int i = 0; i < jets.size(); ++i){
+        TVector2 p(jets[i].px(), jets[i].py());
+        FCCAnalysesJetConstituentsData cprojs;
+        for (int j = 0; j < D0[i].size(); ++j) {
+          if (D0.at(i).at(j) != -9) {
+            TVector2 d0( - D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)) , D0.at(i).at(j) * TMath::Cos(phi0.at(i).at(j))  );
+            cprojs.push_back( TMath::Sign(1, d0*p) * fabs(D0.at(i).at(j))  );
+          } else {
+            cprojs.push_back(-9.);
+          }
+        }
+        out.push_back(cprojs);
+      }
+      return out;
+    }
+
+
+    //The functions get_Sip2dSig and get_Sip2dVal can be made independent;
+    //I passed to the former the result of the latter
+    //avoidind the recomputing
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dSig(const rv::RVec<FCCAnalysesJetConstituentsData>& Sip2dVals,
+							  const rv::RVec<FCCAnalysesJetConstituentsData>& err2_D0) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for(int i = 0; i < Sip2dVals.size(); ++i) {
+	FCCAnalysesJetConstituentsData s;
+	for(int j = 0; j < Sip2dVals.at(i).size(); ++j) {
+	  if(err2_D0.at(i).at(j) > 0) {
+	    s.push_back( Sip2dVals.at(i).at(j)/std::sqrt(err2_D0.at(i).at(j)) );
+	  } else {
+	    s.push_back(-9);
+	  }
+	}
+	out.push_back(s);
+      }
+      return out;
+    }
+
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip3dVal(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+                                                          const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+                                                          const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
+      rv::RVec<FCCAnalysesJetConstituentsData> Z0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Z0);
+      rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
+        
+      for(int i = 0; i < jets.size(); ++i){
+	TVector3 p(jets[i].momentum.x, jets[i].momentum.y, jets[i].momentum.z);
+	FCCAnalysesJetConstituentsData cprojs;
+        for (int j = 0; j < jcs[i].size(); ++j){
+	  if(D0.at(i).at(j) != -9) {
+	    TVector3 d( - D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)) , D0.at(i).at(j)*TMath::Cos(phi0.at(i).at(j)), Z0.at(i).at(j) );
+	    cprojs.push_back( TMath::Sign(1, d*p) * fabs( sqrt( D0.at(i).at(j)*D0.at(i).at(j) + Z0.at(i).at(j)*Z0.at(i).at(j) ) ) );
+	  } else {
+	    cprojs.push_back(-9);
+	  }
+	}
+	out.push_back(cprojs);
+      } 
+      return out;
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip3dVal_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+								  const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								  const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
+      rv::RVec<FCCAnalysesJetConstituentsData> Z0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Z0);
+      rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
+
+      for(int i = 0; i < jets.size(); ++i){
+        TVector3 p(jets[i].px(), jets[i].py(), jets[i].pz());
+        FCCAnalysesJetConstituentsData cprojs;
+        for (int j = 0; j < jcs[i].size(); ++j){
+          if(D0.at(i).at(j) != -9) {
+            TVector3 d( - D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)) , D0.at(i).at(j)*TMath::Cos(phi0.at(i).at(j)), Z0.at(i).at(j) );
+            cprojs.push_back( TMath::Sign(1, d*p) * fabs( sqrt( D0.at(i).at(j)*D0.at(i).at(j) + Z0.at(i).at(j)*Z0.at(i).at(j) ) ) );
+          } else {
+            cprojs.push_back(-9);
+          }
+        }
+        out.push_back(cprojs);
+      }
+      return out;
+    }
+
+    /*
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip3dVal_clusterV(const rv::RVec<fastjet::PseudoJet>& jets,
+								   const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								   const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+								   const TVector3& V) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      rv::RVec<FCCAnalysesJetConstituentsData> D0 = XPtoPar_dxy(jcs, tracks, V, Bz);
+      rv::RVec<FCCAnalysesJetConstituentsData> Z0 = XPtoPar_dz(jcs, tracks, V, Bz);
+      rv::RVec<FCCAnalysesJetConstituentsData> phi0 = XPtoPar_phi(jcs, tracks, V, Bz);
+
+      for(int i = 0; i < jets.size(); ++i){
+        TVector3 p(jets[i].px(), jets[i].py(), jets[i].pz());
+        FCCAnalysesJetConstituentsData cprojs;
+        for (int j = 0; j < jcs[i].size(); ++j){
+          if(D0.at(i).at(j) != -9) {
+            TVector3 d( - D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)) , D0.at(i).at(j)*TMath::Cos(phi0.at(i).at(j)), Z0.at(i).at(j) );
+            cprojs.push_back( TMath::Sign(1, d*p) * fabs( sqrt( D0.at(i).at(j)*D0.at(i).at(j) + Z0.at(i).at(j)*Z0.at(i).at(j) ) ) );
+          } else {
+            cprojs.push_back(-9);
+          }
+        }
+        out.push_back(cprojs);
+      }
+      return out;
+    }
+    */
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip3dVal_clusterV(const rv::RVec<fastjet::PseudoJet>& jets,
+                                                                   const rv::RVec<FCCAnalysesJetConstituentsData>& D0,
+								   const rv::RVec<FCCAnalysesJetConstituentsData>& Z0,
+                                                                   const rv::RVec<FCCAnalysesJetConstituentsData>& phi0,
+                                                                   const TVector3& V,
+                                                                   const float Bz) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+
+      for(int i = 0; i < jets.size(); ++i){
+        TVector3 p(jets[i].px(), jets[i].py(), jets[i].pz());
+        FCCAnalysesJetConstituentsData cprojs;
+        for (int j = 0; j < D0[i].size(); ++j){
+          if(D0.at(i).at(j) != -9) {
+            TVector3 d( - D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)) , D0.at(i).at(j)*TMath::Cos(phi0.at(i).at(j)), Z0.at(i).at(j) );
+            cprojs.push_back( TMath::Sign(1, d*p) * fabs( sqrt( D0.at(i).at(j)*D0.at(i).at(j) + Z0.at(i).at(j)*Z0.at(i).at(j) ) ) );
+          } else {
+            cprojs.push_back(-9);
+          }
+        }
+        out.push_back(cprojs);
+      }
+      return out;
+    }
+
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip3dSig(const rv::RVec<FCCAnalysesJetConstituentsData>& Sip3dVals,
+							  const rv::RVec<FCCAnalysesJetConstituentsData>& err2_D0,
+							  const rv::RVec<FCCAnalysesJetConstituentsData>& err2_Z0) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for(int i = 0; i < Sip3dVals.size(); ++i) {
+	FCCAnalysesJetConstituentsData s;
+	for(int j = 0; j < Sip3dVals.at(i).size(); ++j) {
+	  if (err2_D0.at(i).at(j) > 0.) {
+	    s.push_back( Sip3dVals.at(i).at(j)/sqrt( err2_D0.at(i).at(j) + err2_Z0.at(i).at(j) ) );
+	  } else {
+	    s.push_back(-9);
+	  }
+	}
+	out.push_back(s);
+      }
+      return out;
+    }
+
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_JetDistVal(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+							    const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							    const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
+      rv::RVec<FCCAnalysesJetConstituentsData> Z0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Z0);
+      rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
+      for(int i = 0; i < jets.size(); ++i){
+	FCCAnalysesJetConstituentsData tmp;
+	TVector3 p_jet(jets[i].momentum.x, jets[i].momentum.y, jets[i].momentum.z);
+	FCCAnalysesJetConstituents ct = jcs.at(i);
+	for(int j = 0; j < ct.size(); ++j) {
+	  if (D0.at(i).at(j) != -9) { 
+	    TVector3 d( - D0.at(i).at(j)* TMath::Sin(phi0.at(i).at(j)) , D0.at(i).at(j)*TMath::Cos(phi0.at(i).at(j)), Z0.at(i).at(j) );
+	    TVector3 p_ct(ct[j].momentum.x, ct[j].momentum.y, ct[j].momentum.z);
+	    TVector3 r_jet(0.0, 0.0, 0.0);
+	    TVector3 n = p_ct.Cross(p_jet).Unit(); //What if they are parallel?
+	    tmp.push_back( n.Dot(d - r_jet) );
+	  } else {
+	    tmp.push_back(-9);
+	  }
+	}
+	out.push_back(tmp);
+      }
+      return out;
+    }
+
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_JetDistVal_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+								    const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								    const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
+      rv::RVec<FCCAnalysesJetConstituentsData> Z0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Z0);
+      rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
+      for(int i = 0; i < jets.size(); ++i){
+        FCCAnalysesJetConstituentsData tmp;
+        TVector3 p_jet(jets[i].px(), jets[i].py(), jets[i].pz());
+        FCCAnalysesJetConstituents ct = jcs.at(i);
+        for(int j = 0; j < ct.size(); ++j) {
+          if (D0.at(i).at(j) != -9) {
+            TVector3 d( - D0.at(i).at(j)* TMath::Sin(phi0.at(i).at(j)) , D0.at(i).at(j)*TMath::Cos(phi0.at(i).at(j)), Z0.at(i).at(j) );
+            TVector3 p_ct(ct[j].momentum.x, ct[j].momentum.y, ct[j].momentum.z);
+            TVector3 r_jet(0.0, 0.0, 0.0);
+            TVector3 n = p_ct.Cross(p_jet).Unit(); //What if they are parallel? 
+            tmp.push_back( n.Dot(d - r_jet) );
+          } else {
+            tmp.push_back(-9);
+          }
+        }
+        out.push_back(tmp);
+      }
+      return out;
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_JetDistVal_clusterV(const rv::RVec<fastjet::PseudoJet>& jets,
+								     const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+								     const rv::RVec<FCCAnalysesJetConstituentsData>& D0,
+								     const rv::RVec<FCCAnalysesJetConstituentsData>& Z0,
+								     const rv::RVec<FCCAnalysesJetConstituentsData>& phi0,
+								     const TVector3& V,
+								     const float Bz) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+
+      for(int i = 0; i < jets.size(); ++i){
+        FCCAnalysesJetConstituentsData tmp;
+        TVector3 p_jet(jets[i].px(), jets[i].py(), jets[i].pz());
+        FCCAnalysesJetConstituents ct = jcs.at(i);
+        for(int j = 0; j < ct.size(); ++j) {
+          if (D0.at(i).at(j) != -9) {
+            TVector3 d( - D0.at(i).at(j)* TMath::Sin(phi0.at(i).at(j)) , D0.at(i).at(j)*TMath::Cos(phi0.at(i).at(j)), Z0.at(i).at(j) );
+            TVector3 p_ct(ct[j].momentum.x, ct[j].momentum.y, ct[j].momentum.z);
+            TVector3 r_jet(0.0, 0.0, 0.0);
+            TVector3 n = p_ct.Cross(p_jet).Unit(); //What if they are parallel?                                                                                                                             
+            tmp.push_back( n.Dot(d - r_jet) );
+          } else {
+            tmp.push_back(-9);
+          }
+        }
+        out.push_back(tmp);
+      }
+      return out;
+    }
+
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_JetDistSig(const rv::RVec<FCCAnalysesJetConstituentsData>& JetDistVal, 
+							    const rv::RVec<FCCAnalysesJetConstituentsData>& err2_D0,
+							    const rv::RVec<FCCAnalysesJetConstituentsData>& err2_Z0) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for(int i = 0; i < JetDistVal.size(); ++i) {
+	FCCAnalysesJetConstituentsData tmp;
+	for(int j = 0; j < JetDistVal.at(i).size(); ++j) {
+	  if (err2_D0.at(i).at(j) > 0) {
+	    float err3d = std::sqrt(err2_D0.at(i).at(j) + err2_Z0.at(i).at(j));
+	    float jetdistsig = JetDistVal.at(i).at(j) / err3d;
+	    tmp.push_back(jetdistsig);
+	  } else {
+	    tmp.push_back(-9.);
+	  }
+	}
+	out.push_back(tmp);
+      }
+      return out;
+    }
+
+
+    //we measure L, tof; mtof in GeV
+    //neutrals are set to 0; muons and electrons are set to their mass;
+    // only charged hads are considered (mtof used to disctriminate charged kaons and pions)
+    rv::RVec<FCCAnalysesJetConstituentsData> get_mtof(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+						      const rv::RVec<float>& track_L,
+						      const rv::RVec<edm4hep::TrackData>& trackdata,
+						      const rv::RVec<edm4hep::TrackerHitData>& trackerhits, 
+						      const rv::RVec<FCCAnalysesJetConstituentsData> JetsConstituents_Pids) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for(int i = 0; i < jcs.size(); ++i){
+	FCCAnalysesJetConstituents ct = jcs.at(i);
+	FCCAnalysesJetConstituentsData pids = JetsConstituents_Pids.at(i);
+	FCCAnalysesJetConstituentsData tmp;
+	for(int j = 0; j < ct.size(); ++j) {
+	  //if(ct.at(j).tracks_begin > 0 && ct.at(j).tracks_begin < trackdata.size()) { //??????????? CHECK!!!
+	  if (ct.at(j).tracks_begin < trackdata.size()) {
+	    if( abs(pids.at(j)) == 11) {
+	      tmp.push_back(0.00051099895);
+	    } else if (abs(pids.at(j)) == 13) {
+	      tmp.push_back(105.65837);
+	    } else {
+	      float Tin = trackerhits.at(trackdata.at(ct.at(j).tracks_begin).trackerHits_begin).time;
+	      float Tout = trackerhits.at(trackdata.at(ct.at(j).tracks_begin).trackerHits_end-1).time; //one track and two hits per recon. particle are assumed
+	      float tof = (Tout - Tin);
+	      float L = track_L.at(ct.at(j).tracks_begin) * 0.001;
+	      //std::cout << "tof: " << tof << "  -  L: " << L <<  << std::endl;
+	      float beta = L/(tof * 2.99792458e+8) ;
+	      float p = std::sqrt( ct.at(j).momentum.x*ct.at(j).momentum.x + ct.at(j).momentum.y*ct.at(j).momentum.y + ct.at(j).momentum.z * ct.at(j).momentum.z );
+	      //std::cout << "tof: " << tof << " - L: " << L << " - beta: " << beta << " - momentum: " << p << " - mtof: " << p * std::sqrt(1/(beta*beta)-1) << std::endl;
+	      if (beta < 1. && beta > 0.) {
+		tmp.push_back( p * std::sqrt(1/(beta*beta)-1) ); 
+	      } else {
+		tmp.push_back(0.13957039);
+	      } 
+	    }
+	  } else {
+	    //float E = ct.at(j).energy;
+	    //tmp.pushback( E * std::sqrt(1-beta*beta) );
+	    tmp.push_back(0.);
+	  }
+	}
+	out.push_back(tmp);
+      }
+      return out;
+    }
+    
+    
+    //rv::RVec<FCCAnalysesJetConstituentsData> get_pt(const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
+    //  return cast_constituent(jcs, ReconstructedParticle::get_pt);
+    //}
+
+
+    //kinematics const/jet
+    rv::RVec<FCCAnalysesJetConstituentsData> get_erel_log(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+                                                          const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for (size_t i = 0; i < jets.size(); ++i) {
+        auto& jet_csts = out.emplace_back();
+        float e_jet = jets.at(i).energy;
+        auto csts = get_jet_constituents(jcs, i);
+        for (const auto& jc : csts) {
+          float val = (e_jet > 0.) ? jc.energy / e_jet : 1.;
+          float erel_log = float(std::log10(val));
+          jet_csts.emplace_back(erel_log);
+        }
+      }
+      return out;
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_erel_log_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+								  const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for (size_t i = 0; i < jets.size(); ++i) {
+        auto& jet_csts = out.emplace_back();
+        float e_jet = jets.at(i).E();
+        auto csts = get_jet_constituents(jcs, i);
+        for (const auto& jc : csts) {
+          float val = (e_jet > 0.) ? jc.energy / e_jet : 1.;
+          float erel_log = float(std::log10(val));
+          jet_csts.emplace_back(erel_log);
+        }
+      }
+      return out;
+    }
+
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_erel(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+                                                          const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for (size_t i = 0; i < jets.size(); ++i) {
+        auto& jet_csts = out.emplace_back();
+        double e_jet = jets.at(i).energy;
+        auto csts = get_jet_constituents(jcs, i);
+        for (const auto& jc : csts) {
+          float val = (e_jet > 0.) ? jc.energy / e_jet : 1.;
+          float erel = val;
+          jet_csts.emplace_back(erel);
+        }
+      }
+      return out;
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_erel_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+							      const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for (size_t i = 0; i < jets.size(); ++i) {
+        auto& jet_csts = out.emplace_back();
+        double e_jet = jets.at(i).E();
+	//float sum_e_const = 0.;
+        auto csts = get_jet_constituents(jcs, i);
+        for (const auto& jc : csts) {
+	  //sum_e_const += jc.energy;
+          float val = (e_jet > 0.) ? jc.energy / e_jet : 1.;
+          float erel = val;
+          jet_csts.emplace_back(erel);
+        }
+	//std::cout << "-> jet_e: " << e_jet << "  ;  sum(const_e) : " << sum_e_const << std::endl;
+      }
+      return out;
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_thetarel(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+                                                          const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for (size_t i = 0; i < jets.size(); ++i) {
+        auto& jet_csts = out.emplace_back();
+        TLorentzVector tlv_jet;
+        tlv_jet.SetXYZM(jets.at(i).momentum.x, jets.at(i).momentum.y, jets.at(i).momentum.z, jets.at(i).mass);
+        float theta_jet = tlv_jet.Theta();
+        float phi_jet = tlv_jet.Phi();
+        auto csts = get_jet_constituents(jcs, i);
+        for (const auto& jc : csts) {
+          TLorentzVector tlv_const;
+          tlv_const.SetXYZM(jc.momentum.x, jc.momentum.y, jc.momentum.z, jc.mass);
+          TVector3 v_const = tlv_const.Vect();
+          v_const.RotateZ(-phi_jet);
+          v_const.RotateY(-theta_jet);
+          float theta_rel = v_const.Theta();
+          jet_csts.emplace_back(theta_rel);
+        }
+      }
+      return out;
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_thetarel_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+								  const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for (size_t i = 0; i < jets.size(); ++i) {
+        auto& jet_csts = out.emplace_back();
+        TLorentzVector tlv_jet;
+        tlv_jet.SetXYZM(jets.at(i).px(), jets.at(i).py(), jets.at(i).pz(), jets.at(i).E());
+        float theta_jet = tlv_jet.Theta();
+        float phi_jet = tlv_jet.Phi();
+        auto csts = get_jet_constituents(jcs, i);
+        for (const auto& jc : csts) {
+          TLorentzVector tlv_const;
+          tlv_const.SetXYZM(jc.momentum.x, jc.momentum.y, jc.momentum.z, jc.energy);
+          TVector3 v_const = tlv_const.Vect();
+          v_const.RotateZ(-phi_jet);
+          v_const.RotateY(-theta_jet);
+          float theta_rel = v_const.Theta();
+          jet_csts.emplace_back(theta_rel);
+        }
+      }
+      return out;
+    }
+
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_phirel(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
+                                                        const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for (size_t i = 0; i < jets.size(); ++i) {
+        auto& jet_csts = out.emplace_back();
+        TLorentzVector tlv_jet;
+        tlv_jet.SetXYZM(jets.at(i).momentum.x, jets.at(i).momentum.y, jets.at(i).momentum.z, jets.at(i).mass);
+        float theta_jet = tlv_jet.Theta();
+        float phi_jet = tlv_jet.Phi();
+        auto csts = get_jet_constituents(jcs, i);
+        for (const auto& jc : csts) {
+          TLorentzVector tlv_const;
+          tlv_const.SetXYZM(jc.momentum.x, jc.momentum.y, jc.momentum.z, jc.mass);
+          TVector3 v_const = tlv_const.Vect();
+          v_const.RotateZ(-phi_jet);
+          v_const.RotateY(-theta_jet);
+          float phi_rel = v_const.Phi();
+          jet_csts.emplace_back(phi_rel);
+        }
+      }
+      return out;
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_phirel_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+								const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for (size_t i = 0; i < jets.size(); ++i) {
+        auto& jet_csts = out.emplace_back();
+        TLorentzVector tlv_jet;
+        tlv_jet.SetXYZM(jets.at(i).px(), jets.at(i).py(), jets.at(i).pz(), jets.at(i).E());
+        float theta_jet = tlv_jet.Theta();
+        float phi_jet = tlv_jet.Phi();
+        auto csts = get_jet_constituents(jcs, i);
+        for (const auto& jc : csts) {
+          TLorentzVector tlv_const;
+          tlv_const.SetXYZM(jc.momentum.x, jc.momentum.y, jc.momentum.z, jc.mass);
+          TVector3 v_const = tlv_const.Vect();
+          v_const.RotateZ(-phi_jet);
+          v_const.RotateY(-theta_jet);
+          float phi_rel = v_const.Phi();
+          jet_csts.emplace_back(phi_rel);
+        }
+      }
+      return out;
+    }
+
+
+    
+    //Identification
+    
+    rv::RVec<FCCAnalysesJetConstituentsData> get_PIDs(const ROOT::VecOps::RVec< int > recin,
+						      const ROOT::VecOps::RVec< int > mcin,
+						      //const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+						      const rv::RVec<edm4hep::ReconstructedParticleData>& RecPart, 
+						      const rv::RVec<edm4hep::MCParticleData>& Particle,
+						      const rv::RVec<edm4hep::ReconstructedParticleData>& jets) { 
+      //return cast_constituent_4(recin, mcin, jcs, Particle, FCCAnalyses::ReconstructedParticle2MC::getRP2MC_pdg);
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      FCCAnalysesJetConstituentsData PIDs = FCCAnalyses::ReconstructedParticle2MC::getRP2MC_pdg(recin, mcin, RecPart, Particle);
+      
+      for (const auto& jet : jets) {
+	FCCAnalysesJetConstituentsData tmp;
+        for (auto it = jet.particles_begin; it < jet.particles_end; ++it) {
+          tmp.push_back(PIDs.at(it));
+	}
+	out.push_back(tmp);
+      }
+      return out;
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_PIDs_cluster(const ROOT::VecOps::RVec< int > recin,
+							      const ROOT::VecOps::RVec< int > mcin,
+							      //const rv::RVec<FCCAnalysesJetConstituents>& jcs,
+							      const rv::RVec<edm4hep::ReconstructedParticleData>& RecPart,
+							      const rv::RVec<edm4hep::MCParticleData>& Particle,
+							      const std::vector<std::vector<int>>& indices) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      FCCAnalysesJetConstituentsData PIDs = FCCAnalyses::ReconstructedParticle2MC::getRP2MC_pdg(recin, mcin, RecPart, Particle);
+
+      for (const auto& jet_index : indices) {
+        FCCAnalysesJetConstituentsData tmp;
+        for (const auto& const_index : jet_index) {
+          tmp.push_back(PIDs.at(const_index));
+        }
+        out.push_back(tmp);
+      }
+      return out;
+    }
+
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isMu(const rv::RVec<FCCAnalysesJetConstituentsData>& PIDs) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;      
+      for(int i = 0; i < PIDs.size(); ++i) {
+	FCCAnalysesJetConstituentsData is_Mu;
+	for (int j = 0; j < PIDs.at(i).size(); ++j) {
+	  if ( abs(PIDs.at(i).at(j)) == 13) {                                                                                         
+	    is_Mu.push_back(1.);                                                                                                                                        
+          } else {                                                                                                                                                   
+            is_Mu.push_back(0.);                                                                                                                                                     
+	  }
+	}
+	out.push_back(is_Mu);
+      }
+      return out;
+    }
+
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isEl(const rv::RVec<FCCAnalysesJetConstituentsData>& PIDs) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for(int i = 0; i < PIDs.size(); ++i) {
+        FCCAnalysesJetConstituentsData is_El;
+        FCCAnalysesJetConstituentsData pids = PIDs.at(i);
+	for (int j = 0; j < pids.size(); ++j) {                                                                                                                                     
+	  if ( abs(pids.at(j)) == 11) {                                                                                                     
+	    is_El.push_back(1.);       
+	  } else {                                                                                                                                  
+            is_El.push_back(0.);                                                                                                                                                     
+	  }
+	}
+	out.push_back(is_El);
+      }
+      return out;
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isChargedHad(const rv::RVec<FCCAnalysesJetConstituentsData>& PIDs, 
+							      const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for(int i = 0; i < PIDs.size(); ++i) {
+        FCCAnalysesJetConstituentsData is_ChargedHad;
+        FCCAnalysesJetConstituents ct = jcs.at(i);
+	FCCAnalysesJetConstituentsData pids = PIDs.at(i);
+        for (int j = 0; j < pids.size(); ++j) {
+	  if (ct.at(j).charge != 0 && abs(pids.at(j)) != 11 && abs(pids.at(j)) != 13) {                                                                                                       
+	    is_ChargedHad.push_back(1.);                                                                                                                                        
+	  } else {                                                                                                                                                 
+            is_ChargedHad.push_back(0.);                                                                                                                                 
+          }
+	}
+        out.push_back(is_ChargedHad);
+      }
+      return out;
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isGamma(const rv::RVec<FCCAnalysesJetConstituentsData>& PIDs) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for(int i = 0; i < PIDs.size(); ++i) {
+        FCCAnalysesJetConstituentsData is_Gamma;
+        FCCAnalysesJetConstituentsData pids = PIDs.at(i);
+        for (int j = 0; j < pids.size(); ++j) {
+          if ( abs(pids.at(j)) == 22) {
+            is_Gamma.push_back(1.);
+          } else {
+            is_Gamma.push_back(0.);
+          }
+        }
+        out.push_back(is_Gamma);
+      }
+      return out;
+    }
+
+    rv::RVec<FCCAnalysesJetConstituentsData> get_isNeutralHad(const rv::RVec<FCCAnalysesJetConstituentsData>& PIDs,
+							      const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for(int i = 0; i < PIDs.size(); ++i) {
+        FCCAnalysesJetConstituentsData is_NeutralHad;
+        FCCAnalysesJetConstituents ct = jcs.at(i);
+        FCCAnalysesJetConstituentsData pids = PIDs.at(i);
+        for (int j = 0; j < pids.size(); ++j) {
+	  if (ct.at(j).charge == 0 && abs(pids.at(j)) != 22 )                                                                                      
+            is_NeutralHad.push_back(1.);                                                                                                                         
+	  else                      
+	    is_NeutralHad.push_back(0.);                                                                                                
+	}
+	out.push_back(is_NeutralHad);
+      }
+      return out;
+    }
+
+
+    //countings
+    int count_jets(rv::RVec<FCCAnalysesJetConstituents> jets) {
+      return jets.size();
+    }
+    
+    rv::RVec<int> count_consts(rv::RVec<FCCAnalysesJetConstituents> jets) {
+      rv::RVec<int> out;
+      for(int i = 0; i < jets.size(); ++i) {
+	out.push_back(jets.at(i).size());
+      }
+      return out;
+    }
+
+    rv::RVec<int> count_type(const rv::RVec<FCCAnalysesJetConstituentsData>& isType) {
+      rv::RVec<int> out;
+      for(int i = 0; i < isType.size(); ++i){
+	int count = 0;
+	rv::RVec<float> istype = isType.at(i);
+	for(int j = 0; j < istype.size(); ++j){
+	  if( (int)(istype.at(j)) == 1) count++;
+	}
+	out.push_back(count);
+      }
+      return out;
+    }
+
+    //compute residues
+    rv::RVec<TLorentzVector> compute_tlv_jets(const rv::RVec<fastjet::PseudoJet>& jets) {
+      rv::RVec<TLorentzVector> out;
+      for(const auto& jet : jets) {
+	TLorentzVector tlv_jet;
+	tlv_jet.SetPxPyPzE(jet.px(), jet.py(), jet.pz(), jet.E());
+	out.push_back(tlv_jet);
+      }
+      return out;
+    }
+
+    rv::RVec<TLorentzVector> sum_tlv_constituents(const rv::RVec<FCCAnalysesJetConstituents>& jets) {
+      rv::RVec<TLorentzVector> out;
+      for (int i = 0; i < jets.size(); ++i) {
+	TLorentzVector sum_tlv; // initialized by (0., 0., 0., 0.)
+	FCCAnalysesJetConstituents jcs = jets.at(i);
+	for (const auto& jc : jcs) {
+	  TLorentzVector tlv;
+	  tlv.SetPxPyPzE(jc.momentum.x, jc.momentum.y, jc.momentum.z, jc.energy);
+	  sum_tlv += tlv;
+	}
+	out.push_back(sum_tlv);
+      }
+      return out;
+    }
+    
+    float InvariantMass(const TLorentzVector& tlv1, const TLorentzVector& tlv2) {
+      float E = tlv1.E() + tlv2.E();
+      float px = tlv1.Px() + tlv2.Px();
+      float py = tlv1.Py() + tlv2.Py();
+      float pz = tlv1.Pz() + tlv2.Pz();
+      return std::sqrt(E*E - px*px - py*py - pz*pz);
+    }
+
+    rv::RVec<double> compute_residue_energy(const rv::RVec<TLorentzVector>& tlv_jet, const rv::RVec<TLorentzVector>& sum_tlv_jcs) {
+      rv::RVec<double> out;
+      for(int i = 0; i < tlv_jet.size(); ++i) {
+	float de = (sum_tlv_jcs.at(i).E() - tlv_jet.at(i).E())/tlv_jet.at(i).E();
+	out.push_back(de);
+      }
+      return out;
+    }
+
+    rv::RVec<double> compute_residue_px(const rv::RVec<TLorentzVector>& tlv_jet, const rv::RVec<TLorentzVector>& sum_tlv_jcs) {
+      rv::RVec<double> out;
+      for(int i = 0; i < tlv_jet.size(); ++i) {
+        float dpx = (sum_tlv_jcs.at(i).Px() - tlv_jet.at(i).Px())/tlv_jet.at(i).Px();
+        out.push_back(dpx);
+      }
+      return out;
+    }
+
+    rv::RVec<double> compute_residue_py(const rv::RVec<TLorentzVector>& tlv_jet, const rv::RVec<TLorentzVector>& sum_tlv_jcs) {
+      rv::RVec<double> out;
+      for(int i = 0; i < tlv_jet.size(); ++i) {
+        float dpy = (sum_tlv_jcs.at(i).Py() - tlv_jet.at(i).Py())/tlv_jet.at(i).Py();
+        out.push_back(dpy);
+      }
+      return out;
+    }
+
+    rv::RVec<double> compute_residue_pz(const rv::RVec<TLorentzVector>& tlv_jet, const rv::RVec<TLorentzVector>& sum_tlv_jcs) {
+      rv::RVec<double> out;
+      for(int i = 0; i < tlv_jet.size(); ++i) {
+        float dpz = (sum_tlv_jcs.at(i).Pz() - tlv_jet.at(i).Pz())/tlv_jet.at(i).Pz();
+        out.push_back(dpz);
+      }
+      return out;
+    }
+
+    rv::RVec<double> compute_residue_pt(const rv::RVec<TLorentzVector>& tlv_jet, const rv::RVec<TLorentzVector>& sum_tlv_jcs) {
+      rv::RVec<double> out;
+      for(int i = 0; i < tlv_jet.size(); ++i) {
+	double pt_jet = std::sqrt( tlv_jet.at(i).Px()*tlv_jet.at(i).Px() + tlv_jet.at(i).Py()*tlv_jet.at(i).Py() );
+	double pt_jcs = std::sqrt( sum_tlv_jcs.at(i).Px()*sum_tlv_jcs.at(i).Px() + sum_tlv_jcs.at(i).Py()*sum_tlv_jcs.at(i).Py() );
+	double dpt = ( pt_jcs - pt_jet)/pt_jet;
+	out.push_back(dpt);
+      } 
+      return out;
+    }
+
+    rv::RVec<double> compute_residue_phi(const rv::RVec<TLorentzVector>& tlv_jet, const rv::RVec<TLorentzVector>& sum_tlv_jcs) {
+      rv::RVec<double> out;
+      for(int i = 0; i < tlv_jet.size(); ++i) {
+	double phi_jet = tlv_jet.at(i).Phi();
+        double phi_jcs = sum_tlv_jcs.at(i).Phi();
+	double dphi = (phi_jcs - phi_jet)/phi_jet;
+	out.push_back(dphi);
+      }
+      return out;
+    }
+
+    rv::RVec<double> compute_residue_theta(const rv::RVec<TLorentzVector>& tlv_jet, const rv::RVec<TLorentzVector>& sum_tlv_jcs) {
+      rv::RVec<double> out;
+      for(int i = 0; i < tlv_jet.size(); ++i) {
+	double theta_jet = tlv_jet.at(i).Theta();
+	double theta_jcs = sum_tlv_jcs.at(i).Theta();
+	double dtheta = (theta_jcs - theta_jet)/theta_jet;
+	out.push_back(dtheta);
+      } 
+      return out;
+    }
+
+
   }  // namespace JetConstituentsUtils
 }  // namespace FCCAnalyses

--- a/analyzers/dataframe/src/JetConstituentsUtils.cc
+++ b/analyzers/dataframe/src/JetConstituentsUtils.cc
@@ -36,14 +36,12 @@ namespace FCCAnalyses {
           jc.emplace_back(rps.at(it));
 	  energy_const += rps.at(it).energy;
 	}
-	std::cout << "-> jet_e: " << energy_jet << "  ;  const_e : " << energy_const << std::endl;
       }
       return jcs;
     }
 
     rv::RVec<FCCAnalysesJetConstituents> build_constituents_cluster(const rv::RVec<edm4hep::ReconstructedParticleData>& rps,
 								    const std::vector<std::vector<int>>& indices) {
-      //std::cout << "... Building jets-constituents after clustering " << std::endl;
       rv::RVec<FCCAnalysesJetConstituents> jcs;
       for (const auto& jet_index : indices) {
 	FCCAnalysesJetConstituents jc;
@@ -82,12 +80,10 @@ namespace FCCAnalyses {
     };
 
 
-    //Questa funzione semplicemente applica le funzioni a 2 args per vett di rec part a un vettore di vett di rec part
+    /// This function simply applies the 2 args functions per vector of Rec Particles to a vector of vectors of Rec Particles
     auto cast_constituent_2 = [](const auto& jcs, const auto& coll, auto&& meth) {
-      //auto cast_constituent_2 = [](const auto& jcs, auto&& meth) {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
       for (const auto& jc : jcs) {
-        //std::cout<<"new jet:  " <<jc.size()<<std::endl;
         out.emplace_back(meth(jc, coll));
         //out.emplace_back(meth(jc));
       }
@@ -95,12 +91,10 @@ namespace FCCAnalyses {
     };
 
     auto cast_constituent_4 = [](const auto& jcs, const auto& coll1, const auto& coll2, const auto& coll3,auto&& meth) {
-      //auto cast_constituent_2 = [](const auto& jcs, auto&& meth) { 
       rv::RVec<FCCAnalysesJetConstituentsData> out;
       for (const auto& jc : jcs) {
         //std::cout<<"new jet:  " <<jc.size()<<std::endl;
         out.emplace_back(meth(jc, coll1, coll2, coll3));
-        //out.emplace_back(meth(jc));         
       }
       return out;
     };
@@ -190,21 +184,6 @@ namespace FCCAnalyses {
       return cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_tanLambda);
     }
 
-    //displacement (wrt Vertex)
-
-    /*
-    rv::RVec< rv::RVec< rv::RVec<float>  > > XPtoPar(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
-						     const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
-						     const TVector3& V,
-						     const float& Bz) {
-      rv::RVec<rv::RVec<rv::RVec<float> > > out;
-      for(const auto & jc : jcs) {
-	out.emplace_back(ReconstructedParticle2Track::XPtoPar(jc, tracks, V, Bz));
-      }
-      return out;
-      //return cast_constituent_4(jcs, tracks, V, Bz, ReconstructedParticle2Track::XPtoPar);
-    }
-    */
  
     rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_dxy(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
 							 const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
@@ -246,27 +225,6 @@ namespace FCCAnalyses {
       return cast_constituent_4(jcs, tracks, V, Bz, ReconstructedParticle2Track::XPtoPar_ct);
     }
 
-    /*      
-    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_dxy(const rv::RVec< rv::RVec<TVectorD> >& par) {
-      return cast_constituent(par, ReconstructedParticle2Track::XPtoPar_dxy);
-    }
-
-    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_dz(const rv::RVec<rv::RVec<TVectorD> >& par) {
-      return cast_constituent(par, ReconstructedParticle2Track::XPtoPar_dz);
-    }
-
-    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_phi0(const rv::RVec< rv::RVec<TVectorD> >& par) {
-      return cast_constituent(par, ReconstructedParticle2Track::XPtoPar_phi0);
-    }
-
-    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_C(const rv::RVec<rv::RVec<TVectorD> >& par) {
-      return cast_constituent(par, ReconstructedParticle2Track::XPtoPar_C);
-    }
-
-    rv::RVec<FCCAnalysesJetConstituentsData> XPtoPar_ct(const rv::RVec< rv::RVec<TVectorD> >& par) {
-      return cast_constituent(par, ReconstructedParticle2Track::XPtoPar_ct);
-    }
-    */
    
     //Covariance matrix elements of tracks parameters
     //diagonal
@@ -376,16 +334,6 @@ namespace FCCAnalyses {
       rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
       rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
       
-      //for (size_t i = 0; i < jets.size(); ++i){
-      //	TVector2 jetP3();
-      //}
-
-      //for (auto & j: jets) {
-      //	TVector2 p(j.momentum.x, j.momentum.y);
-      //FCCAnalysesJetConstituentsData projs;
-      //for(size_t i = 0; i < )
-      //result.push_back(tlv.Eta());
-      //}
       
       for(int i = 0; i < jets.size(); ++i){
 	TVector2 p(jets[i].momentum.x, jets[i].momentum.y);
@@ -426,33 +374,6 @@ namespace FCCAnalyses {
       return out;
     }
 
-    /*
-    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dVal_clusterV(const rv::RVec<fastjet::PseudoJet>& jets,
-								   const rv::RVec<FCCAnalysesJetConstituents>& jcs,
-								   const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
-								   const TVector3& V) {
-      rv::RVec<FCCAnalysesJetConstituentsData> out;
-
-      float Bz = ReconstructedParticle2Track::Bz(jcs, tracks);
-      rv::RVec<FCCAnalysesJetConstituentsData> D0 = XPtoPar_dxy(jcs, tracks, V, Bz);
-      rv::RVec<FCCAnalysesJetConstituentsData> phi0 = XPtoPar_phi(jcs, tracks, V, Bz);
-      
-      for(int i = 0; i < jets.size(); ++i){
-        TVector2 p(jets[i].px(), jets[i].py());
-        FCCAnalysesJetConstituentsData cprojs;
-        for (int j = 0; j < jcs[i].size(); ++j) {
-          if (D0.at(i).at(j) != -9) {
-            TVector2 d0( - D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)) , D0.at(i).at(j) * TMath::Cos(phi0.at(i).at(j))  );
-            cprojs.push_back( TMath::Sign(1, d0*p) * fabs(D0.at(i).at(j))  );
-          } else {
-            cprojs.push_back(-9.);
-          }
-        }
-        out.push_back(cprojs);
-      }
-      return out;
-    }
-    */
 
     rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dVal_clusterV(const rv::RVec<fastjet::PseudoJet>& jets,
 								   const rv::RVec<FCCAnalysesJetConstituentsData>& D0,
@@ -478,9 +399,8 @@ namespace FCCAnalyses {
     }
 
 
-    //The functions get_Sip2dSig and get_Sip2dVal can be made independent;
-    //I passed to the former the result of the latter
-    //avoidind the recomputing
+    /// The functions get_Sip2dSig and get_Sip2dVal can be made independent;
+    /// I passed to the former the result of the latter, avoiding the recomputation
     rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dSig(const rv::RVec<FCCAnalysesJetConstituentsData>& Sip2dVals,
 							  const rv::RVec<FCCAnalysesJetConstituentsData>& err2_D0) {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
@@ -547,32 +467,6 @@ namespace FCCAnalyses {
       return out;
     }
 
-    /*
-    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip3dVal_clusterV(const rv::RVec<fastjet::PseudoJet>& jets,
-								   const rv::RVec<FCCAnalysesJetConstituents>& jcs,
-								   const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
-								   const TVector3& V) {
-      rv::RVec<FCCAnalysesJetConstituentsData> out;
-      rv::RVec<FCCAnalysesJetConstituentsData> D0 = XPtoPar_dxy(jcs, tracks, V, Bz);
-      rv::RVec<FCCAnalysesJetConstituentsData> Z0 = XPtoPar_dz(jcs, tracks, V, Bz);
-      rv::RVec<FCCAnalysesJetConstituentsData> phi0 = XPtoPar_phi(jcs, tracks, V, Bz);
-
-      for(int i = 0; i < jets.size(); ++i){
-        TVector3 p(jets[i].px(), jets[i].py(), jets[i].pz());
-        FCCAnalysesJetConstituentsData cprojs;
-        for (int j = 0; j < jcs[i].size(); ++j){
-          if(D0.at(i).at(j) != -9) {
-            TVector3 d( - D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)) , D0.at(i).at(j)*TMath::Cos(phi0.at(i).at(j)), Z0.at(i).at(j) );
-            cprojs.push_back( TMath::Sign(1, d*p) * fabs( sqrt( D0.at(i).at(j)*D0.at(i).at(j) + Z0.at(i).at(j)*Z0.at(i).at(j) ) ) );
-          } else {
-            cprojs.push_back(-9);
-          }
-        }
-        out.push_back(cprojs);
-      }
-      return out;
-    }
-    */
 
     rv::RVec<FCCAnalysesJetConstituentsData> get_Sip3dVal_clusterV(const rv::RVec<fastjet::PseudoJet>& jets,
                                                                    const rv::RVec<FCCAnalysesJetConstituentsData>& D0,
@@ -770,11 +664,6 @@ namespace FCCAnalyses {
       return out;
     }
     
-    
-    //rv::RVec<FCCAnalysesJetConstituentsData> get_pt(const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
-    //  return cast_constituent(jcs, ReconstructedParticle::get_pt);
-    //}
-
 
     //kinematics const/jet
     rv::RVec<FCCAnalysesJetConstituentsData> get_erel_log(const rv::RVec<edm4hep::ReconstructedParticleData>& jets,
@@ -832,15 +721,12 @@ namespace FCCAnalyses {
       for (size_t i = 0; i < jets.size(); ++i) {
         auto& jet_csts = out.emplace_back();
         double e_jet = jets.at(i).E();
-	//float sum_e_const = 0.;
         auto csts = get_jet_constituents(jcs, i);
         for (const auto& jc : csts) {
-	  //sum_e_const += jc.energy;
           float val = (e_jet > 0.) ? jc.energy / e_jet : 1.;
           float erel = val;
           jet_csts.emplace_back(erel);
         }
-	//std::cout << "-> jet_e: " << e_jet << "  ;  sum(const_e) : " << sum_e_const << std::endl;
       }
       return out;
     }
@@ -944,11 +830,9 @@ namespace FCCAnalyses {
     
     rv::RVec<FCCAnalysesJetConstituentsData> get_PIDs(const ROOT::VecOps::RVec< int > recin,
 						      const ROOT::VecOps::RVec< int > mcin,
-						      //const rv::RVec<FCCAnalysesJetConstituents>& jcs,
 						      const rv::RVec<edm4hep::ReconstructedParticleData>& RecPart, 
 						      const rv::RVec<edm4hep::MCParticleData>& Particle,
 						      const rv::RVec<edm4hep::ReconstructedParticleData>& jets) { 
-      //return cast_constituent_4(recin, mcin, jcs, Particle, FCCAnalyses::ReconstructedParticle2MC::getRP2MC_pdg);
       rv::RVec<FCCAnalysesJetConstituentsData> out;
       FCCAnalysesJetConstituentsData PIDs = FCCAnalyses::ReconstructedParticle2MC::getRP2MC_pdg(recin, mcin, RecPart, Particle);
       

--- a/analyzers/dataframe/src/ReconstructedParticle2Track.cc
+++ b/analyzers/dataframe/src/ReconstructedParticle2Track.cc
@@ -4,6 +4,326 @@ namespace FCCAnalyses{
 
 namespace ReconstructedParticle2Track{
 
+  ROOT::VecOps::RVec<float> getRP2TRK_Bz(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& rps, const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+    const double c_light = 2.99792458e8;
+    const double a = c_light * 1e3 * 1e-15; //[omega] = 1/mm
+    ROOT::VecOps::RVec<float> out;
+    
+    for(auto & p: rps) {
+      if(p.tracks_begin < tracks.size()) {
+	double pt= sqrt(p.momentum.x * p.momentum.x + p.momentum.y * p.momentum.y);
+	double Bz= tracks.at(p.tracks_begin).omega / a * pt * std::copysign(1.0, p.charge);
+	out.push_back(Bz);
+      } else {
+	out.push_back(-9.);
+      }
+    }
+    return out;
+  }
+
+  float Bz(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& rps, const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks) {
+    const double c_light =  2.99792458e8;// speed of light m/sec;
+    const double a = c_light * 1e3 * 1e-15; //[omega] = 1/mm 
+    
+    double Bz = -9;
+
+    for(auto & p: rps) {
+      if(p.tracks_begin < tracks.size()) {
+        double pt= sqrt(p.momentum.x * p.momentum.x + p.momentum.y * p.momentum.y);
+        Bz= tracks.at(p.tracks_begin).omega / a * pt * std::copysign(1.0, p.charge);
+      }
+    }
+    return Bz;
+  }
+
+  /*  
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > XPtoPar(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
+							   const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+							   const TVector3& V, 
+							   const float& Bz) {
+    
+    const double cSpeed = 2.99792458e8 * 1.0e-9; //Reduced speed of light ???
+    float dft[5] = {-9., -9., -9., -9., -9.};
+    ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > out;
+    
+    for (const auto & rp: in) {
+      ROOT::VecOps::RVec<float> Par(dft, 5);
+    
+      if( rp.tracks_begin < tracks.size()) {
+
+        float D0_wrt0 = tracks.at(rp.tracks_begin).D0;
+	float Z0_wrt0 = tracks.at(rp.tracks_begin).Z0;
+	float phi0_wrt0 = tracks.at(rp.tracks_begin).phi;
+
+	TVector3 X( - D0_wrt0 * TMath::Sin(phi0_wrt0) , D0_wrt0 * TMath::Cos(phi0_wrt0) , Z0_wrt0);
+	TVector3 x = X - V;
+
+	TVector3 p(rp.momentum.x, rp.momentum.y, rp.momentum.z);
+
+	double a = - rp.charge * Bz * cSpeed;  // Units are Tesla, GeV and meters
+	double pt = p.Pt();
+	double C = a/(2 * pt); // Half curvature
+	double r2 = x(0) * x(0) + x(1) * x(1);
+	double cross = x(0) * p(1) - x(1) * p(0);
+	double T = TMath::Sqrt(pt * pt - 2 * a * cross + a * a * r2);
+	double phi0 = TMath::ATan2((p(1) - a * x(0)) / T, (p(0) + a * x(1)) / T); // Phi0
+	double D;// Impact parameter D
+	if (pt < 10.0) D = (T - pt) / a;
+	else D = (-2 * cross + a * r2) / (T + pt);
+	//
+	Par[0] = D;// Store D
+	Par[1] = phi0;// Store phi0
+	Par[2] = C;// Store C
+	//Longitudinal parameters
+	double B = C * TMath::Sqrt(TMath::Max(r2 - D * D, 0.0) / (1 + 2 * C * D));
+	double st = TMath::ASin(B) / C;
+	double ct = p(2) / pt;
+	double z0;
+	double dot = x(0) * p(0) + x(1) * p(1);
+	if (dot > 0.0) z0 = x(2) - ct * st;
+	else z0 = x(2) + ct * st;
+	//
+	Par[3] = z0;// Store z0
+	Par[4] = ct;// Store cot(theta)
+	//
+      }
+      //std::cout << "-> par.size(): " << Par.size() << std::endl;
+      //std::cout << "par: " << Par[0] << " " << Par[1] << Par[2] << Par[3] << Par[4] <<std::endl;
+      out.push_back(Par);
+    }
+    //std::cout << "--> in.size(): " << in.size() << std::endl;
+    //std::cout << "--> in.size(): " << in.size() << std::endl;
+    //std::cout << "--> out.size(): " << out.size() << std::endl;
+    //std::cout << "----------------------------" << std::endl;
+    //std::cout << "----------------------------" << std::endl;
+    return out;
+  }
+  
+  */
+  ROOT::VecOps::RVec<float> XPtoPar_dxy(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
+					const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+					const TVector3& V,
+					const float& Bz) {
+    
+    const double cSpeed = 2.99792458e8 * 1.0e-9; 
+                                        
+    ROOT::VecOps::RVec<float> out;
+
+    for (const auto & rp: in) {
+      
+      if( rp.tracks_begin < tracks.size()) {
+	
+        float D0_wrt0 = tracks.at(rp.tracks_begin).D0;
+        float Z0_wrt0 = tracks.at(rp.tracks_begin).Z0;
+        float phi0_wrt0 = tracks.at(rp.tracks_begin).phi;
+
+        TVector3 X( - D0_wrt0 * TMath::Sin(phi0_wrt0) , D0_wrt0 * TMath::Cos(phi0_wrt0) , Z0_wrt0);
+        TVector3 x = X - V;
+
+        TVector3 p(rp.momentum.x, rp.momentum.y, rp.momentum.z);
+
+        double a = - rp.charge * Bz * cSpeed;       
+        double pt = p.Pt();
+        double r2 = x(0) * x(0) + x(1) * x(1);
+        double cross = x(0) * p(1) - x(1) * p(0);
+        double D=-9;
+        if (pt * pt - 2 * a * cross + a * a * r2 > 0) {
+          double T = TMath::Sqrt(pt * pt - 2 * a * cross + a * a * r2);                                                         
+	  if (pt < 10.0) D = (T - pt) / a;
+          else D = (-2 * cross + a * r2) / (T + pt);
+        }
+	out.push_back(D);
+	
+      } else {
+	out.push_back(-9.);
+      }
+    }
+    return out;
+  }
+
+  
+  
+  ROOT::VecOps::RVec<float> XPtoPar_dz(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
+                                        const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+                                        const TVector3& V,
+                                        const float& Bz) {
+
+    const double cSpeed = 2.99792458e8 * 1.0e-9; //Reduced speed of light ???                                                                                                      
+
+    ROOT::VecOps::RVec<float> out;
+
+    for (const auto & rp: in) {
+
+      if( rp.tracks_begin < tracks.size()) {
+
+        float D0_wrt0 = tracks.at(rp.tracks_begin).D0;
+        float Z0_wrt0 = tracks.at(rp.tracks_begin).Z0;
+        float phi0_wrt0 = tracks.at(rp.tracks_begin).phi;
+
+        TVector3 X( - D0_wrt0 * TMath::Sin(phi0_wrt0) , D0_wrt0 * TMath::Cos(phi0_wrt0) , Z0_wrt0);
+        TVector3 x = X - V;
+
+        TVector3 p(rp.momentum.x, rp.momentum.y, rp.momentum.z);
+
+        double a = - rp.charge * Bz * cSpeed;
+        double pt = p.Pt();
+        double C = a/(2 * pt);
+        double r2 = x(0) * x(0) + x(1) * x(1);
+        double cross = x(0) * p(1) - x(1) * p(0);
+        double T = TMath::Sqrt(pt * pt - 2 * a * cross + a * a * r2);
+        double D;
+        if (pt < 10.0) D = (T - pt) / a;
+        else D = (-2 * cross + a * r2) / (T + pt);
+        double B = C * TMath::Sqrt(TMath::Max(r2 - D * D, 0.0) / (1 + 2 * C * D));
+        double st = TMath::ASin(B) / C;
+        double ct = p(2) / pt;
+        double z0;
+        double dot = x(0) * p(0) + x(1) * p(1);
+        if (dot > 0.0) z0 = x(2) - ct * st;
+        else z0 = x(2) + ct * st;
+
+        out.push_back(z0);
+      } else {
+        out.push_back(-9.);
+      }
+    }
+    return out;
+  }
+
+  ROOT::VecOps::RVec<float> XPtoPar_phi(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
+					const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+					const TVector3& V,
+					const float& Bz) {
+
+    const double cSpeed = 2.99792458e8 * 1.0e-9; //Reduced speed of light ???                                                                                                                               
+
+    ROOT::VecOps::RVec<float> out;
+
+    for (const auto & rp: in) {
+
+      if( rp.tracks_begin < tracks.size()) {
+
+        float D0_wrt0 = tracks.at(rp.tracks_begin).D0;
+        float Z0_wrt0 = tracks.at(rp.tracks_begin).Z0;
+        float phi0_wrt0 = tracks.at(rp.tracks_begin).phi;
+
+        TVector3 X( - D0_wrt0 * TMath::Sin(phi0_wrt0) , D0_wrt0 * TMath::Cos(phi0_wrt0) , Z0_wrt0);
+        TVector3 x = X - V;
+
+        TVector3 p(rp.momentum.x, rp.momentum.y, rp.momentum.z);
+
+        double a = - rp.charge * Bz * cSpeed;
+        double pt = p.Pt();
+        double r2 = x(0) * x(0) + x(1) * x(1);
+        double cross = x(0) * p(1) - x(1) * p(0);
+        double T = TMath::Sqrt(pt * pt - 2 * a * cross + a * a * r2);
+        double phi0 = TMath::ATan2((p(1) - a * x(0)) / T, (p(0) + a * x(1)) / T);
+       
+	out.push_back(phi0);
+
+      } else {
+        out.push_back(-9.);
+      }
+    }
+    return out;
+  }
+
+  ROOT::VecOps::RVec<float> XPtoPar_C(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
+				       const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+				       const TVector3& V,
+				       const float& Bz) {
+
+    const double cSpeed = 2.99792458e8 * 1.0e3 * 1.0e-15;
+    ROOT::VecOps::RVec<float> out;
+
+    for (const auto & rp: in) {
+
+      if( rp.tracks_begin < tracks.size()) {
+
+        TVector3 p(rp.momentum.x, rp.momentum.y, rp.momentum.z);
+
+        //double a = - rp.charge * Bz * cSpeed;
+        double a = std::copysign(1.0, rp.charge) * Bz * cSpeed;
+	double pt = p.Pt();
+        double C = a/(2 * pt);
+	
+	out.push_back(C);
+      } else {
+        out.push_back(-9.);
+      }
+    }
+    return out;
+  }
+
+  ROOT::VecOps::RVec<float> XPtoPar_ct(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
+				       const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
+				       const TVector3& V,
+				       const float& Bz) {
+
+    const double cSpeed = 2.99792458e8 * 1.0e-9;
+    ROOT::VecOps::RVec<float> out;
+
+    for (const auto & rp: in) {
+
+      if( rp.tracks_begin < tracks.size()) {
+
+        TVector3 p(rp.momentum.x, rp.momentum.y, rp.momentum.z);
+	double pt = p.Pt();
+       
+        double ct = p(2) / pt;
+	
+	out.push_back(ct);
+
+      } else {
+        out.push_back(-9.);
+      }
+    }
+    return out;
+  }
+
+
+
+
+
+  
+
+/*  
+  ROOT::VecOps::RVec<float> XPtoPar_dxy(const ROOT::VecOps::RVec<TVectorD>& in) {
+    ROOT::VecOps::RVec<float> out;
+    for(auto & par: in) 
+      out.push_back(par(0));
+    return out;
+  }
+
+  ROOT::VecOps::RVec<float> XPtoPar_dz(const ROOT::VecOps::RVec<TVectorD>& in) {
+    ROOT::VecOps::RVec<float> out;
+    for(auto & par: in)
+      out.push_back(par(3));
+    return out;
+  }
+  
+  ROOT::VecOps::RVec<float> XPtoPar_phi0(const ROOT::VecOps::RVec<TVectorD>& in) {
+    ROOT::VecOps::RVec<float> out;
+    for(auto & par: in)
+      out.push_back(par(1));
+    return out;
+  }
+
+  ROOT::VecOps::RVec<float> XPtoPar_C(const ROOT::VecOps::RVec<TVectorD>& in) {
+    ROOT::VecOps::RVec<float> out;
+    for(auto & par: in)
+      out.push_back(par(2));
+    return out;
+  }
+  
+  ROOT::VecOps::RVec<float> XPtoPar_ct(const ROOT::VecOps::RVec<TVectorD>& in) {
+    ROOT::VecOps::RVec<float> out;
+    for(auto & par: in)
+      out.push_back(par(4));
+    return out;
+  }
+*/
+
 ROOT::VecOps::RVec<float>
 getRP2TRK_D0(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
              ROOT::VecOps::RVec<edm4hep::TrackState> tracks) {
@@ -11,7 +331,8 @@ getRP2TRK_D0(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).D0);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9.);
   }
   return result;
 }
@@ -23,7 +344,8 @@ getRP2TRK_D0_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[0]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9.);
   }
   return result;
 }
@@ -35,7 +357,8 @@ getRP2TRK_D0_sig(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).D0/sqrt(tracks.at(p.tracks_begin).covMatrix[0]));
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9.);
   }
   return result;
 }
@@ -47,7 +370,8 @@ getRP2TRK_Z0(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).Z0);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9.);
   }
   return result;
 }
@@ -59,7 +383,8 @@ getRP2TRK_Z0_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[9]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -83,7 +408,8 @@ getRP2TRK_phi(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).phi);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -95,7 +421,8 @@ getRP2TRK_phi_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[2]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -108,7 +435,8 @@ getRP2TRK_omega(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).omega);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -120,7 +448,8 @@ getRP2TRK_omega_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[5]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -132,7 +461,8 @@ getRP2TRK_tanLambda(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).tanLambda);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -144,7 +474,8 @@ getRP2TRK_tanLambda_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> i
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[14]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -156,7 +487,8 @@ getRP2TRK_d0_phi0_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[1]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -168,7 +500,8 @@ getRP2TRK_d0_omega_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[3]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -180,7 +513,8 @@ getRP2TRK_d0_z0_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[6]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -192,7 +526,8 @@ getRP2TRK_d0_tanlambda_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[10]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -204,7 +539,8 @@ getRP2TRK_phi0_omega_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> 
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[4]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -216,7 +552,8 @@ getRP2TRK_phi0_z0_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[7]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -228,7 +565,8 @@ getRP2TRK_phi0_tanlambda_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleDa
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[11]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -240,7 +578,8 @@ getRP2TRK_omega_z0_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[8]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -252,7 +591,8 @@ getRP2TRK_omega_tanlambda_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleD
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[12]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }
@@ -264,7 +604,8 @@ getRP2TRK_z0_tanlambda_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[13]);
-    else result.push_back(std::nan(""));
+    //else result.push_back(std::nan(""));
+    else result.push_back(-9);
   }
   return result;
 }

--- a/analyzers/dataframe/src/ReconstructedParticle2Track.cc
+++ b/analyzers/dataframe/src/ReconstructedParticle2Track.cc
@@ -36,70 +36,6 @@ namespace ReconstructedParticle2Track{
     return Bz;
   }
 
-  /*  
-  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > XPtoPar(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
-							   const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
-							   const TVector3& V, 
-							   const float& Bz) {
-    
-    const double cSpeed = 2.99792458e8 * 1.0e-9; //Reduced speed of light ???
-    float dft[5] = {-9., -9., -9., -9., -9.};
-    ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > out;
-    
-    for (const auto & rp: in) {
-      ROOT::VecOps::RVec<float> Par(dft, 5);
-    
-      if( rp.tracks_begin < tracks.size()) {
-
-        float D0_wrt0 = tracks.at(rp.tracks_begin).D0;
-	float Z0_wrt0 = tracks.at(rp.tracks_begin).Z0;
-	float phi0_wrt0 = tracks.at(rp.tracks_begin).phi;
-
-	TVector3 X( - D0_wrt0 * TMath::Sin(phi0_wrt0) , D0_wrt0 * TMath::Cos(phi0_wrt0) , Z0_wrt0);
-	TVector3 x = X - V;
-
-	TVector3 p(rp.momentum.x, rp.momentum.y, rp.momentum.z);
-
-	double a = - rp.charge * Bz * cSpeed;  // Units are Tesla, GeV and meters
-	double pt = p.Pt();
-	double C = a/(2 * pt); // Half curvature
-	double r2 = x(0) * x(0) + x(1) * x(1);
-	double cross = x(0) * p(1) - x(1) * p(0);
-	double T = TMath::Sqrt(pt * pt - 2 * a * cross + a * a * r2);
-	double phi0 = TMath::ATan2((p(1) - a * x(0)) / T, (p(0) + a * x(1)) / T); // Phi0
-	double D;// Impact parameter D
-	if (pt < 10.0) D = (T - pt) / a;
-	else D = (-2 * cross + a * r2) / (T + pt);
-	//
-	Par[0] = D;// Store D
-	Par[1] = phi0;// Store phi0
-	Par[2] = C;// Store C
-	//Longitudinal parameters
-	double B = C * TMath::Sqrt(TMath::Max(r2 - D * D, 0.0) / (1 + 2 * C * D));
-	double st = TMath::ASin(B) / C;
-	double ct = p(2) / pt;
-	double z0;
-	double dot = x(0) * p(0) + x(1) * p(1);
-	if (dot > 0.0) z0 = x(2) - ct * st;
-	else z0 = x(2) + ct * st;
-	//
-	Par[3] = z0;// Store z0
-	Par[4] = ct;// Store cot(theta)
-	//
-      }
-      //std::cout << "-> par.size(): " << Par.size() << std::endl;
-      //std::cout << "par: " << Par[0] << " " << Par[1] << Par[2] << Par[3] << Par[4] <<std::endl;
-      out.push_back(Par);
-    }
-    //std::cout << "--> in.size(): " << in.size() << std::endl;
-    //std::cout << "--> in.size(): " << in.size() << std::endl;
-    //std::cout << "--> out.size(): " << out.size() << std::endl;
-    //std::cout << "----------------------------" << std::endl;
-    //std::cout << "----------------------------" << std::endl;
-    return out;
-  }
-  
-  */
   ROOT::VecOps::RVec<float> XPtoPar_dxy(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
 					const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
 					const TVector3& V,
@@ -242,7 +178,6 @@ namespace ReconstructedParticle2Track{
 
         TVector3 p(rp.momentum.x, rp.momentum.y, rp.momentum.z);
 
-        //double a = - rp.charge * Bz * cSpeed;
         double a = std::copysign(1.0, rp.charge) * Bz * cSpeed;
 	double pt = p.Pt();
         double C = a/(2 * pt);
@@ -287,43 +222,6 @@ namespace ReconstructedParticle2Track{
 
   
 
-/*  
-  ROOT::VecOps::RVec<float> XPtoPar_dxy(const ROOT::VecOps::RVec<TVectorD>& in) {
-    ROOT::VecOps::RVec<float> out;
-    for(auto & par: in) 
-      out.push_back(par(0));
-    return out;
-  }
-
-  ROOT::VecOps::RVec<float> XPtoPar_dz(const ROOT::VecOps::RVec<TVectorD>& in) {
-    ROOT::VecOps::RVec<float> out;
-    for(auto & par: in)
-      out.push_back(par(3));
-    return out;
-  }
-  
-  ROOT::VecOps::RVec<float> XPtoPar_phi0(const ROOT::VecOps::RVec<TVectorD>& in) {
-    ROOT::VecOps::RVec<float> out;
-    for(auto & par: in)
-      out.push_back(par(1));
-    return out;
-  }
-
-  ROOT::VecOps::RVec<float> XPtoPar_C(const ROOT::VecOps::RVec<TVectorD>& in) {
-    ROOT::VecOps::RVec<float> out;
-    for(auto & par: in)
-      out.push_back(par(2));
-    return out;
-  }
-  
-  ROOT::VecOps::RVec<float> XPtoPar_ct(const ROOT::VecOps::RVec<TVectorD>& in) {
-    ROOT::VecOps::RVec<float> out;
-    for(auto & par: in)
-      out.push_back(par(4));
-    return out;
-  }
-*/
-
 ROOT::VecOps::RVec<float>
 getRP2TRK_D0(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
              ROOT::VecOps::RVec<edm4hep::TrackState> tracks) {
@@ -331,7 +229,6 @@ getRP2TRK_D0(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).D0);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9.);
   }
   return result;
@@ -344,7 +241,6 @@ getRP2TRK_D0_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[0]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9.);
   }
   return result;
@@ -357,7 +253,6 @@ getRP2TRK_D0_sig(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).D0/sqrt(tracks.at(p.tracks_begin).covMatrix[0]));
-    //else result.push_back(std::nan(""));
     else result.push_back(-9.);
   }
   return result;
@@ -370,7 +265,6 @@ getRP2TRK_Z0(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).Z0);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9.);
   }
   return result;
@@ -383,7 +277,6 @@ getRP2TRK_Z0_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[9]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -408,7 +301,6 @@ getRP2TRK_phi(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).phi);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -421,7 +313,6 @@ getRP2TRK_phi_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[2]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -435,7 +326,6 @@ getRP2TRK_omega(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).omega);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -448,7 +338,6 @@ getRP2TRK_omega_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[5]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -461,7 +350,6 @@ getRP2TRK_tanLambda(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).tanLambda);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -474,7 +362,6 @@ getRP2TRK_tanLambda_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> i
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[14]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -487,7 +374,6 @@ getRP2TRK_d0_phi0_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[1]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -500,7 +386,6 @@ getRP2TRK_d0_omega_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[3]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -513,7 +398,6 @@ getRP2TRK_d0_z0_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[6]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -526,7 +410,6 @@ getRP2TRK_d0_tanlambda_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[10]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -539,7 +422,6 @@ getRP2TRK_phi0_omega_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> 
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[4]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -552,7 +434,6 @@ getRP2TRK_phi0_z0_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[7]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -565,7 +446,6 @@ getRP2TRK_phi0_tanlambda_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleDa
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[11]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -578,7 +458,6 @@ getRP2TRK_omega_z0_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[8]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -591,7 +470,6 @@ getRP2TRK_omega_tanlambda_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleD
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[12]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;
@@ -604,7 +482,6 @@ getRP2TRK_z0_tanlambda_cov(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData
   for (auto & p: in) {
     if (p.tracks_begin<tracks.size())
       result.push_back(tracks.at(p.tracks_begin).covMatrix[13]);
-    //else result.push_back(std::nan(""));
     else result.push_back(-9);
   }
   return result;

--- a/examples/FCCee/weaver/README.md
+++ b/examples/FCCee/weaver/README.md
@@ -1,0 +1,368 @@
+# Preparation of dataset
+## Generated samples
+The samples used are stored in the directory `/eos/experiment/fcc/ee/generation/DelphesEvents/pre_fall2022_training/IDEA/` .
+The events were simulated using Delphes. 
+The processes considered are $e^+ e^- \to Z(\to \nu \nu) H(\to aa)$ with $a = u,d,b,c,s,g$.
+For the processes $a =  u,d,b,c,s$ samples of $\sim 10^6$ events were produced (i.e. $2 \times 10^6$ jets per sample), for $a = g$ $\sim 2 \times 10^6$ (i.e. $2 \times 10^6$ jets per sample).
+Beamspot of 20 um size on Y-axis and 600 um on Z-axis was set.
+Tre tree containing the events in the input .root file is called _events_ .
+
+
+## Description and usage
+During the training we want ParticleNet to learn to identify a jet from its properties. This means that each entry of the training dataset should contain the properties of one jet (and of its constituents) which are significant for the discrimination only; furthermore, these properties should be organized in a format accessible to ParticleNet: *arrays*.
+
+However, the samples generated
+* have a per-event structure, 
+* each event contains way more information than the needed one for the training,
+* each event is saved in edm4hep format 
+
+So, before performing the training three actions are required:
+1. read the generated samples in edm4hep format(through fccanalysis),
+2. extract/compute the features of interest (through fccanalysis),
+3. produce the ntuples (one per class) containing the interesting features.
+
+In our case, the first two actions are executed by `stage1.py` and the third by `stage2.cpp` .
+Since we are interested in the final ntuple, these two codes are executed jointly by `produceTrainingTrees_mp.py`, optimizing the times through the usage of multiprocessing.
+So the production of the training dataset from the generated samples is performed in two steps, which in the folloing will be referred to as _Stage1_ and _Stage_ntuple_.
+Even though the joint action of the two steps, an intermediate file is produced by _Stage1_, which will be saved in the ouptut directory (_OUTDIR_), together with the final ntuples but with a recognizable name.
+
+For what concerns time: 
+* _stage1_ takes $\sim 3-4$ minutes per $10^6$ events (run on 8 cpus);
+* _stage2_ takes $\sim 5$ minutes per $10^6$ events (run on 1 cpu).
+
+For what concerns memory usage:
+* intermediate files weight $\sim 4$ Gb per $10^6$ events; 
+* final files weight $\sim 4$ Gb per $10^6$ events;
+
+In our case the directory containing the intermediate and final files weights $\sim 50$ Gb .
+We notice that the intermediate files could be deleted after the production of the final ntuples.
+
+### Stage1 : `stage1.py`
+All the namespaces used are defined and developed inside the folder `analyzers`.
+In particular, in JetConstituentsUtils we developed functions to compute the constituents features and modified ReconstructedParticle2Track in order to return the value $-9$ for particles (neutral) not having a track (the value was chosen arbitrarily, could be changed).
+
+As said, in this stage basically the initial edm4hep files are read and the interesting features are computed. Furthermore, in our version, the clustering is done explicitly. 
+
+In the initial tree each entry corresponds to an event.
+
+Let's go through the code.
+1. explicit clustering. The clustering is done explicitly by the following lines:
+```
+            #===== CLUSTERING
+
+            #define the RP px, py, pz and e
+            .Define("RP_px",          "ReconstructedParticle::get_px(ReconstructedParticles)")
+            .Define("RP_py",          "ReconstructedParticle::get_py(ReconstructedParticles)")
+            .Define("RP_pz",          "ReconstructedParticle::get_pz(ReconstructedParticles)")
+            .Define("RP_e",           "ReconstructedParticle::get_e(ReconstructedParticles)")
+            
+            #build pseudo jets with the RP
+            .Define("pseudo_jets",    "JetClusteringUtils::set_pseudoJets(RP_px, RP_py, RP_pz, RP_e)")
+            #run jet clustering with all reconstructed particles. ee_genkt_algorithm, R=1.5, inclusive clustering, E-scheme
+            .Define("FCCAnalysesJets_ee_genkt", "JetClustering::clustering_ee_genkt(1.5, 0, 0, 0, 0, -1)(pseudo_jets)")
+            #get the jets out of the struct
+            .Define("jets_ee_genkt",           "JetClusteringUtils::get_pseudoJets(FCCAnalysesJets_ee_genkt)")
+            #get the jets constituents out of the struct
+            .Define("jetconstituents_ee_genkt","JetClusteringUtils::get_constituents(FCCAnalysesJets_ee_genkt)")
+```
+In the initial tree, all the particles measured in one event are saved in one entry of the branch _ReconstructedParticles_ in a                                                                 `ROOT::VecOps::RVec<ReconstructedParticleData>`.
+The line `.Define("RP_px",          "ReconstructedParticle::get_px(ReconstructedParticles)")` takes this branch and for all entries computes px of each particle; the output of this call is a branch called _RP_px_ containing an `RVec<float>` per each event.
+
+The jet clustering is performed using the 4-momenta of the reconstructed particles. This operation returns two outputs: 
+  - `jets_ee_genkt` : `RVec< fastjet::Pseudojet >` ; `Pseudojet` methods and attributes allow to access the overall jet properties (implemented in `JetClusteringUtils.cc`).
+  - `jetconstituents_ee_genkt` : `RVec< RVec < int > >` , which is a vector of vectors of integer labels which were assigned to the particles during the clustering by the function `JetClusteringUtils::set_pseudoJets` : 
+```
+std::vector<fastjet::PseudoJet> JetClusteringUtils::set_pseudoJets(ROOT::VecOps::RVec<float> px, 
+					       ROOT::VecOps::RVec<float> py, 
+					       ROOT::VecOps::RVec<float> pz, 
+					       ROOT::VecOps::RVec<float> e) {
+  std::vector<fastjet::PseudoJet> result;
+  unsigned index = 0;
+  for (size_t i = 0; i < px.size(); ++i) {
+    result.emplace_back(px.at(i), py.at(i), pz.at(i), e.at(i));
+    result.back().set_user_index(index);
+    ++index;
+  }
+  return result;
+}
+``` 
+and that are now used to associate the particles to the belonging jet. In fact, by calling
+```
+.Define("JetsConstituents", "JetConstituentsUtils::build_constituents_cluster(ReconstructedParticles, jetconstituents_ee_genkt)") #build jet constituents
+```
+we create an RVec::< RVec < ReconstructedParticleData > > in which the first index _i_ runs over the jets identified in the event and the second _j_ over the particles belonging to the _i_-th jet :
+```
+rv::RVec<FCCAnalysesJetConstituents> build_constituents_cluster(const rv::RVec<edm4hep::ReconstructedParticleData>& rps,
+								    const std::vector<std::vector<int>>& indices) {
+      //std::cout << "... Building jets-constituents after clustering " << std::endl;
+      rv::RVec<FCCAnalysesJetConstituents> jcs;
+      for (const auto& jet_index : indices) {
+	FCCAnalysesJetConstituents jc;
+	for(const auto& const_index : jet_index) {
+	  jc.push_back(rps.at(const_index));
+	}
+	jcs.push_back(jc);
+      }
+      return jcs;
+    }	
+```
+IMPORTANT: this function associates properly jet-constituents because the labels are set to the particles following the order of the particles as they present in the initial entry; so the index coincides with the particle position in the input branch.
+
+The goodness of the association particles-jets was proven by plotting the histograms of the residuals $P^\mu_{jet}-\sum{P^{\mu}_{constituents}})/P^\mu_{jet}$ with $P^\mu = (E, \vec{p})$. Actually the residuals were computed on other 4 quantities which are in one to one relation with 4-momenta: $E, p_t, \phi, \theta$.
+	
+	PLOTS!!!
+
+The structure RVec::< RVec < type > > is the key data structure for treating jets constituents in an event and will be mantained also when computing the features of the constituents for this stage.
+Let's see an example of a function computing a feature of the constituents of the jets in one event (the same structure is mantained for other functions):
+```
+rv::RVec<FCCAnalysesJetConstituentsData> get_erel_log_cluster(const rv::RVec<fastjet::PseudoJet>& jets,
+								  const rv::RVec<FCCAnalysesJetConstituents>& jcs) {
+      rv::RVec<FCCAnalysesJetConstituentsData> out;
+      for (size_t i = 0; i < jets.size(); ++i) {   // external loop: first index (i) running over the jets in the event
+        auto& jet_csts = out.emplace_back();      //in the ext. loop we fill the external vector with vectors 
+						  //(one per jet)
+        float e_jet = jets.at(i).E();
+        auto csts = get_jet_constituents(jcs, i);
+        for (const auto& jc : csts) {                         //second index (j) running over the constituents
+							      //of the i-th jet     
+          float val = (e_jet > 0.) ? jc.energy / e_jet : 1.;
+          float erel_log = float(std::log10(val));
+          jet_csts.emplace_back(erel_log);                    //in the int. loop we fill the internal vectors (jets)
+	  						      //with constituents data
+        }
+      }
+      return out;
+    }
+```
+Notice: the functions are written considering one event, then the processing of all the events in the tree is performed by `fccanalysis run` command (see `produceTrainingTrees_mp.py`).
+
+The computed features were also validated by comparing them with the ones obtained in a previous study by Michele Selvaggi and Loukas Gouskos (samples spring2021). We obtained the following plots.
+	
+	PLOTS!!!
+
+At the end of this stage we have a tree in which each entry is an event; the features of the jets are saved as `RVec < float > ` and the features of the constituents of the jets are saved as `RVec < RVec < float > >` ; the return type is actually a pointer to these structures. We still need to rearrange the structure from a per-event tree of pointers to RVec to a per-jet tree of arrays (an ntuple).
+
+#### What if implicit clustering ?
+	...
+
+### Stage_ntuple : `stage2.cpp`
+The main goal of this stage is to rearrange the tree obtained in _Stage1_ to a per-jet format, but other tasks are accomplished:
+* setting the flags of the class which the jets belong to;
+* checking the number of events actually considered is the wanted one;
+* there is a $\sim 30\%$ cases in which the clustering returns more than 2 jets, and $\sim$ few per million cases in which less than 2 jets are returned; so in the first case just the two higher energy jets are considered, while in the second case no jet is considered; a count of this events is printed to stdout.
+	
+`MakeNtuple_constituents2.cpp` takes 4 arguments: `USAGE: ./MakeNtuple_constituents2 [root_inFileName] [root_outFileName] N_i N_f`
+1. [root_inFileName] : path to input file in the form `path_to_stage1file/stage1_infilename` , 
+2. [root_outFileName] : path to output file in the form `path_to_outputdir/outfilename` ,
+3. N_i : index of the event from where start reading the tree ,
+4. N_f : index of the event ehrtr to stop reading the tree .
+
+Our choices are implemented in the app `produceTrainingTrees_mp.py`, so will be explained in the next section.
+Now, let's go through the code.
+
+###### Loop structure
+
+The general structure of the loop is:
+```
+loop : events {
+	...
+	loop : jets {
+		...
+		loop : constituents {
+			...
+		}
+	ntuple.Fill()  
+	}
+}
+```
+
+The position of ntuple.Fill() inside the loop structure determines the per-jet structure.
+We modified this basic structure:
+* we insert where to start looping by `N_i` and how many events to consider by `Nevents_Max = N_f - N_i`;
+* we loop over the events from N_i to the end of the tree, but introduce an external counter `saved_events_counts` which grows only if the event has been saved; this is the reliable counter! In fact, if the event is "strange" we don't save any jet, we skip to the next event. The loop breaks when `saved_events_counts == Nevents_Max` if the loop has not reached the end of the input file. Let's study different cases:
+    - If `nentries - N_i < Nevents_Max` $\implies$ in the file there are less events than required; no error produced, but in stdout will be printed the actual number of saved events; 
+    - If `nentries - N_i > Nevents_Max` $\implies$ in the file there are exactly $Nevents_{Max}$; 
+    - If `nentries - N_i = Nevents_Max` but there are strange events I will have less saved events, no error, but I know from stdout.
+
+Are considered "strange" events those in which the clustering returns `njets < 2`; in that case we skip the loop. If `njets >= 2` the loop is performed on the first two jets only (the ones having more ENERGY, they're ordered in stage1; the successives not expected: leak in clustering).
+
+```
+int N_i = atoi(argv[3]); //where to start reading the tree
+int N_f = atoi(argv[4]); 
+int Nevents_Max = N_f - N_i;  //number of events to be saved
+int saved_events_counts = 0; //counts the number of events actually saved
+int nentries = ev->GetEntries(); //total number of events in the tree
+
+for(int i = N_i+1; i < nentries; ++i) { // Loop over the events 
+	ev->GetEntry(i);
+    	njet = nJets;
+    
+    	if (njet < 2) {   //exclude the events with less than two jets
+      		continue ;
+    	}
+		     
+	for(int j=0; j < 2; ++j) {   //Loop over the jets inside the i-th event
+	//we only take the first two jets (the ones having more ENERGY, they're ordered in stage1),
+	//the third not expected: leak in clustering
+	
+		...
+	
+		nconst = (count_Const->at(j));
+	
+		for(int k = 0; k < nconst; ++k){ //Loop over the constituents of the j-th jet in the i-th event
+			...
+		}
+		ntuple->Fill();	
+	}
+	saved_events_counts += 1; //we count the num of events saved
+	if (saved_events_counts == Nevents_Max) { //interrupt the loop if Nevents_max events have already been saved
+		break;
+	}
+}
+```
+	
+	
+###### Translating
+As an example, we take one jet feature (stored as `RVec < float> *` in the per-event tree) and one constituent feature (`RVec < RVec < float> > *`) and follow them through the code.
+ 
+```
+//Setting variables for reading
+int nJets; //number of jets in the event
+int nconst = 0; //number of constituents of the jets
+ROOT::VecOps::RVec<float> *Jets_e=0;
+ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_e = 0;
+
+ev->SetBranchAddress("njet", &nJets);
+ev->SetBranchAddress("nconst", &count_Const);
+ev->SetBranchAddress("Jets_e", &Jets_e);
+ev->SetBranchAddress("JetsConstituents_e", &JetsConstituents_e);	
+
+int njet = 0;
+int nconst = 0;	
+double recojet_e; 
+float pfcand_e[1000] = {0.}; //here we initialize wit a large size
+
+ntuple->Branch("nconst", &nconst, "nconst/I");
+ntuple->Branch("recojet_e", &recojet_e);
+ntuple->Branch("pfcand_e", pfcand_e, "pfcand_e[nconst]/F");
+
+loop : i over events
+	loop : j over jets
+	
+		recojet_e = (*Jets_e)[j];       //Pointer usage
+		nconst = (count_Const->at(j));
+	
+		loop : k over constituents
+			pfcand_e[k] = (JetsConstituents_e->at(j))[k]; //k-th element of the j-th vector 
+								      //pointed by JetsConstituents_e
+```
+
+In the ntuple, a jet overall property will be just a `double`.
+Since we don't know a priori how many constituents the jet has, we initialize a constituent feature as an array with a number of elements larger than possible number of constituents, to be sure that we succeed in reading all of them from the input file (this array works as a temporary "home" before being sent to the output file); we initialize all the values to 0. When we create the branch of the ntuple (`ntuple->Branch("pfcand_e", pfcand_e, "pfcand_e[nconst]/F")`), we pass as the size of the entry the actual number of constituents `nconst` which has already been read into another branch (during the loop), in order not to save all the padding zeros contained in the local array.  
+	
+###### Setting the flags
+We read the name and take the character in the name corresponding to the class (in this case last letter before .root); we fix the flag in the beginning and never change it anymore; since it is pointing to the ntuple branch, everytime I call `ntuple.Fill()` the same value will be added to the branch.
+```
+std::string infileName(argv[1]);
+char flavour = infileName[infileName.length()-6];
+
+float is_q = 0.;
+float is_b = 0.;
+float is_c = 0.;
+float is_s = 0.;
+float is_g = 0.;
+
+if (flavour == 'q') {is_q = 1.;}
+if (flavour == 'b') {is_b = 1.;}
+if (flavour == 'c') {is_c = 1.;}
+if (flavour == 's') {is_s = 1.;}
+if (flavour == 'g') {is_g = 1.;}
+if (flavour == 't') {is_t = 1.;}
+
+ntuple->Branch("pfcand_isMu", pfcand_isMu, "pfcand_isMu[nconst]/F");
+ntuple->Branch("pfcand_isEl", pfcand_isEl, "pfcand_isEl[nconst]/F");
+ntuple->Branch("pfcand_isChargedHad", pfcand_isChargedHad, "pfcand_isChargedHad[nconst]/F");
+ntuple->Branch("pfcand_isGamma", pfcand_isGamma, "pfcand_isGamma[nconst]/F");
+ntuple->Branch("pfcand_isNeutralHad", pfcand_isNeutralHad, "pfcand_isNeutralHad[nconst]/F");
+
+loop : events {
+	...
+	loop: jets {
+		...
+		loop: constituents {
+			...
+		}
+	ntuple.Fill() 
+	}
+}	
+```
+
+###### Countings of anomalies and other useful information
+Along the code there are counters of anomalies; these and other information are printed to stdoout.
+
+### Joint run of Stage1 and Stage_ntuple : `produceTrainingTrees_mp.py`
+This app is aimed to run the two stages jointly in an automatized and optimized way using multiprocessing. 
+The command to run `analysis_constituents_stage1_cluster.py` is of the form
+```
+fccanalysis run analysis_constituents_stage1_cluster.py --output PATH_to_OUTFILE/filename.root --files-list PATH_to_INFILE/filename1.root PATH_to_INFILE/filename2.root ... 
+```
+IMPORTANT: This commands accepts wildcard `*` in input.
+
+The command to run `MakeNtuple_constituents2.cpp` is of the form:
+```
+g++ -o MakeNtuple_constituents MakeNtuple_constituents.cpp `root-config --cflags --libs` -Wall
+./MakeNtuple_constituents2 [root_inFileName] [root_outFileName] N_i N_f
+```
+
+The _Stage1_ is sent in parallel by fccanalyses (the number of cores to use has to be set in `analysis_constituents_stage1_cluster.py` as the parameter `ncpus = `), while _Stage_ntuple_ needs to be parallelized.
+
+Few parameters are set:
+* path to initial samples,
+* path the output directory (will store the output files of the two stages),
+* train/test splitting fraction (the _Stage_ntuple_ is run twice, once to create the training dataset and once for the test dataset).
+The code creates a subdirectory inside the indicated output directory, named as `user_date`. 
+Inside this subdirectory the output files of _Stage1_ and _Stage_ntuple_ are created. 
+Furthermore, for each class two `.txt` files are created and `stdout` and `stderr` of the programs are redirected there. 
+
+In our study five classes are considered: $\{ q = (u,d), b, c, s, g\}$; for each class $10^6$ events were considered, and a $train/test$ split fraction of $9/1$ was used. The output directory of both stages is the same: we have one input directory which contains the initial samples and one output directory containing outputs of `Stage1`, `Stage_ntuple` ; the input directory of `Stage_ntuple` is the same as its output directory. 
+
+> Still work in progress ...
+
+## How to run this example
+### Way 1
+###### Set-up
+1. Clone this repository
+2. Set up the environment
+```
+cd FCCAnalyses/
+source ./setup.sh
+mkdir build install
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=../install
+make install
+cd ..
+```
+###### Run
+3. `cd ParticleNet_FCCSW/FCCAnalyses/` 
+4. Set your `outDir` inside `produceTrainingTrees_mp.py`:
+```
+outDIR = "/eos/home-a/adelvecc/try_script_mp/"
+```
+4. `source setup.sh`
+5. `python produceTrainingTrees_mp.py`
+
+### Way 2
+1. Copy the files `analysis_constituents_stage1_cluster.py`, `MakeNtuple_constituents2.cpp` and `produceTrainingTrees_mp.py` inside your FCCAnalyses directory.
+2. Update the file `JetConstituentsUtils` in both `analyzers/dataframe/src/` and `analyzers/dataframe/FCCAnalyses/`
+3. Set your `outDir` inside `produceTrainingTrees_mp.py`
+4. Run `python produceTrainingTrees_mp.py`
+
+
+## What could be improved
+* the stage 1 doesn't reduce the statistics if needed, only in stage_ntuple this is done; this implies heavier intermediate files and longer times even when I want to consider small fractions of the initial samples. Stage_ntuple runs only on the required statistics.
+* beamspot treatment
+* "independently of the process which generated it"
+* ```...```
+
+# Evaluation
+```...```

--- a/examples/FCCee/weaver/all_stages.py
+++ b/examples/FCCee/weaver/all_stages.py
@@ -1,0 +1,145 @@
+import sys
+import os
+import argparse
+import multiprocessing as mp
+import subprocess
+from subprocess import Popen, PIPE
+from datetime import date
+import time
+
+
+# ________________________________________________________________________________
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--indir",
+        help="path input directory",
+        default="/eos/experiment/fcc/ee/generation/DelphesEvents/pre_fall2022_training/IDEA/",
+    )
+    parser.add_argument(
+        "--outdir",
+        help="path output directory",
+        default="/eos/experiment/fcc/ee/jet_flavour_tagging/pre_fall2022_training/IDEA/",
+    )
+    parser.add_argument("--nev", help="number of events", type=int, default=1000000)
+    parser.add_argument("--fsplit", help="fraction train/test", type=float, default=0.9)
+    parser.add_argument("--dry", help="dry run ", action='store_true')
+
+    args = parser.parse_args()
+    inDIR = args.indir
+    outDIR = args.outdir
+
+    # create necessary subdirectories
+    actualDIR = subprocess.check_output(["bash", "-c", "pwd"], universal_newlines=True)[:-1]
+    username = subprocess.check_output(["bash", "-c", "echo $USER"], universal_newlines=True)[:-1]
+    today = date.today().strftime("%Y%b%d")
+    subdir = username + "_" + today
+    subprocess.call(["bash", "-c", "mkdir -p {}".format(subdir)], cwd=outDIR)
+    OUTDIR = outDIR + username + "_" + today + "/"
+    print(OUTDIR)
+
+    # set total number of events
+    N = args.nev
+    frac_split = args.fsplit
+    N_split = int(frac_split * N)
+
+    print("")
+    print("=================================================")
+    print("")
+    print(" INDIR           = {}".format(inDIR))
+    print(" OUTDIR          = {}".format(OUTDIR))
+    print(" NEVENTS         = {}".format(N))
+    print(" FRAC SPLIT      = {}".format(frac_split))
+    print("")
+
+    # compile stage2 c++ code
+    cmd_compile = "g++ -o stage2 stage2.cpp `root-config --cflags --libs` -Wall"
+    subprocess.check_call(cmd_compile, shell=True, stdout=None, stderr=None)
+
+    # create commands
+    #cmdbase_stage1 = "fccanalysis run stage1.py --nevents {}".format(N)
+    cmdbase_stage1 = "fccanalysis run stage1.py".format(N)
+    opt1_out = " --output {}stage1_ee_ZH_vvCLASS.root ".format(OUTDIR)
+    opt1_in = " --files-list {}p8_ee_ZH_Znunu_HCLASS_ecm240/*.root ".format(inDIR)
+    wait = " ; sleep 30;"
+    cmd_stage1 = cmdbase_stage1 + opt1_out + opt1_in
+
+    cmdbase_stagentuple = "./stage2 DIRstage1_ee_ZH_vvCLASS.root  DIRntuple_MOD_ee_ZH_vvCLASS.root "
+    cmd_stage2 = cmdbase_stagentuple.replace("DIR", OUTDIR)
+
+    samples = ["bb", "cc", "ss", "gg", "qq"]
+    mods = ["train", "test"]
+
+    # create files storing stdout and stderr
+    list_stdout = [open(OUTDIR + "{}_stdout.txt".format(sample), "w") for sample in samples]
+    list_stderr = [open(OUTDIR + "{}_stderr.txt".format(sample), "w") for sample in samples]
+
+    ###=== RUN STAGE 1
+    for i, sample in enumerate(samples):
+
+        if sample == "qq":
+            cmd_stage1_f = (
+                cmdbase_stage1
+                + opt1_out.replace("CLASS", "qq")
+                + " --files-list {}p8_ee_ZH_Znunu_Huu_ecm240/*.root {}p8_ee_ZH_Znunu_Hdd_ecm240/*.root".format(
+                    inDIR, inDIR
+                )
+            )
+        else:
+            cmd_stage1_f = cmd_stage1.replace("CLASS", sample)
+
+        print(cmd_stage1_f)
+        # run stage1
+        start1_time = time.time()
+        if not args.dry:    
+            subprocess.check_call(
+                cmd_stage1_f, shell=True, stdout=list_stdout[i], stderr=list_stderr[i]
+            )
+        end1_time = time.time()
+        list_stdout[i].write("Stage1 time: {} \n".format(end1_time - start1_time))
+
+    ###=== RUN STAGE 2
+    threads = []
+    for i, sample in enumerate(samples):
+
+        cmd_stage2_train = cmd_stage2.replace("CLASS", sample).replace(
+            "MOD", mods[0]
+        ) + " {} {} ".format(0, N_split)
+        cmd_stage2_test = cmd_stage2.replace("CLASS", sample).replace(
+            "MOD", mods[1]
+        ) + " {} {} ".format(N_split, N)
+        print(cmd_stage2_train)
+        print(cmd_stage2_test)
+         
+        if not args.dry:
+            thread = mp.Process(
+                target=ntuplizer,
+                args=(cmd_stage2_train, cmd_stage2_test, list_stdout[i], list_stderr[i]),
+            )
+            thread.start()
+            threads.append(thread)
+
+    for proc in threads:
+        proc.join()
+
+
+    for i in range(len(list_stdout)):
+        list_stdout[i].close()
+        list_stderr[i].close()
+
+
+# ________________________________________________________________________________
+def ntuplizer(cmd_stage2_train, cmd_stage2_test, f_stdout, f_stderr):
+
+    start2_time = time.time()
+    subprocess.check_call(cmd_stage2_train, shell=True, stdout=f_stdout, stderr=f_stderr)
+    subprocess.check_call(cmd_stage2_test, shell=True, stdout=f_stdout, stderr=f_stderr)
+    end2_time = time.time()
+    f_stdout.write("stage2 time (run only): {} \n".format(end2_time - start2_time))
+
+
+# _______________________________________________________________________________________
+if __name__ == "__main__":
+    main()
+

--- a/examples/FCCee/weaver/analysis_inference.py
+++ b/examples/FCCee/weaver/analysis_inference.py
@@ -1,0 +1,263 @@
+#Mandatory: List of processes
+processList = {
+    #prefall2022 samples (generated centrally)
+    'p8_ee_ZH_Znunu_Hbb_ecm240':{}, #1030000 events
+    'p8_ee_ZH_Znunu_Hcc_ecm240':{}, #1060000
+    'p8_ee_ZH_Znunu_Hss_ecm240':{}, #1060000 
+    'p8_ee_ZH_Znunu_Hgg_ecm240':{'fraction':0.5}, #2000000 
+    'p8_ee_ZH_Znunu_Huu_ecm240':{'fraction':0.5}, #we take only half sample for uu,dd because they will go into qq label which contains both
+    'p8_ee_ZH_Znunu_Hdd_ecm240':{'fraction':0.5}, #and we want for qq same number of jets as other classes; the two files 2080000 events in total, 1040000 each? 
+}
+
+#Mandatory: Production tag when running over EDM4Hep centrally produced events, this points to the yaml files for getting sample statistics
+#prodTag     = "FCCee/spring2021/IDEA/"
+prodTag     = "FCCee/pre_fall2022_training/IDEA/" #for prefall2022 samples 
+
+#Optional: output directory, default is local running directory
+#outputDir   = "/eos/home-a/adelvecc/FCCevaluate/"
+
+#Optional
+nCPUS       = 8
+runBatch    = False
+#batchQueue = "longlunch"
+#compGroup = "group_u_FCC.local_gen"
+
+
+#USER DEFINED CODE
+
+#Mandatory: RDFanalysis class where the use defines the operations on the TTree
+class RDFanalysis():
+    #__________________________________________________________
+    #Mandatory: analysers funtion to define the analysers to process, please make sure you return the last dataframe, in this example it is df2
+    def analysers(df):
+
+        from ROOT import JetFlavourUtils 
+        weaver = JetFlavourUtils.setup_weaver(
+            "/eos/experiment/fcc/ee/jet_flavour_tagging/pre_fall2022_training/IDEA/selvaggi_2022Oct30/fccee_flavtagging_edm4hep_v2.onnx", #name of the trained model exported 
+            "/eos/experiment/fcc/ee/jet_flavour_tagging/pre_fall2022_training/IDEA/selvaggi_2022Oct30/preprocess_fccee_flavtagging_edm4hep_v2.json", #.json file produced by weaver during training
+            (
+                "pfcand_erel_log", #list of the training variables,
+                "pfcand_thetarel", #will be used for predictions as well
+                "pfcand_phirel",
+                "pfcand_dxy",
+                "pfcand_dz",
+                "pfcand_dptdpt",
+                "pfcand_detadeta",
+                "pfcand_dphidphi",
+                "pfcand_dxydxy",
+                "pfcand_dzdz",
+                "pfcand_dxydz",
+                "pfcand_dphidxy",
+                "pfcand_dlambdadz",
+                "pfcand_dxyc",
+                "pfcand_dxyctgtheta",
+                "pfcand_phic",
+                "pfcand_phidz",
+                "pfcand_phictgtheta",
+                "pfcand_cdz",
+                "pfcand_cctgtheta",
+                "pfcand_mtof",
+                "pfcand_dndx",
+                "pfcand_charge",
+                "pfcand_isMu",
+                "pfcand_isEl",
+                "pfcand_isChargedHad",
+                "pfcand_isGamma",
+                "pfcand_isNeutralHad",
+                "pfcand_btagSip2dVal",
+                "pfcand_btagSip2dSig",
+                "pfcand_btagSip3dVal",
+                "pfcand_btagSip3dSig",
+                "pfcand_btagJetDistVal",
+                "pfcand_btagJetDistSig",
+            ),
+        )
+
+        df2 = (
+            df
+            ### COMPUTE THE VARIABLES FOR INFERENCE OF THE TRAINING MODEL
+            ### This section should be equal to the one used for training
+
+            ### MC primary vertex
+            .Define("MC_PrimaryVertex",  "FCCAnalyses::MCParticle::get_EventPrimaryVertex(21)( Particle )" )
+
+            # CLUSTERING 
+            #define the RP px, py, pz and e
+            .Define("RP_px",          "ReconstructedParticle::get_px(ReconstructedParticles)")
+            .Define("RP_py",          "ReconstructedParticle::get_py(ReconstructedParticles)")
+            .Define("RP_pz",          "ReconstructedParticle::get_pz(ReconstructedParticles)")
+            .Define("RP_e",           "ReconstructedParticle::get_e(ReconstructedParticles)")
+            .Define("RP_m",           "ReconstructedParticle::get_mass(ReconstructedParticles)")
+            .Define("RP_q",           "ReconstructedParticle::get_charge(ReconstructedParticles)")
+            
+            #build pseudo jets with the RP
+            .Define("pseudo_jets",    "JetClusteringUtils::set_pseudoJets(RP_px, RP_py, RP_pz, RP_e)")
+            #run jet clustering with all reconstructed particles. ee_genkt_algorithm, R=1.5, inclusive clustering, E-scheme
+            .Define("FCCAnalysesJets_ee_genkt", "JetClustering::clustering_ee_genkt(1.5, 0, 0, 0, 0, -1)(pseudo_jets)")
+            #get the jets out of the struct
+            .Define("jets_ee_genkt",           "JetClusteringUtils::get_pseudoJets(FCCAnalysesJets_ee_genkt)")
+            #get the jets constituents out of the struct 
+            .Define("jetconstituents_ee_genkt","JetClusteringUtils::get_constituents(FCCAnalysesJets_ee_genkt)")
+            
+            #===== COMPUTE TRAINING FEATURES
+            
+            .Define("JetsConstituents", "JetConstituentsUtils::build_constituents_cluster(ReconstructedParticles, jetconstituents_ee_genkt)") #build jet constituents lists
+
+            ### Types of particles 
+            .Alias("MCRecoAssociations0", "MCRecoAssociations#0.index")
+            .Alias("MCRecoAssociations1", "MCRecoAssociations#1.index")
+            .Define("JetsConstituents_Pids", "JetConstituentsUtils::get_PIDs_cluster(MCRecoAssociations0, MCRecoAssociations1, ReconstructedParticles, Particle, jetconstituents_ee_genkt)")
+            
+            .Define("pfcand_isMu", "JetConstituentsUtils::get_isMu(JetsConstituents_Pids)")
+            .Define("pfcand_isEl", "JetConstituentsUtils::get_isEl(JetsConstituents_Pids)")
+            .Define("pfcand_isChargedHad", "JetConstituentsUtils::get_isChargedHad(JetsConstituents_Pids, JetsConstituents)")
+            .Define("pfcand_isGamma", "JetConstituentsUtils::get_isGamma(JetsConstituents_Pids)")
+            .Define("pfcand_isNeutralHad", "JetConstituentsUtils::get_isNeutralHad(JetsConstituents_Pids, JetsConstituents)")
+            
+            ### Kinematics, displacement, PID
+
+            .Define("pfcand_erel", "JetConstituentsUtils::get_erel_cluster(jets_ee_genkt, JetsConstituents)")
+            .Define("pfcand_erel_log", "JetConstituentsUtils::get_erel_log_cluster(jets_ee_genkt, JetsConstituents)")
+            .Define("pfcand_thetarel", "JetConstituentsUtils::get_thetarel_cluster(jets_ee_genkt, JetsConstituents)")
+            .Define("pfcand_phirel", "JetConstituentsUtils::get_phirel_cluster(jets_ee_genkt, JetsConstituents)")
+
+            .Define("pfcand_charge", "JetConstituentsUtils::get_charge(JetsConstituents)")
+            .Define("pfcand_dndx", "JetConstituentsUtils::get_dndx(JetsConstituents, EFlowTrack_2, EFlowTrack, pfcand_isChargedHad)")
+            .Define("pfcand_mtof", "JetConstituentsUtils::get_mtof(JetsConstituents, EFlowTrack_L, EFlowTrack, TrackerHits, JetsConstituents_Pids)")
+
+            .Define("Bz", "ReconstructedParticle2Track::Bz(ReconstructedParticles, EFlowTrack_1)")
+
+            .Define("pfcand_dxy", "JetConstituentsUtils::XPtoPar_dxy(JetsConstituents, EFlowTrack_1, MC_PrimaryVertex, Bz)")
+            .Define("pfcand_dz", "JetConstituentsUtils::XPtoPar_dz(JetsConstituents, EFlowTrack_1, MC_PrimaryVertex, Bz)")
+            .Define("pfcand_phi0", "JetConstituentsUtils::XPtoPar_phi(JetsConstituents, EFlowTrack_1, MC_PrimaryVertex, Bz)")
+            .Define("pfcand_C", "JetConstituentsUtils::XPtoPar_C(JetsConstituents, EFlowTrack_1, MC_PrimaryVertex, Bz)")
+            .Define("pfcand_ct", "JetConstituentsUtils::XPtoPar_ct(JetsConstituents, EFlowTrack_1, MC_PrimaryVertex, Bz)")
+
+            .Define("pfcand_dptdpt", "JetConstituentsUtils::get_omega_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("pfcand_dxydxy", "JetConstituentsUtils::get_d0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("pfcand_dzdz", "JetConstituentsUtils::get_z0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("pfcand_dphidphi", "JetConstituentsUtils::get_phi0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("pfcand_detadeta", "JetConstituentsUtils::get_tanlambda_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("pfcand_dxydz", "JetConstituentsUtils::get_d0_z0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("pfcand_dphidxy", "JetConstituentsUtils::get_phi0_d0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("pfcand_phidz", "JetConstituentsUtils::get_phi0_z0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("pfcand_phictgtheta", "JetConstituentsUtils::get_tanlambda_phi0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("pfcand_dxyctgtheta", "JetConstituentsUtils::get_tanlambda_d0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("pfcand_dlambdadz", "JetConstituentsUtils::get_tanlambda_z0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("pfcand_cctgtheta", "JetConstituentsUtils::get_omega_tanlambda_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("pfcand_phic", "JetConstituentsUtils::get_omega_phi0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("pfcand_dxyc", "JetConstituentsUtils::get_omega_d0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("pfcand_cdz", "JetConstituentsUtils::get_omega_z0_cov(JetsConstituents, EFlowTrack_1)")
+
+            .Define("pfcand_btagSip2dVal", "JetConstituentsUtils::get_Sip2dVal_clusterV(jets_ee_genkt, pfcand_dxy, pfcand_phi0, MC_PrimaryVertex, Bz)")
+            .Define("pfcand_btagSip2dSig", "JetConstituentsUtils::get_Sip2dSig(pfcand_btagSip2dVal, pfcand_dxydxy)")
+            .Define("pfcand_btagSip3dVal", "JetConstituentsUtils::get_Sip3dVal_clusterV(jets_ee_genkt, pfcand_dxy, pfcand_dz, pfcand_phi0, MC_PrimaryVertex, Bz)")
+            .Define("pfcand_btagSip3dSig", "JetConstituentsUtils::get_Sip3dSig(pfcand_btagSip3dVal, pfcand_dxydxy, pfcand_dzdz)")
+            .Define("pfcand_btagJetDistVal", "JetConstituentsUtils::get_JetDistVal_clusterV(jets_ee_genkt, JetsConstituents, pfcand_dxy, pfcand_dz, pfcand_phi0, MC_PrimaryVertex, Bz)")
+            .Define("pfcand_btagJetDistSig", "JetConstituentsUtils::get_JetDistSig(pfcand_btagJetDistVal, pfcand_dxydxy, pfcand_dzdz)")
+
+       
+            ##### RUN INFERENCE (fixed by the previous section)
+
+            .Define(
+                "MVAVec",
+                "JetFlavourUtils::get_weights(\
+                    pfcand_erel_log,\
+                    pfcand_thetarel,\
+                    pfcand_phirel,\
+                    pfcand_dxy,\
+                    pfcand_dz,\
+                    pfcand_dptdpt,\
+                    pfcand_dphidphi,\
+                    pfcand_detadeta,\
+                    pfcand_dxydxy,\
+                    pfcand_dzdz,\
+                    pfcand_dxydz,\
+                    pfcand_dphidxy,\
+                    pfcand_dlambdadz,\
+                    pfcand_dxyc,\
+                    pfcand_dxyctgtheta,\
+                    pfcand_phic,\
+                    pfcand_phidz,\
+                    pfcand_phictgtheta,\
+                    pfcand_cdz,\
+                    pfcand_cctgtheta,\
+                    pfcand_mtof,\
+                    pfcand_dndx,\
+                    pfcand_charge,\
+                    pfcand_isMu,\
+                    pfcand_isEl,\
+                    pfcand_isChargedHad,\
+                    pfcand_isGamma,\
+                    pfcand_isNeutralHad,\
+                    pfcand_btagSip2dVal,\
+                    pfcand_btagSip2dSig,\
+                    pfcand_btagSip3dVal,\
+                    pfcand_btagSip3dSig,\
+                    pfcand_btagJetDistVal,\
+                    pfcand_btagJetDistSig\
+               )",
+            )              
+            
+            ##### RECAST OUTPUT (get predictions per each sample)
+            .Define("recojet_isG", "JetFlavourUtils::get_weight(MVAVec, 0)")
+            .Define("recojet_isQ", "JetFlavourUtils::get_weight(MVAVec, 1)")
+            .Define("recojet_isS", "JetFlavourUtils::get_weight(MVAVec, 2)")
+            .Define("recojet_isC", "JetFlavourUtils::get_weight(MVAVec, 3)")
+            .Define("recojet_isB", "JetFlavourUtils::get_weight(MVAVec, 4)")
+                        
+            ##### COMPUTE OBSERVABLES FOR ANALYSIS 
+            #if not changing training etc... but only interested in the analysis using a trained model (fixed classes), you should only operate in this section.
+            #if you're interested in saving variables used for training don't need to compute them again, just
+            #add them to the list in at the end of the code
+            
+            #EXAMPLE
+
+            #EVENT LEVEL
+            .Define("njet", "JetConstituentsUtils::count_jets(JetsConstituents)")
+
+            #JET LEVEL
+            #jet kinematics
+            .Define("recojet_pt",        "JetClusteringUtils::get_pt(jets_ee_genkt)")
+            .Define("recojet_e",        "JetClusteringUtils::get_e(jets_ee_genkt)")
+            .Define("recojet_mass",        "JetClusteringUtils::get_m(jets_ee_genkt)")
+            .Define("recojet_phi",        "JetClusteringUtils::get_phi(jets_ee_genkt)")
+            .Define("recojet_theta",        "JetClusteringUtils::get_theta(jets_ee_genkt)")
+
+            .Define("tlv_jets", "JetConstituentsUtils::compute_tlv_jets(jets_ee_genkt)")
+            .Define("invariant_mass", "JetConstituentsUtils::InvariantMass(tlv_jets[0], tlv_jets[1])")
+
+            #counting types of particles composing the jet
+            .Define("nconst", "JetConstituentsUtils::count_consts(JetsConstituents)")
+            .Define("nmu", "JetConstituentsUtils::count_type(pfcand_isMu)")
+            .Define("nel", "JetConstituentsUtils::count_type(pfcand_isEl)")
+            .Define("nchargedhad", "JetConstituentsUtils::count_type(pfcand_isChargedHad)")
+            .Define("nphoton", "JetConstituentsUtils::count_type(pfcand_isGamma)")
+            .Define("nneutralhad", "JetConstituentsUtils::count_type(pfcand_isNeutralHad)")
+
+            #CONSTITUENTS LEVEL
+            .Define("pfcand_e", "JetConstituentsUtils::get_e(JetsConstituents)")
+            .Define("pfcand_pt", "JetConstituentsUtils::get_pt(JetsConstituents)")
+            .Define("pfcand_theta", "JetConstituentsUtils::get_theta(JetsConstituents)")
+            .Define("pfcand_phi", "JetConstituentsUtils::get_phi(JetsConstituents)")
+
+        )
+
+        return df2
+
+    #__________________________________________________________
+    #SAVE PREDICTIONS & OBSERVABLES FOR ANALYSIS
+    #Mandatory: output function, please make sure you return the branchlist as a python list
+    def output():
+        branchList = [
+            #predictions
+            'recojet_isG', 'recojet_isQ', 'recojet_isS', 'recojet_isC', 'recojet_isB',
+            #observables
+            'recojet_mass', 'recojet_e', 'recojet_pt',
+            'invariant_mass', 
+            'nconst', 'nchargedhad',
+            'pfcand_e', 'pfcand_pt', 'pfcand_phi',
+            'pfcand_erel', 
+            'pfcand_erel_log',
+        ]
+        return branchList

--- a/examples/FCCee/weaver/stage1.py
+++ b/examples/FCCee/weaver/stage1.py
@@ -1,0 +1,193 @@
+processList = {
+    #prefall2022 samples (generated centrally)
+    'p8_ee_ZH_Znunu_Hbb_ecm240':{}, #1030000 events
+    'p8_ee_ZH_Znunu_Hcc_ecm240':{}, #1060000
+    'p8_ee_ZH_Znunu_Hss_ecm240':{}, #1060000
+    'p8_ee_ZH_Znunu_Hgg_ecm240':{'fraction':0.5}, #2000000
+    'p8_ee_ZH_Znunu_Huu_ecm240':{'fraction':0.5}, #we take only half sample for uu,dd because they will go into qq label which contains both
+    'p8_ee_ZH_Znunu_Hdd_ecm240':{'fraction':0.5}, #and we want for qq same number of jets as other classes; the two files 2080000 events in total, 1040000 each? 
+}
+
+
+#prodTag     = "FCCee/spring2021/IDEA/" #for spring2022 samples
+prodTag     = "FCCee/pre_fall2022_training/IDEA/" #for prefall2022 samples
+
+#outputDir   = ""
+
+#Optional: ncpus, default is 4                       
+nCPUS       = 8
+
+
+class RDFanalysis():
+
+    def analysers(df):
+        
+        df2 = (
+            df
+
+            #===== VERTEX
+            
+            #MC primary vertex
+            .Define("MC_PrimaryVertex",  "FCCAnalyses::MCParticle::get_EventPrimaryVertex(21)( Particle )" )
+
+            #===== CLUSTERING
+            #define the RP px, py, pz and e
+            .Define("RP_px",          "ReconstructedParticle::get_px(ReconstructedParticles)")
+            .Define("RP_py",          "ReconstructedParticle::get_py(ReconstructedParticles)")
+            .Define("RP_pz",          "ReconstructedParticle::get_pz(ReconstructedParticles)")
+            .Define("RP_e",           "ReconstructedParticle::get_e(ReconstructedParticles)")
+            .Define("RP_m",           "ReconstructedParticle::get_mass(ReconstructedParticles)")
+            .Define("RP_q",           "ReconstructedParticle::get_charge(ReconstructedParticles)")
+            
+            #build pseudo jets with the RP, using the interface that takes px,py,pz,E
+            #.Define("pseudo_jets",    "JetClusteringUtils::set_pseudoJets_xyzm(RP_px, RP_py, RP_pz, RP_m)")
+            .Define("pseudo_jets",    "JetClusteringUtils::set_pseudoJets(RP_px, RP_py, RP_pz, RP_e)")
+            #run jet clustering with all reconstructed particles. ee_genkt_algorithm, R=1.5, inclusive clustering, E-scheme
+            .Define("FCCAnalysesJets_ee_genkt", "JetClustering::clustering_ee_genkt(1.5, 0, 0, 0, 0, -1)(pseudo_jets)")
+            #get the jets out of the struct
+            .Define("jets_ee_genkt",           "JetClusteringUtils::get_pseudoJets(FCCAnalysesJets_ee_genkt)")
+            #get the jets constituents out of the struct
+            .Define("jetconstituents_ee_genkt","JetClusteringUtils::get_constituents(FCCAnalysesJets_ee_genkt)")
+
+
+            #===== OBSERVABLES
+            #JET LEVEL
+            ###.Define("Jets_px",        "JetClusteringUtils::get_px(jets_ee_genkt)")  #jets_ee_genkt_px
+            ###.Define("Jets_py",        "JetClusteringUtils::get_py(jets_ee_genkt)")
+            ###.Define("Jets_pz",        "JetClusteringUtils::get_pz(jets_ee_genkt)")
+            
+            .Define("Jets_pt",        "JetClusteringUtils::get_pt(jets_ee_genkt)")
+            .Define("Jets_e",        "JetClusteringUtils::get_e(jets_ee_genkt)")
+            .Define("Jets_mass",        "JetClusteringUtils::get_m(jets_ee_genkt)")
+            .Define("Jets_phi",        "JetClusteringUtils::get_phi(jets_ee_genkt)")
+            .Define("Jets_theta",        "JetClusteringUtils::get_theta(jets_ee_genkt)")
+
+            #CONSTITUENT LEVEL
+            .Define("JetsConstituents", "JetConstituentsUtils::build_constituents_cluster(ReconstructedParticles, jetconstituents_ee_genkt)") #build jet constituents lists
+        
+            #getting the types of particles 
+            .Alias("MCRecoAssociations0", "MCRecoAssociations#0.index")
+            .Alias("MCRecoAssociations1", "MCRecoAssociations#1.index")
+            .Define("JetsConstituents_Pids", "JetConstituentsUtils::get_PIDs_cluster(MCRecoAssociations0, MCRecoAssociations1, ReconstructedParticles, Particle, jetconstituents_ee_genkt)")
+            .Define("JetsConstituents_isMu", "JetConstituentsUtils::get_isMu(JetsConstituents_Pids)")
+            .Define("JetsConstituents_isEl", "JetConstituentsUtils::get_isEl(JetsConstituents_Pids)")
+            .Define("JetsConstituents_isChargedHad", "JetConstituentsUtils::get_isChargedHad(JetsConstituents_Pids, JetsConstituents)")
+            .Define("JetsConstituents_isGamma", "JetConstituentsUtils::get_isGamma(JetsConstituents_Pids)")
+            .Define("JetsConstituents_isNeutralHad", "JetConstituentsUtils::get_isNeutralHad(JetsConstituents_Pids, JetsConstituents)")
+
+            #kinematics, displacement, PID
+            .Define("JetsConstituents_e", "JetConstituentsUtils::get_e(JetsConstituents)")
+            .Define("JetsConstituents_pt", "JetConstituentsUtils::get_pt(JetsConstituents)")
+            .Define("JetsConstituents_theta", "JetConstituentsUtils::get_theta(JetsConstituents)")
+            .Define("JetsConstituents_phi", "JetConstituentsUtils::get_phi(JetsConstituents)")
+            .Define("JetsConstituents_charge", "JetConstituentsUtils::get_charge(JetsConstituents)")
+
+            .Define("JetsConstituents_erel", "JetConstituentsUtils::get_erel_cluster(jets_ee_genkt, JetsConstituents)")
+            .Define("JetsConstituents_erel_log", "JetConstituentsUtils::get_erel_log_cluster(jets_ee_genkt, JetsConstituents)")
+            .Define("JetsConstituents_thetarel", "JetConstituentsUtils::get_thetarel_cluster(jets_ee_genkt, JetsConstituents)")
+            .Define("JetsConstituents_phirel", "JetConstituentsUtils::get_phirel_cluster(jets_ee_genkt, JetsConstituents)") 
+            
+            .Define("JetsConstituents_dndx", "JetConstituentsUtils::get_dndx(JetsConstituents, EFlowTrack_2, EFlowTrack, JetsConstituents_isChargedHad)")
+            .Define("JetsConstituents_mtof", "JetConstituentsUtils::get_mtof(JetsConstituents, EFlowTrack_L, EFlowTrack, TrackerHits, JetsConstituents_Pids)")
+            
+            .Define("JetsConstituents_d0_wrt0", "JetConstituentsUtils::get_d0(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_z0_wrt0", "JetConstituentsUtils::get_z0(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_phi0_wrt0", "JetConstituentsUtils::get_phi0(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_omega_wrt0", "JetConstituentsUtils::get_omega(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_tanlambda_wrt0", "JetConstituentsUtils::get_tanLambda(JetsConstituents, EFlowTrack_1)")
+
+            .Define("JetsConstituents_Bz", "JetConstituentsUtils::get_Bz(JetsConstituents, EFlowTrack_1)")
+            .Define("Bz", "ReconstructedParticle2Track::Bz(ReconstructedParticles, EFlowTrack_1)")
+            
+            #.Define("JetsConstituents_Par", "ReconstructedParticle2Track::XPtoPar(ReconstructedParticles, EFlowTrack_1, MC_PrimaryVertex, Bz)")
+            #.Define("JetsConstituents_dxy", "JetConstituentsUtils::XPtoPar_dxy(JetsConstituents_Par)")
+            #.Define("JetsConstituents_dxy", "JetConstituentsUtils::XPtoPar_dxy(JetsConstituents_Par)")
+            #.Define("JetsConstituents_dz", "JetConstituentsUtils::XPtoPar_dz(JetsConstituents_Par)")
+            #.Define("JetsConstituents_phi0", "JetConstituentsUtils::XPtoPar_phi0(JetsConstituents_Par)")
+            #.Define("JetsConstituents_C", "JetConstituentsUtils::XPtoPar_C(JetsConstituents_Par)")
+            #.Define("JetsConstituents_ct", "JetConstituentsUtils::XPtoPar_ct(JetsConstituents_Par)")
+
+            .Define("JetsConstituents_dxy", "JetConstituentsUtils::XPtoPar_dxy(JetsConstituents, EFlowTrack_1, MC_PrimaryVertex, Bz)")
+            .Define("JetsConstituents_dz", "JetConstituentsUtils::XPtoPar_dz(JetsConstituents, EFlowTrack_1, MC_PrimaryVertex, Bz)")
+            .Define("JetsConstituents_phi0", "JetConstituentsUtils::XPtoPar_phi(JetsConstituents, EFlowTrack_1, MC_PrimaryVertex, Bz)")
+            .Define("JetsConstituents_C", "JetConstituentsUtils::XPtoPar_C(JetsConstituents, EFlowTrack_1, MC_PrimaryVertex, Bz)")
+            .Define("JetsConstituents_ct", "JetConstituentsUtils::XPtoPar_ct(JetsConstituents, EFlowTrack_1, MC_PrimaryVertex, Bz)")
+
+            .Define("JetsConstituents_omega_cov", "JetConstituentsUtils::get_omega_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_d0_cov", "JetConstituentsUtils::get_d0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_z0_cov", "JetConstituentsUtils::get_z0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_phi0_cov", "JetConstituentsUtils::get_phi0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_tanlambda_cov", "JetConstituentsUtils::get_tanlambda_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_d0_z0_cov", "JetConstituentsUtils::get_d0_z0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_phi0_d0_cov", "JetConstituentsUtils::get_phi0_d0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_phi0_z0_cov", "JetConstituentsUtils::get_phi0_z0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_tanlambda_phi0_cov", "JetConstituentsUtils::get_tanlambda_phi0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_tanlambda_d0_cov", "JetConstituentsUtils::get_tanlambda_d0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_tanlambda_z0_cov", "JetConstituentsUtils::get_tanlambda_z0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_omega_tanlambda_cov", "JetConstituentsUtils::get_omega_tanlambda_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_omega_phi0_cov", "JetConstituentsUtils::get_omega_phi0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_omega_d0_cov", "JetConstituentsUtils::get_omega_d0_cov(JetsConstituents, EFlowTrack_1)")
+            .Define("JetsConstituents_omega_z0_cov", "JetConstituentsUtils::get_omega_z0_cov(JetsConstituents, EFlowTrack_1)")
+            
+            .Define("JetsConstituents_Sip2dVal", "JetConstituentsUtils::get_Sip2dVal_clusterV(jets_ee_genkt, JetsConstituents_dxy, JetsConstituents_phi0, MC_PrimaryVertex, Bz)")
+            .Define("JetsConstituents_Sip2dSig", "JetConstituentsUtils::get_Sip2dSig(JetsConstituents_Sip2dVal, JetsConstituents_d0_cov)")
+            .Define("JetsConstituents_Sip3dVal", "JetConstituentsUtils::get_Sip3dVal_clusterV(jets_ee_genkt, JetsConstituents_dxy, JetsConstituents_dz, JetsConstituents_phi0, MC_PrimaryVertex, Bz)")
+            .Define("JetsConstituents_Sip3dSig", "JetConstituentsUtils::get_Sip3dSig(JetsConstituents_Sip3dVal, JetsConstituents_d0_cov, JetsConstituents_z0_cov)")
+            .Define("JetsConstituents_JetDistVal", "JetConstituentsUtils::get_JetDistVal_clusterV(jets_ee_genkt, JetsConstituents, JetsConstituents_dxy, JetsConstituents_dz, JetsConstituents_phi0, MC_PrimaryVertex, Bz)")
+            .Define("JetsConstituents_JetDistSig", "JetConstituentsUtils::get_JetDistSig(JetsConstituents_JetDistVal, JetsConstituents_d0_cov, JetsConstituents_z0_cov)")
+
+            #counting the types of particles per jet
+            .Define("njet", "JetConstituentsUtils::count_jets(JetsConstituents)")
+            .Define("nconst", "JetConstituentsUtils::count_consts(JetsConstituents)")
+            .Define("nmu", "JetConstituentsUtils::count_type(JetsConstituents_isMu)")
+            .Define("nel", "JetConstituentsUtils::count_type(JetsConstituents_isEl)")
+            .Define("nchargedhad", "JetConstituentsUtils::count_type(JetsConstituents_isChargedHad)")
+            .Define("nphoton", "JetConstituentsUtils::count_type(JetsConstituents_isGamma)")
+            .Define("nneutralhad", "JetConstituentsUtils::count_type(JetsConstituents_isNeutralHad)")
+        
+            #compute the residues jet-constituents on significant kinematic variables as a check
+            .Define("tlv_jets", "JetConstituentsUtils::compute_tlv_jets(jets_ee_genkt)")
+            .Define("sum_tlv_jcs", "JetConstituentsUtils::sum_tlv_constituents(JetsConstituents)")
+            .Define("de", "JetConstituentsUtils::compute_residue_energy(tlv_jets, sum_tlv_jcs)")
+            .Define("dpt", "JetConstituentsUtils::compute_residue_pt(tlv_jets, sum_tlv_jcs)")
+            .Define("dphi", "JetConstituentsUtils::compute_residue_phi(tlv_jets, sum_tlv_jcs)")
+            .Define("dtheta", "JetConstituentsUtils::compute_residue_theta(tlv_jets, sum_tlv_jcs)")
+            
+            #.Define("Invariant_mass", "ROOT::VecOps::InvariantMasses(jets_ee_genkt[0].pt(), jets_ee_genkt[0].rap(), jets_ee_genkt[0].phi(), jets_ee_genkt[0].m(), jets_ee_genkt[1].pt(), jets_ee_genkt[1].rap(), jets_ee_genkt[1].phi(), jets_ee_genkt[1].m())); 
+            .Define("invariant_mass", "JetConstituentsUtils::InvariantMass(tlv_jets[0], tlv_jets[1])")
+        )
+        return df2
+
+    def output():
+        branchList = [
+            #'RP_px', 'RP_py','RP_pz','RP_e', 'RP_m', 'RP_q',
+            #'Jets_px', 'Jets_py', 'Jets_pz',
+            'Jets_e', 'Jets_mass', 'Jets_pt', 'Jets_phi', 'Jets_theta',
+            'JetsConstituents_e', 'JetsConstituents_pt', 'JetsConstituents_theta', 'JetsConstituents_phi', 'JetsConstituents_charge',
+            'JetsConstituents_erel', 'JetsConstituents_erel_log', 'JetsConstituents_thetarel', 'JetsConstituents_phirel', 
+            'JetsConstituents_dndx', 'JetsConstituents_mtof',
+            
+            'JetsConstituents_d0_wrt0', 'JetsConstituents_z0_wrt0', 'JetsConstituents_phi0_wrt0', 'JetsConstituents_omega_wrt0', 'JetsConstituents_tanlambda_wrt0',
+            'Bz', 'JetsConstituents_Bz',
+            #'JetsConstituents_Par',
+            'JetsConstituents_dxy', 'JetsConstituents_dz', 'JetsConstituents_phi0', 'JetsConstituents_C', 'JetsConstituents_ct',
+
+            'JetsConstituents_omega_cov', 'JetsConstituents_d0_cov', 'JetsConstituents_z0_cov', 'JetsConstituents_phi0_cov', 'JetsConstituents_tanlambda_cov',
+            'JetsConstituents_d0_z0_cov', 'JetsConstituents_phi0_d0_cov', 'JetsConstituents_phi0_z0_cov', 
+            'JetsConstituents_tanlambda_phi0_cov', 'JetsConstituents_tanlambda_d0_cov', 'JetsConstituents_tanlambda_z0_cov', 
+            'JetsConstituents_omega_tanlambda_cov', 'JetsConstituents_omega_phi0_cov', 'JetsConstituents_omega_d0_cov', 'JetsConstituents_omega_z0_cov', 
+            'JetsConstituents_Sip2dVal', 'JetsConstituents_Sip2dSig', 
+            'JetsConstituents_Sip3dVal', 'JetsConstituents_Sip3dSig', 
+            'JetsConstituents_JetDistVal', 'JetsConstituents_JetDistSig',
+            #'JC_Jet0_Pids',
+            'JetsConstituents_isMu', 
+            'JetsConstituents_isEl', 
+            'JetsConstituents_isChargedHad',
+            'JetsConstituents_isGamma', 
+            'JetsConstituents_isNeutralHad',
+            'njet', 'nconst', 
+            'nmu', 'nel', 'nchargedhad', 'nphoton', 'nneutralhad',
+            'de', 'dpt', 'dphi', 'dtheta',
+            'invariant_mass'
+        ]
+        return branchList    

--- a/examples/FCCee/weaver/stage2.cpp
+++ b/examples/FCCee/weaver/stage2.cpp
@@ -17,9 +17,6 @@
 #include <Rtypes.h>
 #include "ROOT/RVec.hxx"
 
-//My header files 
-
-//My funcs
 
 
 

--- a/examples/FCCee/weaver/stage2.cpp
+++ b/examples/FCCee/weaver/stage2.cpp
@@ -1,0 +1,538 @@
+//standard library header files
+#include <vector>
+#include <iostream>
+#include <fstream>
+#include <iomanip>
+#include <cmath>
+
+
+
+//ROOT header files
+#include "TH1F.h"
+#include "TCanvas.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TString.h"
+#include "TStyle.h"
+#include <Rtypes.h>
+#include "ROOT/RVec.hxx"
+
+//My header files 
+
+//My funcs
+
+
+
+int main(int argc, char* argv[]) {
+
+  //usage
+  if( argc!= 5 ) {
+    std::cerr << "USAGE: ./to_jetntuple [root_inFileName] [root_outFileName] N_i N_f" << std::endl;
+    exit(1);
+  }
+ 
+  //std::string inDir = "";
+  std::string infileName(argv[1]);
+  //Opening the input file containing the tree (output of fcc analyses_jets_stage1.py)
+  TFile* infile = TFile::Open(infileName.c_str());
+  if( !infile->IsOpen() ){
+    std::cerr << "Problems opening root file. Exiting." << std::endl;
+    exit(-1);
+  }
+  std::cout << "-> Opened file " << infileName.c_str()  << std::endl;
+  //Get pointer to tree object  
+
+  //std::cout << "infileName lenght: " << infileName.length() << std::endl;
+  char flavour = infileName[infileName.length()-6];
+  std::cout << "flavour: " << flavour << std::endl;
+                                                                   
+  TTree* ev = (TTree*)infile->Get("events");
+  if(!ev) {
+    std::cerr << "null pointer for TTree! Exiting." << std::endl;
+    exit(-2);
+  }
+  std::cout << "-> Opened tree " << "events" << std::endl;
+  //variables to be read from the tree
+  //event properties
+  ROOT::VecOps::RVec<float> *Jets_e=0;
+  ROOT::VecOps::RVec<float> *Jets_mass=0;
+  ROOT::VecOps::RVec<float> *Jets_pt = 0;
+  ROOT::VecOps::RVec<float> *Jets_phi = 0;
+  ROOT::VecOps::RVec<float> *Jets_theta = 0;
+
+  int nJets;
+  //float Bz_i;
+  
+  //properties of constituents
+  
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_e = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_pt = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_theta = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_phi = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_charge = 0;
+  
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_erel = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_erel_log = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_thetarel = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_phirel = 0;
+  
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_dndx = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_mtof = 0;
+
+  //ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_d0_wrt0 = 0;
+  //ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_z0_wrt0 = 0;
+  //ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_phi0_wrt0 = 0;
+  //ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_omega_wrt0 = 0;
+  //ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_tanlambda_wrt0 = 0;
+  
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_dxy = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_dz = 0;
+  //ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_phi0 = 0;
+  //ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_C = 0;
+  //ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_ct = 0;
+
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_omega_cov = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_d0_cov = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_z0_cov = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_phi0_cov = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_tanlambda_cov = 0;
+  
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_d0_z0_cov = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_phi0_d0_cov = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_phi0_z0_cov = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_tanlambda_phi0_cov = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_tanlambda_d0_cov = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_tanlambda_z0_cov = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_omega_tanlambda_cov = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_omega_phi0_cov = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_omega_d0_cov = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_omega_z0_cov = 0;
+  
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_Sip2dVal = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_Sip2dSig = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_Sip3dVal = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_Sip3dSig = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_JetDistVal = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_JetDistSig = 0;
+
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_isMu = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_isEl = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_isChargedHad = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_isGamma = 0;
+  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float> > *JetsConstituents_isNeutralHad = 0;
+
+  ROOT::VecOps::RVec<int>* count_Const = 0;
+  ROOT::VecOps::RVec<int>* count_Mu = 0;
+  ROOT::VecOps::RVec<int>* count_El = 0;
+  ROOT::VecOps::RVec<int>* count_ChargedHad = 0;
+  ROOT::VecOps::RVec<int>* count_Photon = 0;
+  ROOT::VecOps::RVec<int>* count_NeutralHad = 0;
+
+  //Set the info for each branch of the tree to correspond to our data 
+  
+  ev->SetBranchAddress("Jets_e", &Jets_e);
+  ev->SetBranchAddress("Jets_mass", &Jets_mass);
+  ev->SetBranchAddress("Jets_pt", &Jets_pt);
+  ev->SetBranchAddress("Jets_phi", &Jets_phi);
+  ev->SetBranchAddress("Jets_theta", &Jets_theta);
+
+  ev->SetBranchAddress("JetsConstituents_e", &JetsConstituents_e);
+  ev->SetBranchAddress("JetsConstituents_pt", &JetsConstituents_pt);
+  ev->SetBranchAddress("JetsConstituents_theta", &JetsConstituents_theta);
+  ev->SetBranchAddress("JetsConstituents_phi", &JetsConstituents_phi);
+  ev->SetBranchAddress("JetsConstituents_charge", &JetsConstituents_charge);
+  
+  ev->SetBranchAddress("JetsConstituents_erel", &JetsConstituents_erel);
+  ev->SetBranchAddress("JetsConstituents_erel_log", &JetsConstituents_erel_log);
+  ev->SetBranchAddress("JetsConstituents_thetarel", &JetsConstituents_thetarel);
+  ev->SetBranchAddress("JetsConstituents_phirel", &JetsConstituents_phirel);
+
+  ev->SetBranchAddress("JetsConstituents_dndx", &JetsConstituents_dndx);
+  ev->SetBranchAddress("JetsConstituents_mtof", &JetsConstituents_mtof);
+
+  //ev->SetBranchAddress("JetsConstituents_d0_wrt0", &JetsConstituents_d0_wrt0);
+  //ev->SetBranchAddress("JetsConstituents_z0_wrt0", &JetsConstituents_z0_wrt0);
+  //ev->SetBranchAddress("JetsConstituents_phi0_wrt0", &JetsConstituents_phi0_wrt0);
+  //ev->SetBranchAddress("JetsConstituents_omega_wrt0", &JetsConstituents_omega_wrt0);
+  //ev->SetBranchAddress("JetsConstituents_tanlambda_wrt0", &JetsConstituents_tanlambda_wrt0);
+
+  ev->SetBranchAddress("JetsConstituents_dxy", &JetsConstituents_dxy);
+  ev->SetBranchAddress("JetsConstituents_dz", &JetsConstituents_dz);
+  //ev->SetBranchAddress("JetsConstituents_phi0", &JetsConstituents_phi0);
+  //ev->SetBranchAddress("JetsConstituents_C", &JetsConstituents_C);
+  //ev->SetBranchAddress("JetsConstituents_ct", &JetsConstituents_ct);
+
+  ev->SetBranchAddress("JetsConstituents_omega_cov", &JetsConstituents_omega_cov);
+  ev->SetBranchAddress("JetsConstituents_d0_cov", &JetsConstituents_d0_cov);
+  ev->SetBranchAddress("JetsConstituents_z0_cov", &JetsConstituents_z0_cov);
+  ev->SetBranchAddress("JetsConstituents_phi0_cov", &JetsConstituents_phi0_cov);
+  ev->SetBranchAddress("JetsConstituents_tanlambda_cov", &JetsConstituents_tanlambda_cov);
+  
+  ev->SetBranchAddress("JetsConstituents_d0_z0_cov", &JetsConstituents_d0_z0_cov);
+  ev->SetBranchAddress("JetsConstituents_phi0_d0_cov", &JetsConstituents_phi0_d0_cov);
+  ev->SetBranchAddress("JetsConstituents_phi0_z0_cov", &JetsConstituents_phi0_z0_cov);
+  ev->SetBranchAddress("JetsConstituents_tanlambda_phi0_cov", &JetsConstituents_tanlambda_phi0_cov);
+  ev->SetBranchAddress("JetsConstituents_tanlambda_d0_cov", &JetsConstituents_tanlambda_d0_cov);
+  ev->SetBranchAddress("JetsConstituents_tanlambda_z0_cov", &JetsConstituents_tanlambda_z0_cov);
+  ev->SetBranchAddress("JetsConstituents_omega_phi0_cov", &JetsConstituents_omega_phi0_cov);
+  ev->SetBranchAddress("JetsConstituents_omega_d0_cov", &JetsConstituents_omega_d0_cov);
+  ev->SetBranchAddress("JetsConstituents_omega_z0_cov", &JetsConstituents_omega_z0_cov);
+  ev->SetBranchAddress("JetsConstituents_omega_tanlambda_cov", &JetsConstituents_omega_tanlambda_cov);
+  
+  ev->SetBranchAddress("JetsConstituents_Sip2dVal", &JetsConstituents_Sip2dVal);
+  ev->SetBranchAddress("JetsConstituents_Sip2dSig", &JetsConstituents_Sip2dSig);
+  ev->SetBranchAddress("JetsConstituents_Sip3dVal", &JetsConstituents_Sip3dVal);
+  ev->SetBranchAddress("JetsConstituents_Sip3dSig", &JetsConstituents_Sip3dSig);
+  ev->SetBranchAddress("JetsConstituents_JetDistVal", &JetsConstituents_JetDistVal);
+  ev->SetBranchAddress("JetsConstituents_JetDistSig", &JetsConstituents_JetDistSig);
+  
+  ev->SetBranchAddress("JetsConstituents_isMu", &JetsConstituents_isMu);
+  ev->SetBranchAddress("JetsConstituents_isEl", &JetsConstituents_isEl);
+  ev->SetBranchAddress("JetsConstituents_isChargedHad", &JetsConstituents_isChargedHad);
+  ev->SetBranchAddress("JetsConstituents_isGamma", &JetsConstituents_isGamma);
+  ev->SetBranchAddress("JetsConstituents_isNeutralHad", &JetsConstituents_isNeutralHad);
+
+  //ev->SetBranchAddress("Bz", &Bz_i);
+
+  ev->SetBranchAddress("njet", &nJets);
+  ev->SetBranchAddress("nconst", &count_Const);
+  ev->SetBranchAddress("nmu", &count_Mu);
+  ev->SetBranchAddress("nel", &count_El);
+  ev->SetBranchAddress("nchargedhad", &count_ChargedHad);
+  ev->SetBranchAddress("nphoton", &count_Photon);
+  ev->SetBranchAddress("nneutralhad", &count_NeutralHad);
+
+
+  //we defined how we read the tree. Now we
+  //need to define how we write the ntuple.
+
+  //std::string outDir(""); 
+  std::string outfileName(argv[2]);
+  TFile* outfile = new TFile(outfileName.c_str(),"recreate");
+  std::cout << "-> Opened outfile " << std::endl;
+  TTree* ntuple = new TTree("tree", "jets_Ntuple");
+  std::cout << "-> Opened ntuple " << std::endl;
+
+  //variables to write
+  //jet
+  double recojet_e, recojet_mass, recojet_pt, recojet_phi, recojet_theta;
+
+  //constituents
+  float pfcand_e[1000] = {0.};
+  float pfcand_pt[1000] = {0.};
+  float pfcand_charge[1000] = {0.};
+  float pfcand_theta[1000] = {0.};
+  float pfcand_phi[1000] = {0.};
+  
+  float pfcand_erel[1000] = {0.};
+  float pfcand_erel_log[1000] = {0.};
+  float pfcand_thetarel[1000] = {0.};
+  float pfcand_phirel[1000] = {0.};
+
+  float pfcand_dndx[1000] = {0.};
+  float pfcand_mtof[1000] = {0.};
+  
+  float pfcand_dxy[1000] = {0.};
+  float pfcand_dz[1000] = {0.};
+  
+  float pfcand_dptdpt[1000] = {0.};
+  float pfcand_dxydxy[1000] = {0.};
+  float pfcand_dzdz[1000] = {0.};
+  float pfcand_dphidphi[1000] = {0.};
+  float pfcand_detadeta[1000] = {0.};
+
+  float pfcand_dxydz[1000] = {0.};
+  float pfcand_dphidxy[1000] = {0.};
+  float pfcand_phidz[1000] = {0.};
+  float pfcand_phictgtheta[1000] = {0.};
+  float pfcand_dxyctgtheta[1000] = {0.};
+  float pfcand_dlambdadz[1000] = {0.};
+  float pfcand_cctgtheta[1000] = {0.};
+  float pfcand_phic[1000] = {0.};
+  float pfcand_dxyc[1000] = {0.};
+  float pfcand_cdz[1000] = {0.};
+
+  float pfcand_btagSip2dVal[1000] = {0.};
+  float pfcand_btagSip2dSig[1000] = {0.};
+  float pfcand_btagSip3dVal[1000] = {0.};
+  float pfcand_btagSip3dSig[1000] = {0.};
+  float pfcand_btagJetDistVal[1000] = {0.};
+  float pfcand_btagJetDistSig[1000] = {0.};
+
+  float pfcand_isMu[1000] = {0.};
+  float pfcand_isEl[1000] ={0.};
+  float pfcand_isChargedHad[1000] ={0.};
+  float pfcand_isGamma[1000] ={0.};
+  float pfcand_isNeutralHad[1000] ={0.};
+
+  //counting species
+  int njet = 0;
+  int nconst = 0; //number of constituents of the jets
+  int anomaly_njets_counts_less = 0;
+  int anomaly_njets_counts_more = 0;
+  int anomaly_njets_counts = 0;
+  int saved_events_counts = 0; //this variable will be used to count the number of events actually saved                                                                                                    
+  //int Nevents_Max = 1000000;  // maximum number of events to be saved                                                                                                                                       
+  int nphotons = 0;
+  int ncharged = 0;
+  int nchargedhad = 0;
+  int nneutralhad = 0;
+  int nel = 0;
+  int nmu = 0;
+
+
+  //set flags
+  float is_q = 0.;
+  float is_b = 0.;
+  float is_c = 0.;
+  float is_s = 0.;
+  float is_g = 0.;
+  float is_t = 0.;
+  
+  if (flavour == 'q') {is_q = 1.;}
+  if (flavour == 'b') {is_b = 1.;}
+  if (flavour == 'c') {is_c = 1.;}
+  if (flavour == 's') {is_s = 1.;}
+  if (flavour == 'g') {is_g = 1.;}
+  if (flavour == 't') {is_t = 1.;}
+  
+  std::cout << "is_q: " << is_q << std::endl; 
+
+  // In an n-tuple, we assign each variable to its own branch. 
+  ntuple->Branch("recojet_e", &recojet_e);
+  ntuple->Branch("recojet_mass", &recojet_mass);
+  ntuple->Branch("recojet_pt", &recojet_pt);
+  ntuple->Branch("recojet_phi", &recojet_phi);
+  ntuple->Branch("recojet_theta", &recojet_theta);
+  
+  
+  ntuple->Branch("recojet_isQ", &is_q);
+  ntuple->Branch("recojet_isB", &is_b);
+  ntuple->Branch("recojet_isC", &is_c);
+  ntuple->Branch("recojet_isS", &is_s);
+  ntuple->Branch("recojet_isG", &is_g);
+  ntuple->Branch("recojet_isT", &is_t);
+  
+  ntuple->Branch("nconst", &nconst, "nconst/I");
+  ntuple->Branch("nphotons", &nphotons, "nphotons/I");
+  ntuple->Branch("ncharged", &ncharged, "ncharged/I");
+  ntuple->Branch("nneutralhad", &nneutralhad, "nneutralhad/I");
+  ntuple->Branch("nchargedhad", &nchargedhad, "nchargedhad/I");
+  ntuple->Branch("nel", &nel, "nel/I");
+  ntuple->Branch("nmu", &nmu, "nmu/I");
+
+  ntuple->Branch("pfcand_e", pfcand_e, "pfcand_e[nconst]/F");
+  ntuple->Branch("pfcand_pt", pfcand_pt, "pfcand_pt[nconst]/F");
+  ntuple->Branch("pfcand_charge", pfcand_charge, "pfcand_charge[nconst]/F");
+  ntuple->Branch("pfcand_theta", pfcand_theta, "pfcand_theta[nconst]/F");
+  ntuple->Branch("pfcand_phi", pfcand_phi, "pfcand_phi[nconst]/F");
+  
+  ntuple->Branch("pfcand_erel", pfcand_erel, "pfcand_erel[nconst]/F");
+  ntuple->Branch("pfcand_erel_log", pfcand_erel_log, "pfcand_erel_log[nconst]/F");
+  ntuple->Branch("pfcand_thetarel", pfcand_thetarel, "pfcand_thetarel[nconst]/F");
+  ntuple->Branch("pfcand_phirel", pfcand_phirel, "pfcand_phirel[nconst]/F");
+  
+  ntuple->Branch("pfcand_dndx", pfcand_dndx, "pfcand_dndx[nconst]/F");
+  ntuple->Branch("pfcand_mtof", pfcand_mtof, "pfcand_mtof[nconst]/F");
+
+  ntuple->Branch("pfcand_dxy", pfcand_dxy, "pfcand_dxy[nconst]/F");
+  ntuple->Branch("pfcand_dz", pfcand_dz, "pfcand_dz[nconst]/F");
+
+  ntuple->Branch("pfcand_dptdpt", pfcand_dptdpt, "pfcand_dptdpt[nconst]/F");
+  ntuple->Branch("pfcand_dxydxy", pfcand_dxydxy, "pfcand_dxydxy[nconst]/F");
+  ntuple->Branch("pfcand_dzdz", pfcand_dzdz, "pfcand_dzdz[nconst]/F");
+  ntuple->Branch("pfcand_dphidphi", pfcand_dphidphi, "pfcand_dphidphi[nconst]/F");
+  ntuple->Branch("pfcand_detadeta", pfcand_detadeta, "pfcand_detadeta[nconst]/F");
+  
+  ntuple->Branch("pfcand_dxydz", pfcand_dxydz, "pfcand_dxydz[nconst]/F");
+  ntuple->Branch("pfcand_dphidxy", pfcand_dphidxy, "pfcand_dphidxy[nconst]/F");
+  ntuple->Branch("pfcand_phidz", pfcand_phidz, "pfcand_phidz[nconst]/F");
+  ntuple->Branch("pfcand_phictgtheta", pfcand_phictgtheta, "pfcand_phictgtheta[nconst]/F");
+  ntuple->Branch("pfcand_dxyctgtheta", pfcand_dxyctgtheta, "pfcand_dxyctgtheta[nconst]/F");
+  ntuple->Branch("pfcand_dlambdadz", pfcand_dlambdadz, "pfcand_dlambdadz[nconst]/F");
+  ntuple->Branch("pfcand_cctgtheta", pfcand_cctgtheta, "pfcand_cctgtheta[nconst]/F");
+  ntuple->Branch("pfcand_phic", pfcand_phic, "pfcand_phic[nconst]/F");
+  ntuple->Branch("pfcand_dxyc", pfcand_dxyc, "pfcand_dxyc[nconst]/F");
+  ntuple->Branch("pfcand_cdz", pfcand_cdz, "pfcand_cdz[nconst]/F");
+
+  ntuple->Branch("pfcand_btagSip2dVal", pfcand_btagSip2dVal, "pfcand_btagSip2dVal[nconst]/F");
+  ntuple->Branch("pfcand_btagSip2dSig", pfcand_btagSip2dSig, "pfcand_btagSip2dSig[nconst]/F");
+  ntuple->Branch("pfcand_btagSip3dVal", pfcand_btagSip3dVal, "pfcand_btagSip3dVal[nconst]/F");
+  ntuple->Branch("pfcand_btagSip3dSig", pfcand_btagSip3dSig, "pfcand_btagSip3dSig[nconst]/F");
+  ntuple->Branch("pfcand_btagJetDistVal", pfcand_btagJetDistVal, "pfcand_btagJetDistVal[nconst]/F");
+  ntuple->Branch("pfcand_btagJetDistSig", pfcand_btagJetDistSig, "pfcand_btagJetDistSig[nconst]/F");
+
+  ntuple->Branch("pfcand_isMu", pfcand_isMu, "pfcand_isMu[nconst]/F");
+  ntuple->Branch("pfcand_isEl", pfcand_isEl, "pfcand_isEl[nconst]/F");
+  ntuple->Branch("pfcand_isChargedHad", pfcand_isChargedHad, "pfcand_isChargedHad[nconst]/F");
+  ntuple->Branch("pfcand_isGamma", pfcand_isGamma, "pfcand_isGamma[nconst]/F");
+  ntuple->Branch("pfcand_isNeutralHad", pfcand_isNeutralHad, "pfcand_isNeutralHad[nconst]/F");
+
+  int N_i = atoi(argv[3]);
+  int N_f = atoi(argv[4]);
+  int Nevents_Max = N_f - N_i;  // maximum number of events to be saved
+
+  //Run over each entry in the tree:
+  int nentries = ev->GetEntries(); //total number of events in the file
+  
+  std::cout<< " " << std::endl;
+  std::cout << "-> number of events contained in the tree: " << nentries <<std::endl;
+  
+  for(int i = N_i+1; i < nentries; ++i) {
+    //Get an event
+    ev->GetEntry(i);
+    
+    //njet = (*Jets_e).size();
+    njet = nJets;
+
+    if(i % 10000 == 0) {
+      std::cout<< "-----" << std::endl;
+      std::cout << "-> event: " << i << " -  " << "#jets: " << njet << " -  (*Jets_e).size(): " << (*Jets_e).size() << std::endl;
+      std::cout << "-----" << std::endl;
+    }
+
+    if(njet != 2) {
+      anomaly_njets_counts += 1;
+      if (njet > 2) {
+	anomaly_njets_counts_more += 1;
+      } else {
+	anomaly_njets_counts_less += 1;
+      }
+    }
+    
+    if (njet < 2) { //exclude the events with less than two jets
+      continue ;
+    }
+
+    //run over the jets in the event
+    for(int j=0; j < 2; ++j) { //we only take the two leadingjets
+
+      recojet_e = (*Jets_e)[j];
+      //jet_e = jets_e->at(j);
+      recojet_mass = (*Jets_mass)[j];
+      recojet_pt = (*Jets_pt)[j];
+      recojet_phi = (*Jets_phi)[j];
+      recojet_theta = (*Jets_theta)[j];
+      //n_constituents = (*jets_ends)[j] - (*jets_begins)[j];
+      //nconst = (JetsConstituents_e->at(j)).size();
+      nconst = (count_Const->at(j));
+      nel = (count_El->at(j));
+      nmu = (count_Mu->at(j));
+      nchargedhad = (count_ChargedHad->at(j));
+      nphotons = (count_Photon->at(j));
+      nneutralhad = (count_NeutralHad->at(j));
+      
+
+      if(i % 10000 == 0) {
+	std::cout << "-> jet: " << j << " -  " << "nconst: " << nconst << "-> (JetsConstituents_e->at(j)).size(): " << (JetsConstituents_e->at(j)).size() << std::endl;
+	std::cout << "-> jet_e: " << recojet_e << " -  jet_pt: " << recojet_pt << std::endl;
+	std::cout<< "-----" << std::endl;
+      }
+    
+      for(int k = 0; k < nconst; ++k){
+	pfcand_e[k] = (JetsConstituents_e->at(j))[k];
+	//std::cout << k << ' ' << JC_e[k] << std::endl;
+	pfcand_pt[k] = (JetsConstituents_pt->at(j))[k];
+	pfcand_theta[k] = (JetsConstituents_theta->at(j))[k];
+	pfcand_phi[k] = (JetsConstituents_phi->at(j))[k];
+	pfcand_charge[k] = (JetsConstituents_charge->at(j))[k];
+	
+	pfcand_erel[k] = (JetsConstituents_erel->at(j))[k];
+	pfcand_erel_log[k] = (JetsConstituents_erel_log->at(j))[k];
+	pfcand_thetarel[k] = (JetsConstituents_thetarel->at(j))[k];
+	pfcand_phirel[k] = (JetsConstituents_phirel->at(j))[k];
+	
+	pfcand_dndx[k] = (JetsConstituents_dndx->at(j))[k]/1000.; //transformed in mm
+	pfcand_mtof[k] = (JetsConstituents_mtof->at(j))[k];
+
+	pfcand_dxy[k] = (JetsConstituents_dxy->at(j))[k];
+	//pfcand_dz[k] = (JetsConstituents_dz->at(j))[k];
+        //std::cout<<pfcand_dz[k] <<","<< (JetsConstituents_dz->at(j))[k]<<std::endl; 
+	if (isnan((JetsConstituents_dz->at(j))[k])) pfcand_dz[k] = -9;
+        else pfcand_dz[k] = (JetsConstituents_dz->at(j))[k];
+        pfcand_dptdpt[k] = (JetsConstituents_omega_cov->at(j))[k];
+	pfcand_dxydxy[k] = (JetsConstituents_d0_cov->at(j))[k];
+	pfcand_dzdz[k] = (JetsConstituents_z0_cov->at(j))[k];
+	pfcand_dphidphi[k] = (JetsConstituents_phi0_cov->at(j))[k];
+	pfcand_detadeta[k] = (JetsConstituents_tanlambda_cov->at(j))[k];
+    
+	pfcand_dxydz[k] = (JetsConstituents_d0_z0_cov->at(j))[k];
+	pfcand_dphidxy[k] = (JetsConstituents_phi0_d0_cov->at(j))[k]; //*****
+	pfcand_phidz[k] = (JetsConstituents_phi0_z0_cov->at(j))[k];
+	
+	pfcand_phictgtheta[k] = (JetsConstituents_tanlambda_phi0_cov->at(j))[k];
+	pfcand_dxyctgtheta[k] = (JetsConstituents_tanlambda_d0_cov->at(j))[k];
+	pfcand_dlambdadz[k] = (JetsConstituents_tanlambda_z0_cov->at(j))[k];
+	
+	pfcand_cctgtheta[k] = (JetsConstituents_omega_tanlambda_cov->at(j))[k];
+	pfcand_phic[k] = (JetsConstituents_omega_phi0_cov->at(j))[k];
+	pfcand_dxyc[k] = (JetsConstituents_omega_d0_cov->at(j))[k];
+	pfcand_cdz[k] = (JetsConstituents_omega_z0_cov->at(j))[k];
+	
+	pfcand_btagSip2dVal[k] = (JetsConstituents_Sip2dVal->at(j))[k];
+	pfcand_btagSip2dSig[k] = (JetsConstituents_Sip2dSig->at(j))[k];
+	//pfcand_btagSip3dVal[k] = (JetsConstituents_Sip3dVal->at(j))[k];
+	//pfcand_btagSip3dSig[k] = (JetsConstituents_Sip3dSig->at(j))[k];
+        //pfcand_btagJetDistVal[k] = (JetsConstituents_JetDistVal->at(j))[k];
+	//pfcand_btagJetDistSig[k] = (JetsConstituents_JetDistSig->at(j))[k];
+       
+        if (isnan((JetsConstituents_Sip3dVal->at(j))[k]))pfcand_btagSip3dVal[k]  = -9;
+        else pfcand_btagSip3dVal[k] = JetsConstituents_Sip3dVal->at(j)[k];
+        if (isnan((JetsConstituents_Sip3dSig->at(j))[k]))pfcand_btagSip3dSig[k]  = -9;
+        else pfcand_btagSip3dSig[k] = JetsConstituents_Sip3dSig->at(j)[k];
+        if (isnan((JetsConstituents_JetDistVal->at(j))[k]))pfcand_btagJetDistVal[k]  = -9;
+        else pfcand_btagJetDistVal[k] = JetsConstituents_JetDistVal->at(j)[k];
+        if (isnan((JetsConstituents_JetDistSig->at(j))[k]))pfcand_btagJetDistSig[k]  = -9;
+        else pfcand_btagJetDistSig[k] = JetsConstituents_JetDistSig->at(j)[k];
+
+	pfcand_isMu[k] = (JetsConstituents_isMu->at(j))[k];
+	pfcand_isEl[k] = (JetsConstituents_isEl->at(j))[k];
+	pfcand_isChargedHad[k] = (JetsConstituents_isChargedHad->at(j))[k];
+	pfcand_isGamma[k] = (JetsConstituents_isGamma->at(j))[k];
+	pfcand_isNeutralHad[k] = (JetsConstituents_isNeutralHad->at(j))[k];
+
+	//std::cout << "k: "<< k << std::endl;
+	//counting species
+	/*if ( (JetsConstituents_isMu->at(j))[k] == 1 ) {
+	  nmu += 1;
+	  ncharged += 1;
+	} else if ((JetsConstituents_isEl->at(j))[k] == 1) {
+	  nel += 1;
+	  ncharged += 1;
+	} else if ( (JetsConstituents_isGamma->at(j))[k] == 1 ) {
+	  nphotons += 1;
+	} else if ((JetsConstituents_isChargedHad->at(j))[k] == 1) {
+	  nchargedhad += 1;
+	  ncharged += 1;
+	} else if ((JetsConstituents_isNeutralHad->at(j))[k] == 1) {
+	  nneutralhad += 1;
+	  }*/
+      }	
+      ntuple->Fill();
+    }
+    saved_events_counts += 1; //we count the num of events saved
+    if (saved_events_counts == Nevents_Max) { //interrupt the loop if Nevents_max events have already been saved
+      break;
+    }
+  }
+
+  std::cout << "-> number of entries run: " << nentries <<std::endl;
+  std::cout << "-> number of entries considered: " << saved_events_counts <<std::endl;
+  std::cout<< " " << std::endl;
+  
+  std::cout << "--> number of events with njets != 2: " << anomaly_njets_counts  << std::endl; 
+  std::cout << "--> number of events with njets > 2: " <<  anomaly_njets_counts_more << std::endl;
+  std::cout << "--> number of events with njets < 2: " <<  anomaly_njets_counts_less << std::endl;
+  
+
+  //outfile->cd();
+  //outfile->mkdir("deepntuplizer/");
+  //outfile->cd("deepntuplizer/");
+  //ntuple->SetDirectory(gDirectory);
+  ntuple->Write();
+  infile->Close();
+  outfile->Close();
+  std::cout << "-> Closed files "<<std::endl;
+  
+  return 0;
+}


### PR DESCRIPTION
This PR provides an example for to produce cluster jets, compute jet constituent observables needed for flavour tagging and build a jet based tree in two steps (`stage1.py` and `stage2.cpp`). The jet-based tree is later used for training the model with @hqucms' [Weaver](https://github.com/hqucms/weaver/). The model is exported into `ONNX` and used for inference as showed in `analysis_inference.py` 
This PR bulld upon and superseeds #188. 

Credits: @hqucms, @forthommel , @ADV99