### PR TITLE
Install the FastJet addons headers to work around #227

### DIFF
--- a/addons/FastJet/CMakeLists.txt
+++ b/addons/FastJet/CMakeLists.txt
@@ -11,3 +11,11 @@ fccanalyses_addon_build(FastJet
                                  ${FASTJET_LIBRARY_DIRS}/libfastjetplugins.so
                                  ROOT::MathCore
                         INSTALL_COMPONENT fastjet)
+
+
+install(FILES
+   ${CMAKE_CURRENT_LIST_DIR}/ExternalRecombiner.h
+   ${CMAKE_CURRENT_LIST_DIR}/ValenciaPlugin.h
+   ${CMAKE_CURRENT_LIST_DIR}/JetClustering.h
+   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/FastJet
+   )


### PR DESCRIPTION
This is probably not the most elegant, but a viable fix for #227. @forthommel I didn't spend enough time diving into the `fccanalyses_addon_build` function to figure out whether there is a way to make that do the installation instead. If there is one, we could obviously also do that.

Additionally, it seems this is only necessary for the `FastJet` addon, but not for the `ONNXRuntime` one. This means that is also possible that these headers just leak accidentally, in this case, this PR is really just a quick fix rather than a proper one.

In any case #227 currently breaks all stacks with a recent build of FCCAnalyses, because root errors out when it loads the dictionary.