### PR TITLE
move test file to http (no xrootd read permissions on ci machines)

### DIFF
--- a/examples/FCCee/test/weaver_inference.py
+++ b/examples/FCCee/test/weaver_inference.py
@@ -18,7 +18,7 @@ runBatch    = False
 #compGroup = "group_u_FCC.local_gen"
 
 #Optional test file
-testFile ="root://eospublic.cern.ch//eos/experiment/fcc/ee/generation/DelphesEvents/spring2021/IDEA/p8_ee_ZH_ecm240/events_101027117.root"
+testFile ="https://fccsw.web.cern.ch/fccsw/testsamples/p8_ee_ZH_ecm240_events_101027117.root"
 
 #Mandatory: RDFanalysis class where the use defines the operations on the TTree
 class RDFanalysis():


### PR DESCRIPTION
Fixes a test failure on the CI machines.