### PR TITLE
Fix: get_phi function in jetclustering utils

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/JetClusteringUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/JetClusteringUtils.h
@@ -78,9 +78,13 @@ namespace FCCAnalyses {
     /** Get jet eta. Details. */
     ROOT::VecOps::RVec<float> get_eta(const ROOT::VecOps::RVec<fastjet::PseudoJet>& in);
 
-    /** Get jet phi. Details. */
+    /** Get jet phi. Details (range [0,2*pi]). */
     ROOT::VecOps::RVec<float> get_phi(const ROOT::VecOps::RVec<fastjet::PseudoJet>& in);
 
+    /** Get jet phi. Details (range [-pi,pi]). */
+    ROOT::VecOps::RVec<float> get_phi_std(const ROOT::VecOps::RVec<fastjet::PseudoJet>& in);
+
+	  
     /** Get jet theta. Details. */
     ROOT::VecOps::RVec<float> get_theta(const ROOT::VecOps::RVec<fastjet::PseudoJet>& in);
 

--- a/analyzers/dataframe/src/JetClusteringUtils.cc
+++ b/analyzers/dataframe/src/JetClusteringUtils.cc
@@ -126,7 +126,7 @@ namespace FCCAnalyses {
     ROOT::VecOps::RVec<float> get_phi(const ROOT::VecOps::RVec<fastjet::PseudoJet>& in) {
       ROOT::VecOps::RVec<float> result;
       for (auto& p : in) {
-        result.push_back(p.phi());
+        result.push_back(p.phi_std());
       }
       return result;
     }

--- a/analyzers/dataframe/src/JetClusteringUtils.cc
+++ b/analyzers/dataframe/src/JetClusteringUtils.cc
@@ -126,6 +126,15 @@ namespace FCCAnalyses {
     ROOT::VecOps::RVec<float> get_phi(const ROOT::VecOps::RVec<fastjet::PseudoJet>& in) {
       ROOT::VecOps::RVec<float> result;
       for (auto& p : in) {
+        result.push_back(p.phi());
+      }
+      return result;
+    }
+
+
+    ROOT::VecOps::RVec<float> get_phi_std(const ROOT::VecOps::RVec<fastjet::PseudoJet>& in) {
+      ROOT::VecOps::RVec<float> result;
+      for (auto& p : in) {
         result.push_back(p.phi_std());
       }
       return result;


### PR DESCRIPTION
The current get_phi function in JetClusteringUtils.cc returns the phi in the range (0,2*pi). 

The standard range usually used for phi is (-pi,pi). 

To fix this I have used phi_std function as described in the [fastjet documentation here](http://fastjet.fr/repo/doxygen-3.4.0/classfastjet_1_1PseudoJet.html#a70c2d0d5b2100edf0c933c4915bb8b30).



