### PR TITLE
Add: sel_pt option in JetClusteringUtils

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/JetClusteringUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/JetClusteringUtils.h
@@ -84,9 +84,16 @@ namespace FCCAnalyses {
     /** Get jet phi. Details (range [-pi,pi]). */
     ROOT::VecOps::RVec<float> get_phi_std(const ROOT::VecOps::RVec<fastjet::PseudoJet>& in);
 
-	  
+
     /** Get jet theta. Details. */
     ROOT::VecOps::RVec<float> get_theta(const ROOT::VecOps::RVec<fastjet::PseudoJet>& in);
+
+    ///Select clustered jets with transverse momentum greader than a minimum value [GeV]
+    struct sel_pt {
+      sel_pt(float arg_min_pt);
+      float m_min_pt = 1.; //> transverse momentum threshold [GeV]
+      ROOT::VecOps::RVec<fastjet::PseudoJet>  operator() (ROOT::VecOps::RVec<fastjet::PseudoJet> in);
+    };
 
     ///Internal methods
     JetClustering::FCCAnalysesJet initialise_FCCAnalysesJet();

--- a/analyzers/dataframe/src/JetClusteringUtils.cc
+++ b/analyzers/dataframe/src/JetClusteringUtils.cc
@@ -148,6 +148,20 @@ namespace FCCAnalyses {
       return result;
     }
 
+    sel_pt::sel_pt(float arg_min_pt) : m_min_pt(arg_min_pt) {};
+    ROOT::VecOps::RVec<fastjet::PseudoJet>  sel_pt::operator() (ROOT::VecOps::RVec<fastjet::PseudoJet> in) {
+      ROOT::VecOps::RVec<fastjet::PseudoJet> result;
+      result.reserve(in.size());
+      for (size_t i = 0; i < in.size(); ++i) {
+        auto & p = in[i];
+        if (std::sqrt(std::pow(p.px(),2) + std::pow(p.py(),2)) > m_min_pt) {
+          result.emplace_back(p);
+        }
+      }
+      return result;
+    }
+
+
     JetClustering::FCCAnalysesJet initialise_FCCAnalysesJet() {
       JetClustering::FCCAnalysesJet result;
       std::vector<fastjet::PseudoJet> jets;


### PR DESCRIPTION
Adds a new "sel_pt" function for selecting clustered jets based on minimum transverse momentum