### PR TITLE
Added jets_TwoHemispheres to Algorithms.

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/Algorithms.h
+++ b/analyzers/dataframe/FCCAnalyses/Algorithms.h
@@ -6,6 +6,9 @@
 
 #include "edm4hep/ReconstructedParticleData.h"
 
+#include "FCCAnalyses/JetClusteringUtils.h"
+#include "FCCAnalyses/ReconstructedParticle.h"
+
 //#include "TFitter.h"
 #include "Math/Minimizer.h"
 #include "ROOT/RVec.hxx"
@@ -188,6 +191,14 @@ namespace Algorithms{
 
   /// Get the invariant mass from a list of reconstructed particles
   float getMass(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> & in);
+
+  /// make "jets" by splitting the events into two hemisphere transverse to the thrust axis. 
+  struct jets_TwoHemispheres {
+      int m_sorted=0;		///< pT ordering=0, E ordering=1
+      int m_recombination = 0;	///< E_scheme=0, pt_scheme=1, pt2_scheme=2, Et_scheme=3, Et2_scheme=4, BIpt_scheme=5, BIpt2_scheme=6, E0_scheme=10, p_scheme=11
+      jets_TwoHemispheres( int arg_sorted, int arg_recombination ) ; 
+      JetClustering::FCCAnalysesJet operator() ( const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> & in);
+  } ;
 
   ///@}
 


### PR DESCRIPTION
It splits an event in two hemispheres based on the thrust axis, and gathers together all reco'ed particles that belong to each hemisphere into a "jet", in the format of JetClustering::FCCAnalysesJet, such that algorithms (e.g. tagging) developed on JetClustering::FCCAnalysesJet's can be used.

On Z -> had events, the resulting jets are very similar to jets from Durham exclusive, N = 2, although a few particles occasionnaly get clustered differently in the two approaches.

Example usage:
            .Define("FCCAnalysesJets_hemispheres",  "Algorithms::jets_TwoHemispheres( 1, 0) ( ReconstructedParticles )")
            .Define("jets_hemispheres", "JetClusteringUtils::get_pseudoJets( FCCAnalysesJets_hemispheres )")
            .Define("jets_hemispheres_px",  " JetClusteringUtils::get_px( jets_hemispheres )")