### PR TITLE
Invariant masses from vector of jets

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
@@ -252,6 +252,7 @@ namespace FCCAnalyses {
     rv::RVec<TLorentzVector> compute_tlv_jets(const rv::RVec<fastjet::PseudoJet>& jets);
     rv::RVec<TLorentzVector> sum_tlv_constituents(const rv::RVec<FCCAnalysesJetConstituents>& jets);
     float InvariantMass(const TLorentzVector& tlv1, const TLorentzVector& tlv2);
+    rv::RVec<double> AllInvariantMasses(rv::RVec<TLorentzVector> AllJets); // invariant masses of all jet pairs given a vector of jets
     rv::RVec<double> compute_residue_energy(const rv::RVec<TLorentzVector>& tlv_jet,
 					    const rv::RVec<TLorentzVector>& sum_tlv_jcs);
     rv::RVec<double> compute_residue_pt(const rv::RVec<TLorentzVector>& tlv_jet,

--- a/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
@@ -251,7 +251,7 @@ namespace FCCAnalyses {
     //residues
     rv::RVec<TLorentzVector> compute_tlv_jets(const rv::RVec<fastjet::PseudoJet>& jets);
     rv::RVec<TLorentzVector> sum_tlv_constituents(const rv::RVec<FCCAnalysesJetConstituents>& jets);
-    float invariant_mass(const TLorentzVector& tlv1, const TLorentzVector& tlv2);
+    float InvariantMass(const TLorentzVector& tlv1, const TLorentzVector& tlv2);
     rv::RVec<double> all_invariant_masses(rv::RVec<TLorentzVector> AllJets); // invariant masses of all jet pairs given a vector of jets
     rv::RVec<double> compute_residue_energy(const rv::RVec<TLorentzVector>& tlv_jet,
 					    const rv::RVec<TLorentzVector>& sum_tlv_jcs);

--- a/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
@@ -251,8 +251,8 @@ namespace FCCAnalyses {
     //residues
     rv::RVec<TLorentzVector> compute_tlv_jets(const rv::RVec<fastjet::PseudoJet>& jets);
     rv::RVec<TLorentzVector> sum_tlv_constituents(const rv::RVec<FCCAnalysesJetConstituents>& jets);
-    float InvariantMass(const TLorentzVector& tlv1, const TLorentzVector& tlv2);
-    rv::RVec<double> AllInvariantMasses(rv::RVec<TLorentzVector> AllJets); // invariant masses of all jet pairs given a vector of jets
+    float invariant_mass(const TLorentzVector& tlv1, const TLorentzVector& tlv2);
+    rv::RVec<double> all_invariant_masses(rv::RVec<TLorentzVector> AllJets); // invariant masses of all jet pairs given a vector of jets
     rv::RVec<double> compute_residue_energy(const rv::RVec<TLorentzVector>& tlv_jet,
 					    const rv::RVec<TLorentzVector>& sum_tlv_jcs);
     rv::RVec<double> compute_residue_pt(const rv::RVec<TLorentzVector>& tlv_jet,

--- a/analyzers/dataframe/src/JetConstituentsUtils.cc
+++ b/analyzers/dataframe/src/JetConstituentsUtils.cc
@@ -1068,6 +1068,36 @@ namespace FCCAnalyses {
       return std::sqrt(E*E - px*px - py*py - pz*pz);
     }
 
+    rv::RVec<double> AllInvariantMasses(rv::RVec<TLorentzVector> AllJets) {
+
+      TLorentzVector tlv1;
+      TLorentzVector tlv2;
+      double E, px, py, pz; 
+      double invmass; 
+      
+      rv::RVec<double> InvariantMasses;
+
+      // For each jet, take its invariant mass with the remaining jets. Stop at last jet.
+      for(int i = 0; i < AllJets.size()-1; ++i) {
+
+        tlv1 = AllJets.at(i); 
+
+        for(int j=i+1; j < AllJets.size(); ++j){ // go until end
+          tlv2 = AllJets.at(j);
+          E = tlv1.E() + tlv2.E();
+          px = tlv1.Px() + tlv2.Px();
+          py = tlv1.Py() + tlv2.Py();
+          pz = tlv1.Pz() + tlv2.Pz();
+
+          invmass = std::sqrt(E*E - px*px - py*py - pz*pz);
+          InvariantMasses.push_back(invmass);
+
+        }
+      }
+
+      return InvariantMasses;
+    }    
+
     rv::RVec<double> compute_residue_energy(const rv::RVec<TLorentzVector>& tlv_jet, const rv::RVec<TLorentzVector>& sum_tlv_jcs) {
       rv::RVec<double> out;
       for(int i = 0; i < tlv_jet.size(); ++i) {

--- a/analyzers/dataframe/src/JetConstituentsUtils.cc
+++ b/analyzers/dataframe/src/JetConstituentsUtils.cc
@@ -1060,7 +1060,7 @@ namespace FCCAnalyses {
       return out;
     }
 
-    float invariant_mass(const TLorentzVector& tlv1, const TLorentzVector& tlv2) {
+    float InvariantMass(const TLorentzVector& tlv1, const TLorentzVector& tlv2) {
       float E = tlv1.E() + tlv2.E();
       float px = tlv1.Px() + tlv2.Px();
       float py = tlv1.Py() + tlv2.Py();

--- a/analyzers/dataframe/src/JetConstituentsUtils.cc
+++ b/analyzers/dataframe/src/JetConstituentsUtils.cc
@@ -1060,7 +1060,7 @@ namespace FCCAnalyses {
       return out;
     }
 
-    float InvariantMass(const TLorentzVector& tlv1, const TLorentzVector& tlv2) {
+    float invariant_mass(const TLorentzVector& tlv1, const TLorentzVector& tlv2) {
       float E = tlv1.E() + tlv2.E();
       float px = tlv1.Px() + tlv2.Px();
       float py = tlv1.Py() + tlv2.Py();
@@ -1068,7 +1068,7 @@ namespace FCCAnalyses {
       return std::sqrt(E*E - px*px - py*py - pz*pz);
     }
 
-    rv::RVec<double> AllInvariantMasses(rv::RVec<TLorentzVector> AllJets) {
+    rv::RVec<double> all_invariant_masses(rv::RVec<TLorentzVector> AllJets) {
 
       TLorentzVector tlv1;
       TLorentzVector tlv2;


### PR DESCRIPTION
Hello - I added a single function to the `JetConstituentsUtils` class to compute and return the invariant masses for a given vector of N jets. For the 2 jet case, invariant mass computation is already there, but for Z(cc)H(hadronic) there may be more e.g. 4 jets. 

Thanks! 