### PR TITLE
Add option for 2D and 3D histograms in final stage

### DIFF
--- a/examples/FCCee/higgs/mH-recoil/mumu/analysis_final.py
+++ b/examples/FCCee/higgs/mH-recoil/mumu/analysis_final.py
@@ -42,4 +42,7 @@ histoList = {
     "leptonic_recoil_m_zoom4":{"name":"Zcand_recoil_m","title":"Z leptonic recoil [GeV]","bin":800,"xmin":120,"xmax":140},
     "leptonic_recoil_m_zoom5":{"name":"Zcand_recoil_m","title":"Z leptonic recoil [GeV]","bin":2000,"xmin":120,"xmax":140},
     "leptonic_recoil_m_zoom6":{"name":"Zcand_recoil_m","title":"Z leptonic recoil [GeV]","bin":100,"xmin":130.3,"xmax":132.5},
+    "mz_1D":{"cols":["Zcand_m"],"title":"m_{Z} [GeV]", "bins": [(40,80,100)]}, # 1D histogram (alternative syntax)
+    "mz_recoil_2D":{"cols":["Zcand_m", "Zcand_recoil_m"],"title":"m_{Z} - leptonic recoil [GeV]", "bins": [(40,80,100), (100,120,140)]}, # 2D histogram
+    "mz_recoil_3D":{"cols":["Zcand_m", "Zcand_recoil_m", "Zcand_recoil_m"],"title":"m_{Z} - leptonic recoil - leptonic recoil [GeV]", "bins": [(40,80,100), (100,120,140), (100,120,140)]}, # 3D histogram
 }


### PR DESCRIPTION
Added the option of writing 2D and 3D histograms during the final stage of the analysis. The syntax in the histoList is as follows:

`
"hist_name1": {"cols": ["col1"], "1D histogram", "bins": [(10, 0, 10)]},
"hist_name2": {"cols": ["col1", "col2"], "2D histogram", "bins": [(10, 0, 10), (20, 80, 100)]},
"hist_name3": {"cols": ["col1", "col2", "col3"], "3D histogram", "bins": [(10, 0, 10), (20, 80, 100), (10, 0, 10)]},
`

This syntax supports 1D, 2D, and 3D histograms, automatically assigned depending on the length of cols. The old syntax (providing name, bins, xmin and xmax) is still valid.

Example attached in the examples/FCCee/higgs/mH-recoil/mumu/analysis_final.py file.