### PR TITLE
Adding exception printout in config file

### DIFF
--- a/config/FCCAnalysisRun.py
+++ b/config/FCCAnalysisRun.py
@@ -1093,6 +1093,7 @@ def run(mainparser, subparser=None):
         elif args.command == "plots":  runPlots(analysisFile)
         return
     except Exception as e:
+        print("Exception:",e)
         print("============running the old way")
 
 


### PR DESCRIPTION
Hello - I would propose adding a single printout statement in the configuration setup, as I found that without it, one may have trouble debugging issues. 

For example - when running with a particular configuration where I was accidentally including the same variable twice in the output tree, I was running the command:

```
fccanalysis run ZccH_stage1.py --output wzp6_ee_ccH_Hcc_ecm240.root --files-list /eos/experiment/fcc/ee/generation/DelphesEvents/winter2023/IDEA/wzp6_ee_ccH_Hcc_ecm240/events_056080797.root --ncpus 64 --nev 100
```

and receiving the output:

```
----> Load cxx analyzers from libFCCAnalyses... 
--------------loading analysis file   /afs/cern.ch/work/a/atishelm/private/FCC/BNL-Analyses/ZccH_stage1.py
batch: 0
EOSoutput: 0
name: ZccH_4jetsRequired
njets: 4
run
The variable <outputDirEos> is optional in your analysis.py file, return default empty string
----> Running with user defined list of files (either locally or from batch)
----> Create dataframe object from files: 
    /eos/experiment/fcc/ee/generation/DelphesEvents/winter2023/IDEA/wzp6_ee_ccH_Hcc_ecm240/events_056080797.root
----> nevents original=0  local=100
The variable <geometryFile> is optional in your analysis.py file, return default value empty string
The variable <readoutName> is optional in your analysis.py file, return default value empty string
----> Init done, about to run 100 events on 1 CPUs
============running the old way
Traceback (most recent call last):
  File "/afs/cern.ch/work/a/atishelm/private/FCC/BNL-Analyses/FCCAnalyses/bin/fccanalysis", line 37, in <module>
    run(parser)
  File "/afs/cern.ch/work/a/atishelm/private/FCC/BNL-Analyses/FCCAnalyses/config/FCCAnalysisRun.py", line 1102, in run
    if args.final:
AttributeError: 'Namespace' object has no attribute 'final'
```

Where it's not obvious what the error is - it just appears that I'm running with the "old" method.

When adding the exception printout, the error became obvious:

```
----> Load cxx analyzers from libFCCAnalyses... 
--------------loading analysis file   /afs/cern.ch/work/a/atishelm/private/FCC/BNL-Analyses/ZccH_stage1.py
batch: 0
EOSoutput: 0
name: ZccH_4jetsRequired
njets: 4
run
The variable <outputDirEos> is optional in your analysis.py file, return default empty string
----> Running with user defined list of files (either locally or from batch)
----> Create dataframe object from files: 
    /eos/experiment/fcc/ee/generation/DelphesEvents/winter2023/IDEA/wzp6_ee_ccH_Hcc_ecm240/events_056080797.root
----> nevents original=0  local=100
The variable <geometryFile> is optional in your analysis.py file, return default value empty string
The variable <readoutName> is optional in your analysis.py file, return default value empty string
----> Init done, about to run 100 events on 1 CPUs
Exception: Template method resolution failed:
  none of the 3 overloaded methods succeeded. Full details:
  ROOT::RDF::RResultPtr<ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager,void> > ROOT::RDF::RInterface<ROOT::Detail::RDF::RRange<ROOT::Detail::RDF::RLoopManager>,void>::Snapshot(basic_string_view<char,char_traits<char> > treename, basic_string_view<char,char_traits<char> > filename, initializer_list<string> columnList, const ROOT::RDF::RSnapshotOptions& options = ROOT::RDF::RSnapshotOptions()) =>
    TypeError: could not convert argument 3
  ROOT::RDF::RResultPtr<ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager,void> > ROOT::RDF::RInterface<ROOT::Detail::RDF::RRange<ROOT::Detail::RDF::RLoopManager>,void>::Snapshot(basic_string_view<char,char_traits<char> > treename, basic_string_view<char,char_traits<char> > filename, const vector<string>& columnList, const ROOT::RDF::RSnapshotOptions& options = ROOT::RDF::RSnapshotOptions()) =>
    logic_error: Error: column "jet_nmu" was passed to Snapshot twice. This is not supported: only one of the columns would be readable with RDataFrame.
  ROOT::RDF::RResultPtr<ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager,void> > ROOT::RDF::RInterface<ROOT::Detail::RDF::RRange<ROOT::Detail::RDF::RLoopManager>,void>::Snapshot(basic_string_view<char,char_traits<char> > treename, basic_string_view<char,char_traits<char> > filename, basic_string_view<char,char_traits<char> > columnNameRegexp = "", const ROOT::RDF::RSnapshotOptions& options = ROOT::RDF::RSnapshotOptions()) =>
    TypeError: could not convert argument 3
  ROOT::RDF::RResultPtr<ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager,void> > ROOT::RDF::RInterface<ROOT::Detail::RDF::RRange<ROOT::Detail::RDF::RLoopManager>,void>::Snapshot(basic_string_view<char,char_traits<char> > treename, basic_string_view<char,char_traits<char> > filename, const vector<string>& columnList, const ROOT::RDF::RSnapshotOptions& options = ROOT::RDF::RSnapshotOptions()) =>
    logic_error: Error: column "jet_nmu" was passed to Snapshot twice. This is not supported: only one of the columns would be readable with RDataFrame.
  Failed to instantiate "Snapshot(std::string,std::string,std::vector<string>*)"
  ROOT::RDF::RResultPtr<ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager,void> > ROOT::RDF::RInterface<ROOT::Detail::RDF::RRange<ROOT::Detail::RDF::RLoopManager>,void>::Snapshot(basic_string_view<char,char_traits<char> > treename, basic_string_view<char,char_traits<char> > filename, const vector<string>& columnList, const ROOT::RDF::RSnapshotOptions& options = ROOT::RDF::RSnapshotOptions()) =>
    logic_error: Error: column "jet_nmu" was passed to Snapshot twice. This is not supported: only one of the columns would be readable with RDataFrame.
============running the old way
Traceback (most recent call last):
  File "/afs/cern.ch/work/a/atishelm/private/FCC/BNL-Analyses/FCCAnalyses/bin/fccanalysis", line 37, in <module>
    run(parser)
  File "/afs/cern.ch/work/a/atishelm/private/FCC/BNL-Analyses/FCCAnalyses/config/FCCAnalysisRun.py", line 1102, in run
    if args.final:
AttributeError: 'Namespace' object has no attribute 'final'
```

Thoughts? Thanks! 