### PR TITLE
Checking for ONNXRuntime early

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,17 @@ if(WITH_DD4HEP)
   endif()
 endif()
 
+if(WITH_ONNX)
+  find_package(ONNXRuntime)
+  if(ONNXRuntime_FOUND)
+
+  elseif(WITH_ONNX STREQUAL AUTO)
+    message(WARNING "ONNXRuntime not found. Skipping ONNX-dependent analyzers.")
+    set(WITH_ONNX OFF)
+  else()
+    message(FATAL_ERROR "Failed to locate ONNXRuntime!")
+  endif()
+endif()
 
 if(WITH_ONNX AND BUILD_TESTING) # currently these files are only needed by ONNX-parts
 # Grab the test files into a cached directory

--- a/analyzers/dataframe/CMakeLists.txt
+++ b/analyzers/dataframe/CMakeLists.txt
@@ -19,9 +19,6 @@ include_directories(${DELPHES_INCLUDE_DIR}
 file(GLOB sources src/*.cc)
 file(GLOB headers RELATIVE ${CMAKE_CURRENT_LIST_DIR} FCCAnalyses/*.h)
 
-message(STATUS "includes headers ${headers}")
-message(STATUS "includes sources ${sources}")
-
 list(FILTER headers EXCLUDE REGEX "LinkDef.h")
 if(NOT WITH_DD4HEP)
   list(FILTER headers EXCLUDE REGEX "CaloNtupleizer.h")
@@ -30,6 +27,8 @@ endif()
 if(NOT WITH_ONNX)
   list(FILTER headers EXCLUDE REGEX "JetFlavourUtils.h")
   list(FILTER sources EXCLUDE REGEX "JetFlavourUtils.cc")
+  list(FILTER headers EXCLUDE REGEX "WeaverUtils.h")
+  list(FILTER sources EXCLUDE REGEX "WeaverUtils.cc")
 endif()
 
 if(NOT WITH_ACTS)
@@ -39,6 +38,8 @@ if(NOT WITH_ACTS)
   list(FILTER sources EXCLUDE REGEX "VertexFinderActs.cc")
 endif()
 
+message(STATUS "includes headers ${headers}")
+message(STATUS "includes sources ${sources}")
 
 message(STATUS "CMAKE_CURRENT_SOURCE_DIR  ${CMAKE_CURRENT_SOURCE_DIR}")
 message(STATUS "CMAKE_INSTALL_INCLUDEDIR  ${CMAKE_INSTALL_INCLUDEDIR}")

--- a/setup.sh
+++ b/setup.sh
@@ -21,8 +21,12 @@ if [ "${0}" != "${BASH_SOURCE}" ]; then
   export CMAKE_PREFIX_PATH=${LOCAL_DIR}/install:${CMAKE_PREFIX_PATH}
   export ROOT_INCLUDE_PATH=${LOCAL_DIR}/install/include:${ROOT_INCLUDE_PATH}
 
-  export ONNXRUNTIME_ROOT_DIR=`python -c "import onnxruntime; print(onnxruntime.__path__[0]+'/../../../..')"`
-  export LD_LIBRARY_PATH=$ONNXRUNTIME_ROOT_DIR/lib:$LD_LIBRARY_PATH
+  export ONNXRUNTIME_ROOT_DIR=`python -c "import onnxruntime; print(onnxruntime.__path__[0]+'/../../../..')" 2> /dev/null`
+  if [ -z "${ONNXRUNTIME_ROOT_DIR}" ]; then
+    echo "WARNING: ONNX Runtime not found! Related analyzers won't be build..."
+  else
+    export LD_LIBRARY_PATH=${ONNXRUNTIME_ROOT_DIR}/lib:${LD_LIBRARY_PATH}
+  fi
 else
   echo "ERROR: This script is meant to be sourced!"
 fi


### PR DESCRIPTION
The check for the ONNXRuntime in `addons/ONNXRuntime` is not propagated to top scope.