### PR TITLE
Implementing selection by type for Reconstructed particles

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/ReconstructedParticle.h
+++ b/analyzers/dataframe/FCCAnalyses/ReconstructedParticle.h
@@ -35,6 +35,22 @@ namespace ReconstructedParticle{
     float operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in) ;
   };
 
+  /// select ReconstructedParticles by type
+  /// Note: type might not correspond to PDG ID
+  struct sel_type {
+    sel_type(const int type);
+    const int m_type;
+    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in);
+  };
+
+  /// select ReconstructedParticles by type absolut value
+  /// Note: type might not correspond to PDG ID
+  struct sel_absType {
+    sel_absType(const int type);
+    const int m_type;
+    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in);
+  };
+
   /// select ReconstructedParticles with transverse momentum greater than a minimum value [GeV]
   struct sel_pt {
     sel_pt(float arg_min_pt);

--- a/analyzers/dataframe/FCCAnalyses/ReconstructedParticle.h
+++ b/analyzers/dataframe/FCCAnalyses/ReconstructedParticle.h
@@ -43,7 +43,7 @@ namespace ReconstructedParticle{
     ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in);
   };
 
-  /// select ReconstructedParticles by type absolut value
+  /// select ReconstructedParticles by type absolute value
   /// Note: type might not correspond to PDG ID
   struct sel_absType {
     sel_absType(const int type);

--- a/analyzers/dataframe/FCCAnalyses/ReconstructedParticle.h
+++ b/analyzers/dataframe/FCCAnalyses/ReconstructedParticle.h
@@ -40,7 +40,8 @@ namespace ReconstructedParticle{
   struct sel_type {
     sel_type(const int type);
     const int m_type;
-    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in);
+    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>
+    operator()(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in);
   };
 
   /// select ReconstructedParticles by type absolute value
@@ -48,7 +49,8 @@ namespace ReconstructedParticle{
   struct sel_absType {
     sel_absType(const int type);
     const int m_type;
-    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in);
+    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>
+    operator()(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in);
   };
 
   /// select ReconstructedParticles with transverse momentum greater than a minimum value [GeV]

--- a/analyzers/dataframe/src/ReconstructedParticle.cc
+++ b/analyzers/dataframe/src/ReconstructedParticle.cc
@@ -1,10 +1,51 @@
 #include "FCCAnalyses/ReconstructedParticle.h"
+
+// std
 #include <iostream>
+#include <cstdlib>
+#include <stdexcept>
 
 namespace FCCAnalyses{
 
 namespace ReconstructedParticle{
 
+/// sel_type
+sel_type::sel_type(const int type) : m_type(type) {}
+
+ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>
+sel_type::operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in) {
+  ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> result;
+  result.reserve(in.size());
+  for (size_t i = 0; i < in.size(); ++i) {
+    if (in[i].type == m_type) {
+      result.emplace_back(in[i]);
+    }
+  }
+  return result;
+}
+
+
+/// sel_absType
+sel_absType::sel_absType(const int type) : m_type(type) {
+  if (m_type < 0) {
+    throw std::invalid_argument("ReconstructedParticle::sel_absType: Received negative value!");
+  }
+}
+
+ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>
+sel_absType::operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in) {
+  ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> result;
+  result.reserve(in.size());
+  for (size_t i = 0; i < in.size(); ++i) {
+    if (std::abs(in[i].type) == m_type) {
+      result.emplace_back(in[i]);
+    }
+  }
+  return result;
+}
+
+
+/// sel_pt
 sel_pt::sel_pt(float arg_min_pt) : m_min_pt(arg_min_pt) {};
 ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>  sel_pt::operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in) {
   ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> result;

--- a/analyzers/dataframe/src/ReconstructedParticle.cc
+++ b/analyzers/dataframe/src/ReconstructedParticle.cc
@@ -1,8 +1,8 @@
 #include "FCCAnalyses/ReconstructedParticle.h"
 
 // std
-#include <iostream>
 #include <cstdlib>
+#include <iostream>
 #include <stdexcept>
 
 namespace FCCAnalyses{
@@ -12,8 +12,8 @@ namespace ReconstructedParticle{
 /// sel_type
 sel_type::sel_type(const int type) : m_type(type) {}
 
-ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>
-sel_type::operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in) {
+ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> sel_type::operator()(
+    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in) {
   ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> result;
   result.reserve(in.size());
   for (size_t i = 0; i < in.size(); ++i) {
@@ -24,16 +24,16 @@ sel_type::operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in)
   return result;
 }
 
-
 /// sel_absType
 sel_absType::sel_absType(const int type) : m_type(type) {
   if (m_type < 0) {
-    throw std::invalid_argument("ReconstructedParticle::sel_absType: Received negative value!");
+    throw std::invalid_argument(
+        "ReconstructedParticle::sel_absType: Received negative value!");
   }
 }
 
-ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>
-sel_absType::operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in) {
+ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> sel_absType::operator()(
+    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in) {
   ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> result;
   result.reserve(in.size());
   for (size_t i = 0; i < in.size(); ++i) {
@@ -43,7 +43,6 @@ sel_absType::operator() (ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> 
   }
   return result;
 }
-
 
 /// sel_pt
 sel_pt::sel_pt(float arg_min_pt) : m_min_pt(arg_min_pt) {};

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -4,7 +4,11 @@ find_catch_instance()
 # list of labels that we want to ignore
 set(filter_tests "")
 
-add_executable(unittest unittest.cpp myutils.cpp algorithms.cpp)
+add_executable(unittest unittest.cpp
+                        myutils.cpp
+                        algorithms.cpp
+                        ReconstructedParticle.cpp
+)
 target_link_libraries(unittest PUBLIC FCCAnalyses gfortran PRIVATE Catch2::Catch2WithMain)
 target_include_directories(unittest PUBLIC ${VDT_INCLUDE_DIR})
 target_compile_definitions(unittest PUBLIC "-DTEST_INPUT_DATA_DIR=${TEST_INPUT_DATA_DIR}")

--- a/tests/unittest/ReconstructedParticle.cpp
+++ b/tests/unittest/ReconstructedParticle.cpp
@@ -1,0 +1,54 @@
+#include "FCCAnalyses/ReconstructedParticle.h"
+
+// Catch2
+#include "catch2/catch_test_macros.hpp"
+#include <catch2/catch_approx.hpp>
+
+
+TEST_CASE("sel_type", "[ReconstructedParticle]") {
+  ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> pVec;
+  edm4hep::ReconstructedParticleData p1;
+  p1.type = 11;
+  pVec.push_back(p1);
+  edm4hep::ReconstructedParticleData p2;
+  p2.type = 13;
+  pVec.push_back(p2);
+  edm4hep::ReconstructedParticleData p3;
+  p3.type = -11;
+  pVec.push_back(p3);
+  edm4hep::ReconstructedParticleData p4;
+  p4.type = -13;
+  pVec.push_back(p4);
+  FCCAnalyses::ReconstructedParticle::sel_type selType{11};
+  auto res = selType(pVec);
+  REQUIRE(res.size() == 1);
+  REQUIRE(res[0].type == 11);
+}
+
+
+TEST_CASE("sel_absType", "[ReconstructedParticle]") {
+  ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> pVec;
+  edm4hep::ReconstructedParticleData p1;
+  p1.type = 11;
+  pVec.push_back(p1);
+  edm4hep::ReconstructedParticleData p2;
+  p2.type = 13;
+  pVec.push_back(p2);
+  edm4hep::ReconstructedParticleData p3;
+  p3.type = -11;
+  pVec.push_back(p3);
+  edm4hep::ReconstructedParticleData p4;
+  p4.type = -13;
+  pVec.push_back(p4);
+  FCCAnalyses::ReconstructedParticle::sel_absType selAbsType{11};
+  auto res = selAbsType(pVec);
+  REQUIRE(res.size() == 2);
+  REQUIRE(res[0].type == 11);
+  REQUIRE(res[1].type == -11);
+}
+
+
+TEST_CASE("sel_absType__neg_type", "[ReconstructedParticle]") {
+  REQUIRE_THROWS_AS(FCCAnalyses::ReconstructedParticle::sel_absType(-17),
+                    std::invalid_argument);
+}

--- a/tests/unittest/ReconstructedParticle.cpp
+++ b/tests/unittest/ReconstructedParticle.cpp
@@ -4,7 +4,6 @@
 #include "catch2/catch_test_macros.hpp"
 #include <catch2/catch_approx.hpp>
 
-
 TEST_CASE("sel_type", "[ReconstructedParticle]") {
   ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> pVec;
   edm4hep::ReconstructedParticleData p1;
@@ -24,7 +23,6 @@ TEST_CASE("sel_type", "[ReconstructedParticle]") {
   REQUIRE(res.size() == 1);
   REQUIRE(res[0].type == 11);
 }
-
 
 TEST_CASE("sel_absType", "[ReconstructedParticle]") {
   ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> pVec;
@@ -46,7 +44,6 @@ TEST_CASE("sel_absType", "[ReconstructedParticle]") {
   REQUIRE(res[0].type == 11);
   REQUIRE(res[1].type == -11);
 }
-
 
 TEST_CASE("sel_absType__neg_type", "[ReconstructedParticle]") {
   REQUIRE_THROWS_AS(FCCAnalyses::ReconstructedParticle::sel_absType(-17),


### PR DESCRIPTION
The PR implements two functors to select reconstructed particle objects by type or absolute value of type.