### PR TITLE
Bugfix in MCParticle::get_indices_MotherByIndex.

### DIFF
--- a/analyzers/dataframe/src/MCParticle.cc
+++ b/analyzers/dataframe/src/MCParticle.cc
@@ -594,6 +594,7 @@ ROOT::VecOps::RVec<int>  get_indices_MotherByIndex ( int imother,
 	// careful, there can be several particles with the same PDG !
 	if (std::find(found.begin(), found.end(), idx_d) == found.end())  {  // idx_d has NOT already been "used"
 	  found.push_back( idx_d );
+          break;
 	}
       }
     }


### PR DESCRIPTION
In some cases with identical particles in the decay chain requested, decays could be selected that did not correspond to the one requested.