### PR TITLE
Ensure compatibility with latest ACTS versions

### DIFF
--- a/analyzers/dataframe/CMakeLists.txt
+++ b/analyzers/dataframe/CMakeLists.txt
@@ -78,6 +78,7 @@ endif()
 
 if(WITH_ACTS)
   target_link_libraries(FCCAnalyses PUBLIC ActsCore)
+  target_compile_definitions(FCCAnalyses PRIVATE "ACTS_VERSION_MAJOR=${Acts_VERSION_MAJOR}")
 endif()
 
 set_target_properties(FCCAnalyses PROPERTIES

--- a/analyzers/dataframe/src/VertexFinderActs.cc
+++ b/analyzers/dataframe/src/VertexFinderActs.cc
@@ -105,8 +105,10 @@ VertexFinderAMVF(ROOT::VecOps::RVec<edm4hep::TrackState> tracks ){
   Finder::Config finderConfig = {std::move(fitter), seedFinder, ipEstimator,
                                  std::move(linearizer), bField};
 
+#if ACTS_VERSION_MAJOR < 29
   // We do not want to use a beamspot constraint here
   finderConfig.useBeamSpotConstraint = false;
+#endif
   //finderConfig.useSeedConstraint = false;
   //finderConfig.tracksMaxSignificance = 100.;//5.;
   //finderConfig.maxVertexChi2 = 500.;//18.42;
@@ -122,6 +124,11 @@ VertexFinderAMVF(ROOT::VecOps::RVec<edm4hep::TrackState> tracks ){
   using VertexingOptions = Acts::VertexingOptions<Acts::BoundTrackParameters>;
   //VertexingOptions finderOpts(myContext, myContext);
   VertexingOptions finderOpts(geoContext, magFieldContext);
+#if ACTS_VERSION_MAJOR >= 29
+  // We do not want to use a beamspot constraint here
+  finderOpts.useConstraintInFit = false;
+#endif
+
   //  vertexingOptions.vertexConstraint = std::get<BeamSpotData>(csvData);
 
   int Ntr = tracks.size();
@@ -153,7 +160,12 @@ VertexFinderAMVF(ROOT::VecOps::RVec<edm4hep::TrackState> tracks ){
     }
 
     // Get track covariance vector
+#if ACTS_VERSION_MAJOR < 29
     using Covariance = Acts::BoundSymMatrix;
+#else
+    using Covariance = Acts::BoundSquareMatrix;
+#endif
+
     Covariance covMat;
     covMat <<
       covACTS(0,0), covACTS(1,0), covACTS(2,0), covACTS(3,0), covACTS(4,0), covACTS(5,0),
@@ -164,12 +176,15 @@ VertexFinderAMVF(ROOT::VecOps::RVec<edm4hep::TrackState> tracks ){
       covACTS(0,5), covACTS(1,5), covACTS(2,5), covACTS(3,5), covACTS(4,5), covACTS(5,5);
 
     // Create track parameters and add to track list
-    std::shared_ptr<Acts::PerigeeSurface> perigeeSurface;
     Acts::Vector3 beamspotPos;
     beamspotPos << 0.0, 0.0, 0.0;
-    perigeeSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(beamspotPos);
+    auto perigeeSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(beamspotPos);
 
+#if ACTS_VERSION_MAJOR < 30
     allTracks.emplace_back(perigeeSurface, newTrackParams, std::move(covMat));
+#else
+    allTracks.emplace_back(perigeeSurface, newTrackParams, std::move(covMat), Acts::ParticleHypothesis::pion());
+#endif
 
     //std::cout << "params: " << allTracks[i] << std::endl;
     }

--- a/analyzers/dataframe/src/VertexFitterActs.cc
+++ b/analyzers/dataframe/src/VertexFitterActs.cc
@@ -64,10 +64,15 @@ VertexingUtils::FCCAnalysesVertex VertexFitterFullBilloir(ROOT::VecOps::RVec<edm
   //VertexFitter::State state(magFieldContext);
   VertexFitter::State state(bField->makeCache(magFieldContext));
 
+#if ACTS_VERSION_MAJOR < 29
+  using CovMatrix4D = Acts::SymMatrix4;
+#else
+  using CovMatrix4D = Acts::SquareMatrix4;
+#endif
   // Constraint for vertex fit
   Acts::Vertex<Acts::BoundTrackParameters> myConstraint;
   // Some abitrary values
-  Acts::SymMatrix4 myCovMat = Acts::SymMatrix4::Zero();
+  CovMatrix4D myCovMat = CovMatrix4D::Zero();
   myCovMat(0, 0) = 30.;
   myCovMat(1, 1) = 30.;
   myCovMat(2, 2) = 30.;
@@ -110,7 +115,11 @@ VertexingUtils::FCCAnalysesVertex VertexFitterFullBilloir(ROOT::VecOps::RVec<edm
     }
 
     // Get track covariance vector
+#if ACTS_VERSION_MAJOR < 29
     using Covariance = Acts::BoundSymMatrix;
+#else
+    using Covariance = Acts::BoundSquareMatrix;
+#endif
     Covariance covMat;
     covMat <<
       covACTS(0,0), covACTS(1,0), covACTS(2,0), covACTS(3,0), covACTS(4,0), covACTS(5,0),
@@ -121,12 +130,15 @@ VertexingUtils::FCCAnalysesVertex VertexFitterFullBilloir(ROOT::VecOps::RVec<edm
       covACTS(0,5), covACTS(1,5), covACTS(2,5), covACTS(3,5), covACTS(4,5), covACTS(5,5);
 
     // Create track parameters and add to track list
-    std::shared_ptr<Acts::PerigeeSurface> perigeeSurface;
     Acts::Vector3 beamspotPos;
     beamspotPos << 0.0, 0.0, 0.0;
-    perigeeSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(beamspotPos);
+    auto perigeeSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(beamspotPos);
 
+#if ACTS_VERSION_MAJOR < 30
     allTracks.emplace_back(perigeeSurface, newTrackParams, std::move(covMat));
+#else
+    allTracks.emplace_back(perigeeSurface, newTrackParams, std::move(covMat), Acts::ParticleHypothesis::pion());
+#endif
   }
 
 


### PR DESCRIPTION
- Switch from Sym to Square matrix types (introduced in v29)
- Pass pion hypothesis to track param constructor (introduced in v30)

**NOTE: I just made things compile again** (and I only tested with v30.3.2). Specifically the explicit passing of the pion hypothesis to the track param constructor may not be the correct thing to do and probably needs some testing. However, it should at least make sense from an input side, since we assume pions for charged tracks usually.

Fixes #319 