### PR TITLE
Remove old way to set verbosity level

### DIFF
--- a/man/man1/fccanalysis-run.1
+++ b/man/man1/fccanalysis-run.1
@@ -9,8 +9,7 @@ fccanalysis\-run \- run FCC analysis
 \fIfccanalysis run\fR [\-h | \-\-help] [\-\-files\-list FILES_LIST [FILES_LIST ...]]
                 [\-\-output OUTPUT] [\-\-nevents NEVENTS] [\-\-test] [\-\-bench]
                 [\-\-ncpus NCPUS] [\-\-preprocess] [\-\-validate] [\-\-rerunfailed]
-                [\-\-jobdir JOBDIR] [\-\-eloglevel {kUnset,kFatal,kError,kWarning,kInfo,kDebug}]
-                [\-\-batch] <analysis-file>
+                [\-\-jobdir JOBDIR] <analysis-file>
 .fi
 .sp
 .SH DESCRIPTION
@@ -83,11 +82,6 @@ Rerun failed jobs\&.
 \-\-jobdir JOBDIR
 .RS 4
 Specify the batch job directory\&.
-.RE
-.PP
-\-\-eloglevel {kUnset,kFatal,kError,kWarning,kInfo,kDebug}
-.RS 4
-Specify the RDataFrame ELogLevel\&.
 .RE
 .SH ENVIRONMENT VARIABLES
 .PP

--- a/python/FCCAnalysisRun.py
+++ b/python/FCCAnalysisRun.py
@@ -1076,8 +1076,7 @@ def setup_run_parser(parser):
     publicOptions.add_argument("--validate", action='store_true', help="Validate a given production", default=False)
     publicOptions.add_argument("--rerunfailed", action='store_true', help="Rerun failed jobs", default=False)
     publicOptions.add_argument("--jobdir", help="Specify the batch job directory", type=str, default="output.root")
-    publicOptions.add_argument("--eloglevel", help="Specify the RDataFrame ELogLevel", type=str, default="kUnset", choices = ['kUnset','kFatal','kError','kWarning','kInfo','kDebug'])
-    
+
     internalOptions = parser.add_argument_group('\033[4m\033[1m\033[91m Internal options, NOT FOR USERS\033[0m')
     internalOptions.add_argument("--batch", action='store_true', help="Submit on batch", default=False)
 
@@ -1106,35 +1105,24 @@ def run(mainparser, subparser=None):
     # Is this still needed?? 01/04/2022 still to be the case
     _fcc = ROOT.dummyLoader
 
-    # Set the RDF ELogLevel
-    if args.eloglevel != "kUnset":
-        try:
-            verbosity = ROOT.Experimental.RLogScopedVerbosity(
-                ROOT.Detail.RDF.RDFLogChannel(),
-                getattr(ROOT.Experimental.ELogLevel, args.eloglevel)
-            )
-        except AttributeError:
-            LOGGER.warning('Verbosity level "%s" not known by RDataFrame!',
-                           args.eloglevel)
-    else:
-        if args.verbose:
-            # ROOT.Experimental.ELogLevel.kInfo verbosity level is more
-            # equivalent to DEBUG in other log systems
-            LOGGER.debug('Setting verbosity level "kInfo" for RDataFrame...')
-            verbosity = ROOT.Experimental.RLogScopedVerbosity(
-                ROOT.Detail.RDF.RDFLogChannel(),
-                ROOT.Experimental.ELogLevel.kInfo)
-        if args.more_verbose:
-            LOGGER.debug('Setting verbosity level "kDebug" for RDataFrame...')
-            verbosity = ROOT.Experimental.RLogScopedVerbosity(
-                ROOT.Detail.RDF.RDFLogChannel(),
-                ROOT.Experimental.ELogLevel.kDebug)
-        if args.most_verbose:
-            LOGGER.debug('Setting verbosity level "kDebug+10" for '
-                         'RDataFrame...')
-            verbosity = ROOT.Experimental.RLogScopedVerbosity(
-                ROOT.Detail.RDF.RDFLogChannel(),
-                ROOT.Experimental.ELogLevel.kDebug+10)
+    if args.verbose:
+        # ROOT.Experimental.ELogLevel.kInfo verbosity level is more
+        # equivalent to DEBUG in other log systems
+        LOGGER.debug('Setting verbosity level "kInfo" for RDataFrame...')
+        verbosity = ROOT.Experimental.RLogScopedVerbosity(
+            ROOT.Detail.RDF.RDFLogChannel(),
+            ROOT.Experimental.ELogLevel.kInfo)
+    if args.more_verbose:
+        LOGGER.debug('Setting verbosity level "kDebug" for RDataFrame...')
+        verbosity = ROOT.Experimental.RLogScopedVerbosity(
+            ROOT.Detail.RDF.RDFLogChannel(),
+            ROOT.Experimental.ELogLevel.kDebug)
+    if args.most_verbose:
+        LOGGER.debug('Setting verbosity level "kDebug+10" for '
+                     'RDataFrame...')
+        verbosity = ROOT.Experimental.RLogScopedVerbosity(
+            ROOT.Detail.RDF.RDFLogChannel(),
+            ROOT.Experimental.ELogLevel.kDebug+10)
 
     # Load the analysis
     analysisFile = os.path.abspath(analysisFile)

--- a/python/Parsers.py
+++ b/python/Parsers.py
@@ -87,9 +87,6 @@ def setup_run_parser(parser):
                         help='rerun failed jobs')
     parser.add_argument('--jobdir', type=str, default='output.root',
                         help='specify the batch job directory')
-    parser.add_argument('--eloglevel', type=str, default='kUnset',
-                        choices=['kUnset', 'kFatal', 'kError', 'kWarning', 'kInfo', 'kDebug'],
-                        help='specify the RDataFrame ELogLevel')
 
     # Internal argument, not to be used by the users
     parser.add_argument('--batch', action='store_true', default=False,
@@ -102,9 +99,6 @@ def setup_run_parser_final(parser):
     '''
     parser.add_argument('anafile_path',
                         help='path to analysis_final script')
-    parser.add_argument('--eloglevel', type=str, default='kUnset',
-                        choices=['kUnset', 'kFatal', 'kError', 'kWarning', 'kInfo', 'kDebug'],
-                        help='Specify the RDataFrame ELogLevel')
 
 
 def setup_run_parser_plots(parser):

--- a/python/doPlots.py
+++ b/python/doPlots.py
@@ -63,7 +63,7 @@ def mapHistos(var, label, sel, param, rebin):
                 except AttributeError:
                     LOGGER.info('No scale signal, using 1.')
                     param.scaleSig=scaleSig
-                LOGGER.info('ScaleSig: ', scaleSig)
+                LOGGER.info('ScaleSig: %g', scaleSig)
                 hh.Scale(param.intLumi*scaleSig)
                 hh.Rebin(rebin)
 


### PR DESCRIPTION
Removing verbosity level set with `--eloglevel`. Use `-v/-vv/-vvv` instead.