### PR TITLE
Protection in all_invariant_masses computation

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
@@ -252,7 +252,11 @@ namespace FCCAnalyses {
     rv::RVec<TLorentzVector> compute_tlv_jets(const rv::RVec<fastjet::PseudoJet>& jets);
     rv::RVec<TLorentzVector> sum_tlv_constituents(const rv::RVec<FCCAnalysesJetConstituents>& jets);
     float InvariantMass(const TLorentzVector& tlv1, const TLorentzVector& tlv2);
-    rv::RVec<double> all_invariant_masses(rv::RVec<TLorentzVector> AllJets); // invariant masses of all jet pairs given a vector of jets
+    
+    /**
+     * @brief all_invariant_masses takes an RVec of TLorentzVectors of jets and computes the invariant masses of all jet pairs, and returns an RVec with all invariant masses.
+    */
+    rv::RVec<double> all_invariant_masses(rv::RVec<TLorentzVector> AllJets);
     rv::RVec<double> compute_residue_energy(const rv::RVec<TLorentzVector>& tlv_jet,
 					    const rv::RVec<TLorentzVector>& sum_tlv_jcs);
     rv::RVec<double> compute_residue_pt(const rv::RVec<TLorentzVector>& tlv_jet,

--- a/analyzers/dataframe/src/JetConstituentsUtils.cc
+++ b/analyzers/dataframe/src/JetConstituentsUtils.cc
@@ -1269,6 +1269,8 @@ namespace FCCAnalyses
       
       rv::RVec<double> InvariantMasses;
 
+      if(AllJets.size() < 2) return InvariantMasses;
+
       // For each jet, take its invariant mass with the remaining jets. Stop at last jet.
       for(int i = 0; i < AllJets.size()-1; ++i) {
 


### PR DESCRIPTION
Hello `FCCAnalyses` experts - when I implemented `all_invariant_masses` a while ago, I forgot to include a protection on the numbers of jets. This is problematic when running on events that do not have at least 2 jets - which can happen for example with the WW background *even* if you require exclusive clustering with njets = 4. See attached the error, stage 1 config file, and command run to produce the error:

[error.log](https://github.com/HEP-FCC/FCCAnalyses/files/14108681/error.log)
[cmd.log](https://github.com/HEP-FCC/FCCAnalyses/files/14108683/cmd.log)
[ZH_Hadronic_stage1.py.txt](https://github.com/HEP-FCC/FCCAnalyses/files/14108685/ZH_Hadronic_stage1.py.txt)

The error is fixed for me when adding the simple protection.

__________________

Files edited:
- `analyzers/dataframe/src/JetConstituentsUtils.cc`:
  - Added the protection.

__________________

By the way, I've encountered the same problem when importing [this weaver example](https://github.com/HEP-FCC/FCCAnalyses/blob/bb9370d266e5e9e5e5643cd76bdee58f7e68214f/examples/FCCee/weaver/stage1.py#L41) as by default it computes invariant mass assuming you have two jets. Given that this is just an example, not sure if the protection is necessary here.