### PR TITLE
Prepare for upcoming renaming and interface introduction

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
@@ -4,6 +4,15 @@
 #include "ROOT/RVec.hxx"
 #include "edm4hep/ReconstructedParticle.h"
 #include "edm4hep/MCParticle.h"
+#if __has_include("edm4hep/TrackerHit3DData.h")
+#include "edm4hep/TrackerHit3DData.h"
+#else
+#include "edm4hep/TrackerHitData.h"
+namespace edm4hep {
+  using TrackerHit3DData = edm4hep::TrackerHitData;
+}
+#endif
+
 #include "fastjet/JetDefinition.hh"
 
 #include "TMath.h"
@@ -195,7 +204,7 @@ namespace FCCAnalyses {
     rv::RVec<FCCAnalysesJetConstituentsData> get_mtof(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
                                                       const rv::RVec<float>& track_L,
                                                       const rv::RVec<edm4hep::TrackData>& trackdata,
-                                                      const rv::RVec<edm4hep::TrackerHitData>& trackerhits,
+                                                      const rv::RVec<edm4hep::TrackerHit3DData>& trackerhits,
                                                       const rv::RVec<edm4hep::ClusterData>& gammadata,
                                                       const rv::RVec<edm4hep::ClusterData>& nhdata,
                                                       const rv::RVec<edm4hep::CalorimeterHitData>& calohits,

--- a/analyzers/dataframe/FCCAnalyses/ReconstructedParticle2Track.h
+++ b/analyzers/dataframe/FCCAnalyses/ReconstructedParticle2Track.h
@@ -10,7 +10,14 @@
 #include "edm4hep/ReconstructedParticleData.h"
 #include "edm4hep/TrackData.h"
 #include "edm4hep/TrackState.h"
+#if __has_include("edm4hep/TrackerHit3DData.h")
+#include "edm4hep/TrackerHit3DData.h"
+#else
 #include "edm4hep/TrackerHitData.h"
+namespace edm4hep {
+  using TrackerHit3DData = edm4hep::TrackerHitData;
+}
+#endif
 #include <TVectorD.h>
 #include <TVector3.h>
 #include <TLorentzVector.h>

--- a/analyzers/dataframe/FCCAnalyses/ReconstructedTrack.h
+++ b/analyzers/dataframe/FCCAnalyses/ReconstructedTrack.h
@@ -7,7 +7,15 @@
 #include "edm4hep/Quantity.h"
 #include "edm4hep/TrackData.h"
 #include "edm4hep/TrackState.h"
+
+#if __has_include("edm4hep/TrackerHit3DData.h")
+#include "edm4hep/TrackerHit3DData.h"
+#else
 #include "edm4hep/TrackerHitData.h"
+namespace edm4hep {
+  using TrackerHit3DData = edm4hep::TrackerHitData;
+}
+#endif
 
 namespace FCCAnalyses {
 
@@ -53,13 +61,13 @@ tracks_length(const ROOT::VecOps::RVec<edm4hep::TrackState> &some_tracks,
 ROOT::VecOps::RVec<float> tracks_TOF(
     const ROOT::VecOps::RVec<int> &track_indices,
     const ROOT::VecOps::RVec<edm4hep::TrackData> &trackdata, // Eflowtrack
-    const ROOT::VecOps::RVec<edm4hep::TrackerHitData> &trackerhits);
+    const ROOT::VecOps::RVec<edm4hep::TrackerHit3DData> &trackerhits);
 
 ROOT::VecOps::RVec<float> tracks_TOF(
     const ROOT::VecOps::RVec<edm4hep::TrackState> &some_tracks,
     const ROOT::VecOps::RVec<edm4hep::TrackState> &FullTracks,
     const ROOT::VecOps::RVec<edm4hep::TrackData> &trackdata, // Eflowtrack
-    const ROOT::VecOps::RVec<edm4hep::TrackerHitData> &trackerhits);
+    const ROOT::VecOps::RVec<edm4hep::TrackerHit3DData> &trackerhits);
 
 /// the dndx values
 ROOT::VecOps::RVec<float> tracks_dNdx(

--- a/analyzers/dataframe/FCCAnalyses/SmearObjects.h
+++ b/analyzers/dataframe/FCCAnalyses/SmearObjects.h
@@ -70,11 +70,11 @@ struct SmearedTracksTOF {
   TRandom m_random;
   float m_scale;
   SmearedTracksTOF(float m_scale, bool debug);
-  ROOT::VecOps::RVec<edm4hep::TrackerHitData>
+  ROOT::VecOps::RVec<edm4hep::TrackerHit3DData>
   operator()(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>
                  &allRecoParticles,
              const ROOT::VecOps::RVec<edm4hep::TrackData> &trackdata,
-             const ROOT::VecOps::RVec<edm4hep::TrackerHitData> &trackerhits,
+             const ROOT::VecOps::RVec<edm4hep::TrackerHit3DData> &trackerhits,
              const ROOT::VecOps::RVec<float> &length,
              const ROOT::VecOps::RVec<int> &RP2MC_indices,
              const ROOT::VecOps::RVec<edm4hep::MCParticleData> &mcParticles);

--- a/analyzers/dataframe/src/JetConstituentsUtils.cc
+++ b/analyzers/dataframe/src/JetConstituentsUtils.cc
@@ -4,7 +4,6 @@
 #include "FCCAnalyses/ReconstructedParticle2MC.h"
 #include "edm4hep/MCParticleData.h"
 #include "edm4hep/Track.h"
-#include "edm4hep/TrackerHitData.h"
 #include "edm4hep/TrackData.h"
 #include "edm4hep/Cluster.h"
 #include "edm4hep/ClusterData.h"
@@ -754,7 +753,7 @@ namespace FCCAnalyses
     rv::RVec<FCCAnalysesJetConstituentsData> get_mtof(const rv::RVec<FCCAnalysesJetConstituents> &jcs,
                                                       const rv::RVec<float> &track_L,
                                                       const rv::RVec<edm4hep::TrackData> &trackdata,
-                                                      const rv::RVec<edm4hep::TrackerHitData> &trackerhits,
+                                                      const rv::RVec<edm4hep::TrackerHit3DData> &trackerhits,
                                                       const rv::RVec<edm4hep::ClusterData> &gammadata,
                                                       const rv::RVec<edm4hep::ClusterData> &nhdata,
                                                       const rv::RVec<edm4hep::CalorimeterHitData> &calohits,

--- a/analyzers/dataframe/src/ReconstructedTrack.cc
+++ b/analyzers/dataframe/src/ReconstructedTrack.cc
@@ -159,7 +159,7 @@ ROOT::VecOps::RVec<float> tracks_length(
 ROOT::VecOps::RVec<float> tracks_TOF(
     const ROOT::VecOps::RVec<int> &track_indices,
     const ROOT::VecOps::RVec<edm4hep::TrackData> &trackdata, // Eflowtrack
-    const ROOT::VecOps::RVec<edm4hep::TrackerHitData> &trackerhits) {
+    const ROOT::VecOps::RVec<edm4hep::TrackerHit3DData> &trackerhits) {
 
   ROOT::VecOps::RVec<float> results;
   for (int i = 0; i < track_indices.size(); i++) {
@@ -179,7 +179,7 @@ ROOT::VecOps::RVec<float> tracks_TOF(
     float tof = -1;
     if (tk_jdx >= 0) {
       int idx_tout = trackdata[tk_jdx].trackerHits_end - 1; // at calo
-      edm4hep::TrackerHitData thits_2 = trackerhits.at(idx_tout);
+      edm4hep::TrackerHit3DData thits_2 = trackerhits.at(idx_tout);
       float hit_time = thits_2.time; // in s
       tof = hit_time * 1e12;         // in ps
     }
@@ -193,7 +193,7 @@ ROOT::VecOps::RVec<float> tracks_TOF(
     const ROOT::VecOps::RVec<edm4hep::TrackState> &some_tracks,
     const ROOT::VecOps::RVec<edm4hep::TrackState> &FullTracks,
     const ROOT::VecOps::RVec<edm4hep::TrackData> &trackdata, // Eflowtrack
-    const ROOT::VecOps::RVec<edm4hep::TrackerHitData> &trackerhits) {
+    const ROOT::VecOps::RVec<edm4hep::TrackerHit3DData> &trackerhits) {
   ROOT::VecOps::RVec<int> indices = get_indices(some_tracks, FullTracks);
   return tracks_TOF(indices, trackdata, trackerhits);
 }

--- a/analyzers/dataframe/src/SmearObjects.cc
+++ b/analyzers/dataframe/src/SmearObjects.cc
@@ -390,11 +390,11 @@ SmearedTracksTOF::SmearedTracksTOF(float scale, bool debug = false) {
   m_debug = debug;
 }
 
-ROOT::VecOps::RVec<edm4hep::TrackerHitData> SmearedTracksTOF::operator()(
+ROOT::VecOps::RVec<edm4hep::TrackerHit3DData> SmearedTracksTOF::operator()(
     const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>
         &allRecoParticles,
     const ROOT::VecOps::RVec<edm4hep::TrackData> &trackdata,
-    const ROOT::VecOps::RVec<edm4hep::TrackerHitData> &trackerhits,
+    const ROOT::VecOps::RVec<edm4hep::TrackerHit3DData> &trackerhits,
     const ROOT::VecOps::RVec<float> &length,
     const ROOT::VecOps::RVec<int> &RP2MC_indices,
     const ROOT::VecOps::RVec<edm4hep::MCParticleData> &mcParticles) {
@@ -403,8 +403,8 @@ ROOT::VecOps::RVec<edm4hep::TrackerHitData> SmearedTracksTOF::operator()(
   // retrieve the MC particle that is associated to a track, and builds a "track
   // state" out of the MC particle and regenerates a new value of the dNdx
 
-  ROOT::VecOps::RVec<edm4hep::TrackerHitData> result;
-  edm4hep::TrackerHitData dummy;
+  ROOT::VecOps::RVec<edm4hep::TrackerHit3DData> result;
+  edm4hep::TrackerHit3DData dummy;
 
   int ntracks = length.size();
   int nhits = trackerhits.size(); // 3x size of tracks since 3 hits per track
@@ -415,8 +415,8 @@ ROOT::VecOps::RVec<edm4hep::TrackerHitData> SmearedTracksTOF::operator()(
   float c_light = 2.99792458e+8;
   float mm_to_sec = 1e-03 / c_light;
 
-  edm4hep::TrackerHitData thits_0, thits_1, thits_2;
-  edm4hep::TrackerHitData smeared_thits_0, smeared_thits_1, smeared_thits_2;
+  edm4hep::TrackerHit3DData thits_0, thits_1, thits_2;
+  edm4hep::TrackerHit3DData smeared_thits_0, smeared_thits_1, smeared_thits_2;
 
   for (int itrack = 0; itrack < ntracks; itrack++) {
 


### PR DESCRIPTION
Aliasing the current `edm4hep::TrackerHitData` to `edm4hep::TrackerHit3DData` in case the latter is not yet available. Directly using that if it is available. See (https://github.com/key4hep/EDM4hep/pull/252) for more details.

This PR should make that switch transparent at least from the interface point of view.

I have prepared this to ease the merging of the EDM4hep PR, in order to allow us to still build the key4hep nightlies once that goes in. Once that is merged things are probably going to break all over the place, including FCCAnalyses, since there is no schema evolution at all to catch any of that. We could think about removing the "legacy" support than and also making the dependency on a suitable version of EDM4hep more explicit in the CMakeLists.txt.