### PR TITLE
Make upcoming introduction of cov matrix components transparent

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/VertexingUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/VertexingUtils.h
@@ -305,13 +305,16 @@ namespace VertexingUtils{
   TVectorD Delphes2Edm4hep_TrackParam( const TVectorD& param, bool Units_mm );
 /// convert track covariance matrix, from edm4hep to delphes conventions
   TMatrixDSym  Edm4hep2Delphes_TrackCovMatrix( const std::array<float, 21>&  covMatrix, bool Units_mm );
+#if __has_include("edm4hep/CovMatrix6f.h")
+  TMatrixDSym  Edm4hep2Delphes_TrackCovMatrix( const edm4hep::CovMatrix6f&  covMatrix, bool Units_mm );
+#endif
 /// convert track covariance matrix, from delphes to edm4hep conventions
   std::array<float, 21> Delphes2Edm4hep_TrackCovMatrix( const TMatrixDSym& cov, bool Units_mm ) ;
 
 
  /// --- Internal methods needed by the code of  Franco B:
   TVectorD get_trackParam( edm4hep::TrackState & atrack, bool Units_mm = false) ;
-  TMatrixDSym get_trackCov( edm4hep::TrackState &  atrack, bool Units_mm = false) ;
+  TMatrixDSym get_trackCov( const edm4hep::TrackState &  atrack, bool Units_mm = false) ;
 
   TVectorD ParToACTS(TVectorD Par);
   TMatrixDSym CovToACTS(TMatrixDSym Cov,TVectorD Par);

--- a/analyzers/dataframe/src/VertexingUtils.cc
+++ b/analyzers/dataframe/src/VertexingUtils.cc
@@ -151,6 +151,14 @@ TVectorD Delphes2Edm4hep_TrackParam(const TVectorD &param, bool Units_mm) {
   return result;
 }
 
+#if __has_include("edm4hep/CovMatrix6f.h")
+TMatrixDSym
+Edm4hep2Delphes_TrackCovMatrix(const edm4hep::CovMatrix6f &covMatrix,
+                               bool Units_mm) {
+  return Edm4hep2Delphes_TrackCovMatrix(covMatrix.values, Units_mm);
+}
+#endif
+
 TMatrixDSym
 Edm4hep2Delphes_TrackCovMatrix(const std::array<float, 21> &covMatrix,
                                bool Units_mm) {
@@ -270,12 +278,10 @@ TVectorD get_trackParam(edm4hep::TrackState &atrack, bool Units_mm) {
   return res;
 }
 
-TMatrixDSym get_trackCov(edm4hep::TrackState &atrack, bool Units_mm) {
-  auto covMatrix = atrack.covMatrix;
+TMatrixDSym get_trackCov(const edm4hep::TrackState &atrack, bool Units_mm) {
+  const auto &covMatrix = atrack.covMatrix;
 
-  TMatrixDSym covM = Edm4hep2Delphes_TrackCovMatrix(covMatrix, Units_mm);
-
-  return covM;
+  return Edm4hep2Delphes_TrackCovMatrix(covMatrix, Units_mm);
 }
 
 // ----------------------------------------------------------------------------------------

--- a/analyzers/dataframe/src/myUtils.cc
+++ b/analyzers/dataframe/src/myUtils.cc
@@ -294,10 +294,10 @@ merge_VertexObjet(ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> in){
   std::cout<<"============================"<<std::endl;
   for (size_t i = 0; i < in.size()-1; ++i){
     edm4hep::VertexData vi = in.at(i).vertex;
-    std::array<float,6> vi_covMatrix = vi.covMatrix;
+    const auto& vi_covMatrix = vi.covMatrix;
     for (size_t j = i+1; j < in.size(); ++j){
       edm4hep::VertexData vj = in.at(j).vertex;
-      std::array<float,6> vj_covMatrix = vj.covMatrix;
+      const auto& vj_covMatrix = vj.covMatrix;
       float dist = get_distanceVertex(vi,vj,-1);
       float err1 = sqrt(vi_covMatrix[0]+vj_covMatrix[0]+vi_covMatrix[2]+vj_covMatrix[2]+vi_covMatrix[5]+vj_covMatrix[5]);
       float err2 = get_distanceErrorVertex(vi,vj,-1);
@@ -605,8 +605,8 @@ float get_distanceVertex(edm4hep::VertexData v1, edm4hep::VertexData v2, int com
 
 float get_distanceErrorVertex(edm4hep::VertexData v1, edm4hep::VertexData v2, int comp){
 
-  std::array<float,6> v1_covMatrix = v1.covMatrix;
-  std::array<float,6> v2_covMatrix = v2.covMatrix;
+  const auto& v1_covMatrix = v1.covMatrix;
+  const auto& v2_covMatrix = v2.covMatrix;
 
   //when error on x, y, z only
   if      (comp==0) return sqrt(v1_covMatrix[0]+v2_covMatrix[0]);


### PR DESCRIPTION
https://github.com/key4hep/EDM4hep/pull/287 introduces dedicated covariance matrix components. These are the minimal changes necessary in order to build with current EDM4hep and keep building with the version with covariance matrix components.

Marking this as WIP until we have actually decided whether we want to have the covariance matrix components.