### PR TITLE
Add support for compiling with newer ONNXRuntime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,11 @@ if(WITH_DD4HEP)
 endif()
 
 if(WITH_ONNX)
+  # New onnxruntime (at least 1.17.1 and above) provide a onnxruntimeConfig.cmake
+  # and use the name onnxruntime
+  find_package(onnxruntime)
   find_package(ONNXRuntime)
-  if(ONNXRuntime_FOUND)
+  if(onnxruntime_FOUND OR ONNXRuntime_FOUND)
 
   elseif(WITH_ONNX STREQUAL AUTO)
     message(WARNING "ONNXRuntime not found. Skipping ONNX-dependent analyzers.")

--- a/addons/ONNXRuntime/CMakeLists.txt
+++ b/addons/ONNXRuntime/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 find_package(ONNXRuntime QUIET)
 find_package(nlohmann_json QUIET)
 find_package(ROOT COMPONENTS ROOTVecOps QUIET)
-if(ONNXRuntime_FOUND AND nlohmann_json_FOUND)
+if(nlohmann_json_FOUND)
   message(STATUS "includes-------------------------- onnxruntime: ${ONNXRUNTIME_INCLUDE_DIRS}")
 elseif(WITH_ONNX STREQUAL AUTO)
   message(WARNING "ONNXRuntime and/or nlohmann's JSON libraries not found. Skipping ONNX-dependent analyzers.")
@@ -14,6 +14,11 @@ elseif(WITH_ONNX STREQUAL AUTO)
 else()
   message(FATAL_ERROR "Failed to locate ONNXRuntime and/or nlohmann's JSON library!")
 endif()
+# For the newer versions of ONNXRuntime, including directories is done
+# through the onnxruntime::onnxruntime target
+if(onnxruntime_FOUND)
+  set(ONNXRUNTIME_LIBRARIES onnxruntime::onnxruntime)
+endif()
 
 file(GLOB sources src/*.cc)
 file(GLOB headers *.h)
@@ -21,7 +26,7 @@ file(GLOB headers *.h)
 fccanalyses_addon_build(ONNXRuntime
                         SOURCES ${sources} ${headers}
                         EXT_HEADERS ${ONNXRUNTIME_INCLUDE_DIRS}
-                        EXT_LIBS ROOT::ROOTVecOps ${ONNXRUNTIME_LIBRARIES} nlohmann_json::nlohmann_json
+                        EXT_LIBS ROOT::ROOTVecOps ${ONNXRUNTIME_LIBRARIES} nlohmann_json::nlohmann_json ${ONNXRUNTIME_LIBRARIES}
                         INSTALL_COMPONENT onnxruntime)
 
 add_custom_command(TARGET ONNXRuntime POST_BUILD


### PR DESCRIPTION
At least version 1.17.1 (this is the most recent one in spack) provides onnxruntimeConfig.cmake and uses the name "onnxruntime" all lower case. This PR should make it possible to build with 1.17.1 (waiting for confirmation if the stack builds) and with the current ONNXRuntime version (CI seems to confirm this)

Related to this, it seems newer versions of ONNXRuntime don't install the headers that are being used by FCCAnalyses (everything under `include/onnxruntime/core` doesn't get installed except `common`):
https://github.com/HEP-FCC/FCCAnalyses/blob/994d52c51aba675dc9ff0c0653383a864ef9b5f3/addons/ONNXRuntime/src/ONNXRuntime.cc#L3
This seems to have changed from the version that was installed last time, which was 1.10.0. In that one, I can see the whole `core` folder being installed. For now I'm patching `ONNXRuntime` but I didn't even find an option in `ONNXRuntime` to install these. Are these intended to be used then?

See also https://github.com/key4hep/key4hep-spack/issues/578