### PR TITLE
Suppressing printf output from TMatrixBase

### DIFF
--- a/analyzers/dataframe/src/VertexFitterSimple.cc
+++ b/analyzers/dataframe/src/VertexFitterSimple.cc
@@ -143,8 +143,10 @@ VertexFitter_Tk(int Primary, ROOT::VecOps::RVec<edm4hep::TrackState> tracks,
 
   int Ntr = tracks.size();
   TheVertex.ntracks = Ntr;
-  if (Ntr <= 1)
+  if (Ntr <= 1) {
+    resume_stdout(fd);
     return TheVertex; // can not reconstruct a vertex with only one track...
+  }
 
   TVectorD **trkPar = new TVectorD *[Ntr];
   TMatrixDSym **trkCov = new TMatrixDSym *[Ntr];


### PR DESCRIPTION
Vertexing analyzers and in turn Delphes heavily uses TMatrix which prints through `printf()`, this PR suppresses the large amount of printouts generated. Ideally the printouts should be adjusted in Delphes, but for the pre-EDM4hep 1.0 versions of the analyses this won't help as the Delphes version is frozen.