### PR TITLE
Make ROOT load libraries without the .so extension

### DIFF
--- a/addons/TMVAHelper/python/TMVAHelper.py
+++ b/addons/TMVAHelper/python/TMVAHelper.py
@@ -3,7 +3,7 @@ import ROOT
 import pathlib
 
 ROOT.gInterpreter.ProcessLine('#include "TMVAHelper/TMVAHelper.h"')
-ROOT.gSystem.Load("libTMVAHelper.so")
+ROOT.gSystem.Load("libTMVAHelper")
 
 class TMVAHelperXGB():
 

--- a/examples/FCCee/vertex/reproducer.cc
+++ b/examples/FCCee/vertex/reproducer.cc
@@ -21,12 +21,12 @@ void reproducer()
 {
 
   gInterpreter->ProcessLine("#include \"VertexFinderActs.h\"");
-  gSystem->Load("libpodio.so");
-  gSystem->Load("libpodioDict.so");
-  gSystem->Load("libpodioRootIO.so");
-  gSystem->Load("libedm4hep.so");
-  gSystem->Load("libedm4hepDict.so");
-  gSystem->Load("libFCCAnalyses.so");
+  gSystem->Load("libpodio");
+  gSystem->Load("libpodioDict");
+  gSystem->Load("libpodioRootIO");
+  gSystem->Load("libedm4hep");
+  gSystem->Load("libedm4hepDict");
+  gSystem->Load("libFCCAnalyses");
 
   auto reader = podio::ROOTReader();
   reader.openFile("https://fcc-physics-events.web.cern.ch/fcc-physics-events/sharedFiles/FCCee/test_zbb_Bs2DsK.root");

--- a/examples/FCChh/tth_4l/fcchh_ana_tth_4l.cxx
+++ b/examples/FCChh/tth_4l/fcchh_ana_tth_4l.cxx
@@ -29,7 +29,7 @@ int main(int argc, char* argv[]){
    #endif
 
    // fcc edm libraries
-   gSystem->Load("libdatamodel.so");
+   gSystem->Load("libdatamodel");
 
    // very basic command line argument parsing
    if (argc < 3) {


### PR DESCRIPTION
so that in works on other operating systems like MacOS. See https://github.com/key4hep/EDM4hep/pull/339 and https://github.com/key4hep/EDM4hep/issues/338