### PR TITLE
Disable the reading of dQ/dx values form Tracks

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
@@ -4,6 +4,7 @@
 #include "ROOT/RVec.hxx"
 #include "edm4hep/ReconstructedParticle.h"
 #include "edm4hep/MCParticle.h"
+#include "edm4hep/Quantity.h"
 #if __has_include("edm4hep/TrackerHit3DData.h")
 #include "edm4hep/TrackerHit3DData.h"
 #else

--- a/analyzers/dataframe/src/JetConstituentsUtils.cc
+++ b/analyzers/dataframe/src/JetConstituentsUtils.cc
@@ -377,7 +377,11 @@ namespace FCCAnalyses
         {
           if (ct.at(j).tracks_begin < trackdata.size() && (int)isChargedHad.at(j) == 1)
           {
+#if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 10, 6)
+            tmp.push_back(-1);
+#else
             tmp.push_back(dNdx.at(trackdata.at(ct.at(j).tracks_begin).dxQuantities_begin).value / 1000.);
+#endif
           }
           else
           {

--- a/analyzers/dataframe/src/ReconstructedTrack.cc
+++ b/analyzers/dataframe/src/ReconstructedTrack.cc
@@ -1,6 +1,8 @@
 #include "FCCAnalyses/ReconstructedParticle.h"
 #include <iostream>
 
+#include "edm4hep/EDM4hepVersion.h"
+
 #include "FCCAnalyses/ReconstructedTrack.h"
 #include "FCCAnalyses/VertexingUtils.h"
 
@@ -219,10 +221,12 @@ ROOT::VecOps::RVec<float> tracks_dNdx(
       }
     }
     float dndx = -1;
+#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 10, 5)
     if (tk_jdx >= 0) {
       int j = trackdata[tk_jdx].dxQuantities_begin;
       dndx = dNdx[j].value / 1000;
     }
+#endif
     results.push_back(dndx);
   }
   return results;


### PR DESCRIPTION
As discussed this PR temporarily disables the reading of dQ/dx values form Tracks since this information will be removed from EDM4hep in https://github.com/key4hep/EDM4hep/pull/311. Instead dummy (`-1`) values will be filled.

A proper fix will require some conceptual rework of these methods which take different collections as inputs.