### PR TITLE
Add checks for TVMA::Experimental::RBDT since it is not a template anymore

### DIFF
--- a/addons/TMVAHelper/TMVAHelper.h
+++ b/addons/TMVAHelper/TMVAHelper.h
@@ -4,6 +4,7 @@
 // ROOT
 #include "ROOT/RVec.hxx"
 #include "TMVA/RBDT.hxx"
+#include "RVersion.h"
 
 // TBB
 #include <tbb/task_arena.h>
@@ -22,7 +23,10 @@ public:
 private:
   // Default backend (template parameter) is:
   // TMVA::Experimental::BranchlessJittedForest<float>
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 0)
+  std::vector<TMVA::Experimental::RBDT> m_interpreters;
+#else
   std::vector<TMVA::Experimental::RBDT<>> m_interpreters;
+#endif
 };
 
-#endif

--- a/addons/TMVAHelper/TMVAHelper.h
+++ b/addons/TMVAHelper/TMVAHelper.h
@@ -3,8 +3,8 @@
 
 // ROOT
 #include "ROOT/RVec.hxx"
-#include "TMVA/RBDT.hxx"
 #include "RVersion.h"
+#include "TMVA/RBDT.hxx"
 
 // TBB
 #include <tbb/task_arena.h>

--- a/addons/TMVAHelper/TMVAHelper.h
+++ b/addons/TMVAHelper/TMVAHelper.h
@@ -30,3 +30,4 @@ private:
 #endif
 };
 
+#endif

--- a/addons/TMVAHelper/src/TMVAHelper.cc
+++ b/addons/TMVAHelper/src/TMVAHelper.cc
@@ -1,5 +1,7 @@
 #include "TMVAHelper/TMVAHelper.h"
 
+#include "RVersion.h"
+
 tmva_helper_xgb::tmva_helper_xgb(const std::string &filename,
                                  const std::string &name,
                                  const unsigned int nslots) {
@@ -7,7 +9,12 @@ tmva_helper_xgb::tmva_helper_xgb(const std::string &filename,
   const unsigned int nslots_actual = std::max(nslots, 1U);
   m_interpreters.reserve(nslots_actual);
   for (unsigned int islot = 0; islot < nslots_actual; ++islot) {
+
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 32, 0)
+    m_interpreters.emplace_back(TMVA::Experimental::RBDT(name, filename));
+#else
     m_interpreters.emplace_back(TMVA::Experimental::RBDT<>(name, filename));
+#endif
   }
 }
 


### PR DESCRIPTION
after ROOT 6.32.0, failing with a compilation error. This was changed in https://github.com/root-project/root/pull/15173.