### PR TITLE
Abort in case input file does not contain events ttree

### DIFF
--- a/python/process.py
+++ b/python/process.py
@@ -22,8 +22,11 @@ def get_entries(inpath: str) -> int:
     '''
     nevents = None
     with ROOT.TFile(inpath, 'READ') as infile:
-        tt = infile.Get("events")
-        nevents = tt.GetEntries()
+        try:
+            nevents = infile.Get("events").GetEntries()
+        except AttributeError:
+            LOGGER.error('Input file is missing "events" TTree!\nAborting...')
+            sys.exit(3)
     return nevents
 
 


### PR DESCRIPTION
Fixes https://github.com/HEP-FCC/FCCAnalyses/issues/398.

For now it hard stops the execution of the script.

Test failure expected, as the `pre-edm4hep1` branch is no longer compatible with the latest versions of the stack.