### PR TITLE
Add REQUIRED for fastjet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ find_package(TBB REQUIRED COMPONENTS tbb)
 
 # need to use our own FindFastJet.cmake
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
-find_package(FastJet)
+find_package(FastJet REQUIRED)
 
 find_package( Delphes REQUIRED )
 


### PR DESCRIPTION
since compilation will fail if it's not found