### PR TITLE
PodioSource: Adding remove, merge and createPseudoJets analyzers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
            mkdir -p build install; \
            source ${{ matrix.STACK }}; \
            cd build; \
-           cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -DWITH_DD4HEP=ON -DWITH_ACTS=OFF -DWITH_ONNX=ON -G Ninja ..;'
+           cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -DWITH_DD4HEP=ON -DWITH_ACTS=OFF -DWITH_ONNX=ON -DWITH_PODIO_DATASOURCE=ON -G Ninja ..;'
     - name: Compile
       run: |
         docker exec CI_container /bin/bash -c 'cd ./Package; \

--- a/analyzers/dataframe/CMakeLists.txt
+++ b/analyzers/dataframe/CMakeLists.txt
@@ -48,7 +48,7 @@ message(STATUS "FCCAnalyses sources:\n   ${sources}")
 message(STATUS "CMAKE_CURRENT_SOURCE_DIR  ${CMAKE_CURRENT_SOURCE_DIR}")
 message(STATUS "CMAKE_INSTALL_INCLUDEDIR  ${CMAKE_INSTALL_INCLUDEDIR}")
 
-add_library(FCCAnalyses ${sources})
+add_library(FCCAnalyses SHARED ${sources})
 target_include_directories(FCCAnalyses PUBLIC
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/addons>

--- a/analyzers/dataframe/CMakeLists.txt
+++ b/analyzers/dataframe/CMakeLists.txt
@@ -33,6 +33,7 @@ if(NOT WITH_ACTS)
 endif()
 
 if(NOT WITH_PODIO_DATASOURCE)
+  list(FILTER headers EXCLUDE REGEX "JetClusteringUtilsSource.h")
   list(FILTER headers EXCLUDE REGEX "LinkSource.h")
   list(FILTER headers EXCLUDE REGEX "ReconstructedParticleSource.h")
   list(FILTER sources EXCLUDE REGEX "ReconstructedParticleSource.cc")

--- a/analyzers/dataframe/CMakeLists.txt
+++ b/analyzers/dataframe/CMakeLists.txt
@@ -34,6 +34,7 @@ endif()
 
 if(NOT WITH_PODIO_DATASOURCE)
   list(FILTER headers EXCLUDE REGEX "JetClusteringUtilsSource.h")
+  list(FILTER sources EXCLUDE REGEX "JetClusteringUtilsSource.cc")
   list(FILTER headers EXCLUDE REGEX "LinkSource.h")
   list(FILTER headers EXCLUDE REGEX "ReconstructedParticleSource.h")
   list(FILTER sources EXCLUDE REGEX "ReconstructedParticleSource.cc")

--- a/analyzers/dataframe/CMakeLists.txt
+++ b/analyzers/dataframe/CMakeLists.txt
@@ -48,7 +48,7 @@ message(STATUS "FCCAnalyses sources:\n   ${sources}")
 message(STATUS "CMAKE_CURRENT_SOURCE_DIR  ${CMAKE_CURRENT_SOURCE_DIR}")
 message(STATUS "CMAKE_INSTALL_INCLUDEDIR  ${CMAKE_INSTALL_INCLUDEDIR}")
 
-add_library(FCCAnalyses SHARED ${sources} ${headers})
+add_library(FCCAnalyses ${sources})
 target_include_directories(FCCAnalyses PUBLIC
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/addons>
@@ -67,12 +67,12 @@ target_link_libraries(FCCAnalyses PUBLIC
                       ROOT::MathCore
                       ROOT::ROOTVecOps
                       ROOT::ROOTDataFrame
-                      EDM4HEP::edm4hep
-                      EDM4HEP::edm4hepDict
-                      EDM4HEP::utils
                       podio::podio
                       podio::podioRootIO
                       podio::podioDataSource
+                      EDM4HEP::edm4hep
+                      EDM4HEP::edm4hepDict
+                      EDM4HEP::utils
                       ${ADDONS_LIBRARIES}
                       ${DELPHES_LIBRARY}
                       gfortran # todo: why necessary?
@@ -112,4 +112,4 @@ if (${ROOT_VERSION} GREATER 6)
     install(FILES
           "${PROJECT_BINARY_DIR}/analyzers/dataframe/libFCCAnalyses_rdict.pcm"
                 DESTINATION "${INSTALL_LIB_DIR}" COMPONENT dev)
-    endif()
+endif()

--- a/analyzers/dataframe/FCCAnalyses/JetClusteringUtilsSource.h
+++ b/analyzers/dataframe/FCCAnalyses/JetClusteringUtilsSource.h
@@ -22,8 +22,8 @@ namespace FCCAnalyses ::PodioSource ::JetClustering {
  * @brief  Create FastJet pseudoJets for later usage by the jet clustering
  *         algorithm(s).
  *
-   * @param[in] inColl  Input collection of the reconstructed particles.
-   * @return  Vector of pseudoJets.
+ * @param[in] inColl  Input collection of the reconstructed particles.
+ * @return  Vector of pseudoJets.
  */
 std::vector<fastjet::PseudoJet>
 createPseudoJets(const edm4hep::ReconstructedParticleCollection &inColl);

--- a/analyzers/dataframe/FCCAnalyses/JetClusteringUtilsSource.h
+++ b/analyzers/dataframe/FCCAnalyses/JetClusteringUtilsSource.h
@@ -1,0 +1,32 @@
+#ifndef ANALYZERS_SOURCE_JET_CLUSTERING_UTILS_H
+#define ANALYZERS_SOURCE_JET_CLUSTERING_UTILS_H
+
+// EDM4hep
+#include "edm4hep/ReconstructedParticleCollection.h"
+
+// FastJet
+#include "FastJet/JetClustering.h"
+#include "fastjet/JetDefinition.hh"
+
+/**
+ * @brief  Jet clustering tools and utilities.
+ *
+ * This namespace contains a set of functions and utilities to perform jet
+ * clustering using FastJet clustering algorithms with pseudoJets created from
+ * EDM4hep collections of particles.
+ *
+ * Most of the analyzers work with FastJet pseudoJets.
+ */
+namespace FCCAnalyses ::PodioSource ::JetClustering {
+/**
+ * @brief  Create FastJet pseudoJets for later usage by the jet clustering
+ *         algorithm(s).
+ *
+   * @param[in] inColl  Input collection of the reconstructed particles.
+   * @return  Vector of pseudoJets.
+ */
+std::vector<fastjet::PseudoJet>
+createPseudoJets(const edm4hep::ReconstructedParticleCollection &inColl);
+} // namespace FCCAnalyses::PodioSource::JetClustering
+
+#endif /* ANALYZERS_SOURCE_JET_CLUSTERING_UTILS_H */

--- a/analyzers/dataframe/FCCAnalyses/ReconstructedParticleSource.h
+++ b/analyzers/dataframe/FCCAnalyses/ReconstructedParticleSource.h
@@ -205,7 +205,7 @@ sortByPt(const edm4hep::ReconstructedParticleCollection &inColl);
  */
 edm4hep::ReconstructedParticleCollection
 remove(const edm4hep::ReconstructedParticleCollection &inColl,
-       const edm4hep::ReconstructedParticle& inPartToBeRemoved,
+       const edm4hep::ReconstructedParticle &inPartToBeRemoved,
        const bool matching = false);
 
 /**

--- a/analyzers/dataframe/FCCAnalyses/ReconstructedParticleSource.h
+++ b/analyzers/dataframe/FCCAnalyses/ReconstructedParticleSource.h
@@ -191,6 +191,54 @@ edm4hep::ReconstructedParticleCollection
 sortByPt(const edm4hep::ReconstructedParticleCollection &inColl);
 
 /**
+ * @brief Remove a particle from a collection.
+ *
+ * If the matching parameter is false them only the particle with the same ID
+ * will be removed from the collection.
+ * If the matching parameter is true then ID is ignored and any particle
+ * matching with the one provided will be removed.
+ *
+ * @param[in] inColl  Collection of input particles.
+ * @param[in] inPartToBeRemoved  Input particle to be removed.
+ * @param[in] matching  Use matching instead of IDs/
+ * @return  Particles remaining.
+ */
+edm4hep::ReconstructedParticleCollection
+remove(const edm4hep::ReconstructedParticleCollection &inColl,
+       const edm4hep::ReconstructedParticle& inPartToBeRemoved,
+       const bool matching = false);
+
+/**
+ * @brief Remove multiple particles from a collection.
+ *
+ * If the matching parameter is false them only the particles with the same IDs
+ * will be removed from the collection.
+ * If the matching parameter is true then ID is ignored and any particle
+ * matching with the particles provided in the remove collection will be
+ * removed.
+ *
+ * @param[in] inColl  Collection of input particles.
+ * @param[in] inPartsToBeRemoved  Collection of input particles to be removed.
+ * @param[in] matching  Use matching instead of IDs/
+ * @return  Particles remaining.
+ */
+edm4hep::ReconstructedParticleCollection
+remove(const edm4hep::ReconstructedParticleCollection &inColl,
+       const edm4hep::ReconstructedParticleCollection &inPartsToBeRemoved,
+       const bool matching = false);
+
+/**
+ * @brief Merge two particle collections together.
+ *
+ * @param[in] inColl1  First collection of input particles.
+ * @param[in] inColl2  Second collection of input particles.
+ * @return  Particles in merged collection.
+ */
+edm4hep::ReconstructedParticleCollection
+merge(const edm4hep::ReconstructedParticleCollection &inColl1,
+      const edm4hep::ReconstructedParticleCollection &inColl2);
+
+/**
  * \brief Build two particle resonances from an arbitrary list of input
  *        reconstructed particles.
  *        Select the one closest to the pre-defined mass.

--- a/analyzers/dataframe/src/JetClusteringUtilsSource.cc
+++ b/analyzers/dataframe/src/JetClusteringUtilsSource.cc
@@ -7,10 +7,8 @@ createPseudoJets(const edm4hep::ReconstructedParticleCollection &inColl) {
   std::vector<fastjet::PseudoJet> result;
   unsigned index = 0;
   for (const auto &particle : inColl) {
-    result.emplace_back(particle.getMomentum().x,
-                        particle.getMomentum().y,
-                        particle.getMomentum().z,
-                        particle.getEnergy());
+    result.emplace_back(particle.getMomentum().x, particle.getMomentum().y,
+                        particle.getMomentum().z, particle.getEnergy());
     result.back().set_user_index(index);
     ++index;
   }

--- a/analyzers/dataframe/src/JetClusteringUtilsSource.cc
+++ b/analyzers/dataframe/src/JetClusteringUtilsSource.cc
@@ -1,0 +1,20 @@
+#include "FCCAnalyses/JetClusteringUtilsSource.h"
+
+namespace FCCAnalyses ::PodioSource ::JetClustering {
+// ----------------------------------------------------------------------------
+std::vector<fastjet::PseudoJet>
+createPseudoJets(const edm4hep::ReconstructedParticleCollection &inColl) {
+  std::vector<fastjet::PseudoJet> result;
+  unsigned index = 0;
+  for (const auto &particle : inColl) {
+    result.emplace_back(particle.getMomentum().x,
+                        particle.getMomentum().y,
+                        particle.getMomentum().z,
+                        particle.getEnergy());
+    result.back().set_user_index(index);
+    ++index;
+  }
+  return result;
+}
+
+} // namespace FCCAnalyses::PodioSource::JetClustering

--- a/analyzers/dataframe/src/ReconstructedParticleSource.cc
+++ b/analyzers/dataframe/src/ReconstructedParticleSource.cc
@@ -213,6 +213,106 @@ sortByPt(const edm4hep::ReconstructedParticleCollection &inColl) {
   return outColl;
 }
 
+// ----------------------------------------------------------------------------
+edm4hep::ReconstructedParticleCollection
+remove(const edm4hep::ReconstructedParticleCollection &inColl,
+       const edm4hep::ReconstructedParticle &inPartToBeRemoved,
+       const bool matching) {
+  edm4hep::ReconstructedParticleCollection inPartsToBeRemoved;
+  inPartsToBeRemoved.setSubsetCollection();
+  inPartsToBeRemoved.push_back(inPartToBeRemoved);
+
+  return remove(inColl, inPartsToBeRemoved, matching);
+}
+
+// ----------------------------------------------------------------------------
+edm4hep::ReconstructedParticleCollection
+remove(const edm4hep::ReconstructedParticleCollection &inColl,
+       const edm4hep::ReconstructedParticleCollection &inPartsToBeRemoved,
+       const bool matching) {
+  edm4hep::ReconstructedParticleCollection outColl;
+  outColl.setSubsetCollection();
+
+  if (!matching) {
+    for (const auto &particle : inColl) {
+      if (std::find(inPartsToBeRemoved.begin(),
+                    inPartsToBeRemoved.end(),
+                    particle) != inPartsToBeRemoved.end()) {
+        continue;
+      }
+      outColl.push_back(particle);
+    }
+  } else {
+    float epsilon = 1e-6;
+    for (const auto &particle1 : inColl) {
+      bool removePart = false;
+      for (const auto &particle2 : inPartsToBeRemoved) {
+        float massDiff = 0.;
+        if (particle1.getMass() > 0.) {
+          massDiff = std::fabs(particle1.getMass() - particle2.getMass()) / particle1.getMass();
+        }
+        float pXDiff = 0.;
+        if (particle1.getMomentum().x != 0.) {
+          pXDiff = std::fabs((particle1.getMomentum().x - particle2.getMomentum().x) /
+                             particle1.getMomentum().x);
+        }
+        float pYDiff = 0.;
+        if (particle1.getMomentum().y != 0.) {
+          pYDiff = std::fabs((particle1.getMomentum().y - particle2.getMomentum().y) /
+                             particle1.getMomentum().y);
+        }
+        float pZDiff = 0.;
+        if (particle1.getMomentum().z != 0.) {
+          pZDiff = std::fabs((particle1.getMomentum().z - particle2.getMomentum().z) /
+                             particle1.getMomentum().z);
+        }
+        float chargeDiff = std::fabs(particle1.getCharge() - particle2.getCharge());
+        int32_t pdgDiff = std::abs(particle1.getPDG() - particle1.getPDG());
+
+        if (massDiff < epsilon &&
+            pXDiff < epsilon &&
+            pYDiff < epsilon &&
+            pZDiff < epsilon &&
+            chargeDiff < epsilon &&
+            pdgDiff < 1) {
+          removePart = true;
+        }
+      }
+      if (removePart) {
+        continue;
+      }
+      outColl.push_back(particle1);
+    }
+  }
+
+  return outColl;
+}
+
+// ----------------------------------------------------------------------------
+edm4hep::ReconstructedParticleCollection
+merge(const edm4hep::ReconstructedParticleCollection &inColl1,
+      const edm4hep::ReconstructedParticleCollection &inColl2) {
+  edm4hep::ReconstructedParticleCollection outColl;
+  outColl.setSubsetCollection();
+
+  for (const auto &particle : inColl1) {
+    /*
+    if (std::find(inPartsToBeRemoved.begin(),
+                  inPartsToBeRemoved.end(),
+                  particle) != inPartsToBeRemoved.end()) {
+      continue;
+    }
+    */
+    outColl.push_back(particle);
+  }
+
+  for (const auto &particle : inColl2) {
+    outColl.push_back(particle);
+  }
+
+  return outColl;
+}
+
 // --------------------------------------------------------------------------
 resonanceBuilder::resonanceBuilder(float resonanceMass)
     : m_resonanceMass(resonanceMass) {

--- a/analyzers/dataframe/src/ReconstructedParticleSource.cc
+++ b/analyzers/dataframe/src/ReconstructedParticleSource.cc
@@ -304,13 +304,6 @@ merge(const edm4hep::ReconstructedParticleCollection &inColl1,
   outColl.setSubsetCollection();
 
   for (const auto &particle : inColl1) {
-    /*
-    if (std::find(inPartsToBeRemoved.begin(),
-                  inPartsToBeRemoved.end(),
-                  particle) != inPartsToBeRemoved.end()) {
-      continue;
-    }
-    */
     outColl.push_back(particle);
   }
 

--- a/analyzers/dataframe/src/ReconstructedParticleSource.cc
+++ b/analyzers/dataframe/src/ReconstructedParticleSource.cc
@@ -235,8 +235,7 @@ remove(const edm4hep::ReconstructedParticleCollection &inColl,
 
   if (!matching) {
     for (const auto &particle : inColl) {
-      if (std::find(inPartsToBeRemoved.begin(),
-                    inPartsToBeRemoved.end(),
+      if (std::find(inPartsToBeRemoved.begin(), inPartsToBeRemoved.end(),
                     particle) != inPartsToBeRemoved.end()) {
         continue;
       }
@@ -249,32 +248,33 @@ remove(const edm4hep::ReconstructedParticleCollection &inColl,
       for (const auto &particle2 : inPartsToBeRemoved) {
         float massDiff = 0.;
         if (particle1.getMass() > 0.) {
-          massDiff = std::fabs(particle1.getMass() - particle2.getMass()) / particle1.getMass();
+          massDiff = std::fabs(particle1.getMass() - particle2.getMass()) /
+                     particle1.getMass();
         }
         float pXDiff = 0.;
         if (particle1.getMomentum().x != 0.) {
-          pXDiff = std::fabs((particle1.getMomentum().x - particle2.getMomentum().x) /
-                             particle1.getMomentum().x);
+          pXDiff = std::fabs(
+              (particle1.getMomentum().x - particle2.getMomentum().x) /
+              particle1.getMomentum().x);
         }
         float pYDiff = 0.;
         if (particle1.getMomentum().y != 0.) {
-          pYDiff = std::fabs((particle1.getMomentum().y - particle2.getMomentum().y) /
-                             particle1.getMomentum().y);
+          pYDiff = std::fabs(
+              (particle1.getMomentum().y - particle2.getMomentum().y) /
+              particle1.getMomentum().y);
         }
         float pZDiff = 0.;
         if (particle1.getMomentum().z != 0.) {
-          pZDiff = std::fabs((particle1.getMomentum().z - particle2.getMomentum().z) /
-                             particle1.getMomentum().z);
+          pZDiff = std::fabs(
+              (particle1.getMomentum().z - particle2.getMomentum().z) /
+              particle1.getMomentum().z);
         }
-        float chargeDiff = std::fabs(particle1.getCharge() - particle2.getCharge());
+        float chargeDiff =
+            std::fabs(particle1.getCharge() - particle2.getCharge());
         int32_t pdgDiff = std::abs(particle1.getPDG() - particle1.getPDG());
 
-        if (massDiff < epsilon &&
-            pXDiff < epsilon &&
-            pYDiff < epsilon &&
-            pZDiff < epsilon &&
-            chargeDiff < epsilon &&
-            pdgDiff < 1) {
+        if (massDiff < epsilon && pXDiff < epsilon && pYDiff < epsilon &&
+            pZDiff < epsilon && chargeDiff < epsilon && pdgDiff < 1) {
           removePart = true;
         }
       }

--- a/analyzers/dataframe/src/ReconstructedParticleSource.cc
+++ b/analyzers/dataframe/src/ReconstructedParticleSource.cc
@@ -235,8 +235,16 @@ remove(const edm4hep::ReconstructedParticleCollection &inColl,
 
   if (!matching) {
     for (const auto &particle : inColl) {
-      if (std::find(inPartsToBeRemoved.begin(), inPartsToBeRemoved.end(),
-                    particle) != inPartsToBeRemoved.end()) {
+      // TODO: Use std::find for this
+      // if (std::find(inPartsToBeRemoved.begin(), inPartsToBeRemoved.end(),
+      //               particle) != inPartsToBeRemoved.end()) {
+      bool removePart = false;
+      for (const auto &partToBeRemoved : inPartsToBeRemoved) {
+        if (particle == partToBeRemoved) {
+          removePart = true;
+        }
+      }
+      if (removePart) {
         continue;
       }
       outColl.push_back(particle);

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -17,8 +17,9 @@ if(WITH_PODIO_DATASOURCE)
 endif()
 
 add_executable(unittest ${unittest_src})
-target_link_libraries(unittest PUBLIC FCCAnalyses
-                                      gfortran
+add_dependencies(unittest FCCAnalyses)
+target_link_libraries(unittest PUBLIC EDM4HEP::edm4hep
+                                      FCCAnalyses
                                PRIVATE Catch2::Catch2WithMain)
 target_include_directories(unittest PUBLIC ${VDT_INCLUDE_DIR})
 target_compile_definitions(unittest PUBLIC "-DTEST_INPUT_DATA_DIR=${TEST_INPUT_DATA_DIR}")

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -18,9 +18,8 @@ endif()
 
 add_executable(unittest ${unittest_src})
 add_dependencies(unittest FCCAnalyses)
-target_link_libraries(unittest PUBLIC EDM4HEP::edm4hep
-                                      FCCAnalyses
-                               PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(unittest PRIVATE Catch2::Catch2WithMain
+                               PUBLIC FCCAnalyses)
 target_include_directories(unittest PUBLIC ${VDT_INCLUDE_DIR})
 target_compile_definitions(unittest PUBLIC "-DTEST_INPUT_DATA_DIR=${TEST_INPUT_DATA_DIR}")
 include(Catch)
@@ -28,4 +27,5 @@ catch_discover_tests(unittest
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
     TEST_PREFIX "UT_" # make it possible to filter easily with -R ^UT
     TEST_SPEC ${filter_tests} # discover only tests that are known to not fail
+    TEST_DL_PATHS $<TARGET_FILE_DIR:FCCAnalyses> # Path to the current FCCAnalyses shared library
 )

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -4,11 +4,19 @@ find_catch_instance()
 # list of labels that we want to ignore
 set(filter_tests "")
 
-add_executable(unittest unittest.cpp
-                        myutils.cpp
-                        algorithms.cpp
-                        ReconstructedParticle.cpp
+list(APPEND unittest_src unittest.cpp
+                         myutils.cpp
+                         algorithms.cpp
+                         ReconstructedParticle.cpp
 )
+
+if(WITH_PODIO_DATASOURCE)
+  list(APPEND unittest_src JetClusteringUtilsSource.cpp
+                           ReconstructedParticleSource.cpp
+  )
+endif()
+
+add_executable(unittest ${unittest_src})
 target_link_libraries(unittest PUBLIC FCCAnalyses
                                       gfortran
                                PRIVATE Catch2::Catch2WithMain)

--- a/tests/unittest/JetClusteringUtilsSource.cpp
+++ b/tests/unittest/JetClusteringUtilsSource.cpp
@@ -1,0 +1,33 @@
+#include "FCCAnalyses/JetClusteringUtilsSource.h"
+
+// Catch2
+#include "catch2/catch_test_macros.hpp"
+#include <catch2/catch_approx.hpp>
+
+TEST_CASE("create-pseudojets", "[JetClusteringUtilsSource]") {
+  edm4hep::ReconstructedParticleCollection pColl;
+  edm4hep::MutableReconstructedParticle p1;
+  p1.setPDG(11);
+  p1.setMomentum({20., 30., 40.});
+  p1.setMass(5.486e-4);
+  p1.setEnergy(53.85164807);
+  pColl.push_back(p1);
+  edm4hep::MutableReconstructedParticle p2;
+  p2.setPDG(13);
+  p2.setMomentum({10., 20., 30.});
+  p2.setMass(1.05658e-1);
+  p2.setEnergy(37.416723);
+  pColl.push_back(p2);
+  auto res = FCCAnalyses::PodioSource::JetClustering::createPseudoJets(pColl);
+  REQUIRE(res.size() == 2);
+  REQUIRE(res[0].px() == Catch::Approx(p1.getMomentum().x));
+  REQUIRE(res[0].py() == Catch::Approx(p1.getMomentum().y));
+  REQUIRE(res[0].pz() == Catch::Approx(p1.getMomentum().z));
+  REQUIRE(res[0].e() == Catch::Approx(p1.getEnergy()));
+  REQUIRE(res[0].m2() == Catch::Approx(p1.getMass()*p1.getMass()).margin(1.e-3));
+  REQUIRE(res[1].px() == Catch::Approx(p2.getMomentum().x));
+  REQUIRE(res[1].py() == Catch::Approx(p2.getMomentum().y));
+  REQUIRE(res[1].pz() == Catch::Approx(p2.getMomentum().z));
+  REQUIRE(res[1].e() == Catch::Approx(p2.getEnergy()));
+  REQUIRE(res[1].m2() == Catch::Approx(p2.getMass()*p2.getMass()).margin(1.e-3));
+}

--- a/tests/unittest/JetClusteringUtilsSource.cpp
+++ b/tests/unittest/JetClusteringUtilsSource.cpp
@@ -24,10 +24,12 @@ TEST_CASE("create-pseudojets", "[JetClusteringUtilsSource]") {
   REQUIRE(res[0].py() == Catch::Approx(p1.getMomentum().y));
   REQUIRE(res[0].pz() == Catch::Approx(p1.getMomentum().z));
   REQUIRE(res[0].e() == Catch::Approx(p1.getEnergy()));
-  REQUIRE(res[0].m2() == Catch::Approx(p1.getMass()*p1.getMass()).margin(1.e-3));
+  REQUIRE(res[0].m2() ==
+          Catch::Approx(p1.getMass() * p1.getMass()).margin(1.e-3));
   REQUIRE(res[1].px() == Catch::Approx(p2.getMomentum().x));
   REQUIRE(res[1].py() == Catch::Approx(p2.getMomentum().y));
   REQUIRE(res[1].pz() == Catch::Approx(p2.getMomentum().z));
   REQUIRE(res[1].e() == Catch::Approx(p2.getEnergy()));
-  REQUIRE(res[1].m2() == Catch::Approx(p2.getMass()*p2.getMass()).margin(1.e-3));
+  REQUIRE(res[1].m2() ==
+          Catch::Approx(p2.getMass() * p2.getMass()).margin(1.e-3));
 }

--- a/tests/unittest/ReconstructedParticle.cpp
+++ b/tests/unittest/ReconstructedParticle.cpp
@@ -2,8 +2,8 @@
 #include "FCCAnalyses/ReconstructedParticle.h"
 
 // Catch2
-#include "catch2/catch_test_macros.hpp"
 #include "catch2/catch_approx.hpp"
+#include "catch2/catch_test_macros.hpp"
 
 // EDM4hep
 #include "edm4hep/EDM4hepVersion.h"

--- a/tests/unittest/ReconstructedParticle.cpp
+++ b/tests/unittest/ReconstructedParticle.cpp
@@ -1,8 +1,9 @@
+// FCCAnalyses
 #include "FCCAnalyses/ReconstructedParticle.h"
 
 // Catch2
 #include "catch2/catch_test_macros.hpp"
-#include <catch2/catch_approx.hpp>
+#include "catch2/catch_approx.hpp"
 
 // EDM4hep
 #include "edm4hep/EDM4hepVersion.h"

--- a/tests/unittest/ReconstructedParticleSource.cpp
+++ b/tests/unittest/ReconstructedParticleSource.cpp
@@ -1,8 +1,9 @@
+// FCCAnalyses
 #include "FCCAnalyses/ReconstructedParticleSource.h"
 
 // Catch2
 #include "catch2/catch_test_macros.hpp"
-#include <catch2/catch_approx.hpp>
+#include "catch2/catch_approx.hpp"
 
 TEST_CASE("remove-by-id", "[ReconstructedParticleSource]") {
   edm4hep::ReconstructedParticleCollection pColl;

--- a/tests/unittest/ReconstructedParticleSource.cpp
+++ b/tests/unittest/ReconstructedParticleSource.cpp
@@ -32,7 +32,8 @@ TEST_CASE("remove-by-id-subset-coll", "[ReconstructedParticleSource]") {
   edm4hep::ReconstructedParticleCollection pCollSubset;
   pCollSubset.setSubsetCollection();
   pCollSubset.push_back(pColl[0]);
-  auto res = FCCAnalyses::PodioSource::ReconstructedParticle::remove(pColl, pCollSubset[0]);
+  auto res = FCCAnalyses::PodioSource::ReconstructedParticle::remove(
+      pColl, pCollSubset[0]);
   REQUIRE(res.size() == 1);
   REQUIRE(res[0].getPDG() == 13);
 }
@@ -52,7 +53,8 @@ TEST_CASE("remove-by-matching", "[ReconstructedParticleSource]") {
   p3.setPDG(11);
   p3.setMomentum({1., 2., 3.});
   pCollRemove.push_back(p3);
-  auto res = FCCAnalyses::PodioSource::ReconstructedParticle::remove(pColl, pCollRemove, true);
+  auto res = FCCAnalyses::PodioSource::ReconstructedParticle::remove(
+      pColl, pCollRemove, true);
   REQUIRE(res.size() == 1);
   REQUIRE(res[0].getPDG() == 13);
 }
@@ -72,7 +74,8 @@ TEST_CASE("merge", "[ReconstructedParticleSource]") {
   p3.setPDG(11);
   p3.setMomentum({1., 2., 3.});
   pColl2.push_back(p3);
-  auto res = FCCAnalyses::PodioSource::ReconstructedParticle::merge(pColl1, pColl2);
+  auto res =
+      FCCAnalyses::PodioSource::ReconstructedParticle::merge(pColl1, pColl2);
   REQUIRE(res.size() == 3);
   REQUIRE(res[0].getPDG() == 11);
   REQUIRE(res[1].getPDG() == 13);

--- a/tests/unittest/ReconstructedParticleSource.cpp
+++ b/tests/unittest/ReconstructedParticleSource.cpp
@@ -2,8 +2,8 @@
 #include "FCCAnalyses/ReconstructedParticleSource.h"
 
 // Catch2
-#include "catch2/catch_test_macros.hpp"
 #include "catch2/catch_approx.hpp"
+#include "catch2/catch_test_macros.hpp"
 
 TEST_CASE("remove-by-id", "[ReconstructedParticleSource]") {
   edm4hep::ReconstructedParticleCollection pColl;

--- a/tests/unittest/ReconstructedParticleSource.cpp
+++ b/tests/unittest/ReconstructedParticleSource.cpp
@@ -1,0 +1,80 @@
+#include "FCCAnalyses/ReconstructedParticleSource.h"
+
+// Catch2
+#include "catch2/catch_test_macros.hpp"
+#include <catch2/catch_approx.hpp>
+
+TEST_CASE("remove-by-id", "[ReconstructedParticleSource]") {
+  edm4hep::ReconstructedParticleCollection pColl;
+  edm4hep::MutableReconstructedParticle p1;
+  p1.setPDG(11);
+  p1.setMomentum({1., 2., 3.});
+  pColl.push_back(p1);
+  edm4hep::MutableReconstructedParticle p2;
+  p2.setPDG(13);
+  p2.setMomentum({10., 20., 30.});
+  pColl.push_back(p2);
+  auto res = FCCAnalyses::PodioSource::ReconstructedParticle::remove(pColl, p1);
+  REQUIRE(res.size() == 1);
+  REQUIRE(res[0].getPDG() == 13);
+}
+
+TEST_CASE("remove-by-id-subset-coll", "[ReconstructedParticleSource]") {
+  edm4hep::ReconstructedParticleCollection pColl;
+  edm4hep::MutableReconstructedParticle p1;
+  p1.setPDG(11);
+  p1.setMomentum({1., 2., 3.});
+  pColl.push_back(p1);
+  edm4hep::MutableReconstructedParticle p2;
+  p2.setPDG(13);
+  p2.setMomentum({10., 20., 30.});
+  pColl.push_back(p2);
+  edm4hep::ReconstructedParticleCollection pCollSubset;
+  pCollSubset.setSubsetCollection();
+  pCollSubset.push_back(pColl[0]);
+  auto res = FCCAnalyses::PodioSource::ReconstructedParticle::remove(pColl, pCollSubset[0]);
+  REQUIRE(res.size() == 1);
+  REQUIRE(res[0].getPDG() == 13);
+}
+
+TEST_CASE("remove-by-matching", "[ReconstructedParticleSource]") {
+  edm4hep::ReconstructedParticleCollection pColl;
+  edm4hep::MutableReconstructedParticle p1;
+  p1.setPDG(11);
+  p1.setMomentum({1., 2., 3.});
+  pColl.push_back(p1);
+  edm4hep::MutableReconstructedParticle p2;
+  p2.setPDG(13);
+  p2.setMomentum({10., 20., 30.});
+  pColl.push_back(p2);
+  edm4hep::ReconstructedParticleCollection pCollRemove;
+  edm4hep::MutableReconstructedParticle p3;
+  p3.setPDG(11);
+  p3.setMomentum({1., 2., 3.});
+  pCollRemove.push_back(p3);
+  auto res = FCCAnalyses::PodioSource::ReconstructedParticle::remove(pColl, pCollRemove, true);
+  REQUIRE(res.size() == 1);
+  REQUIRE(res[0].getPDG() == 13);
+}
+
+TEST_CASE("merge", "[ReconstructedParticleSource]") {
+  edm4hep::ReconstructedParticleCollection pColl1;
+  edm4hep::MutableReconstructedParticle p1;
+  p1.setPDG(11);
+  p1.setMomentum({1., 2., 3.});
+  pColl1.push_back(p1);
+  edm4hep::MutableReconstructedParticle p2;
+  p2.setPDG(13);
+  p2.setMomentum({10., 20., 30.});
+  pColl1.push_back(p2);
+  edm4hep::ReconstructedParticleCollection pColl2;
+  edm4hep::MutableReconstructedParticle p3;
+  p3.setPDG(11);
+  p3.setMomentum({1., 2., 3.});
+  pColl2.push_back(p3);
+  auto res = FCCAnalyses::PodioSource::ReconstructedParticle::merge(pColl1, pColl2);
+  REQUIRE(res.size() == 3);
+  REQUIRE(res[0].getPDG() == 11);
+  REQUIRE(res[1].getPDG() == 13);
+  REQUIRE(res[2].getPDG() == 11);
+}


### PR DESCRIPTION
* Adds ability to remove or add together collections of reconstructed particles.
* Adds analyzer , which converts collection of reconstructed particles into FastJet Pseudojets.

These analyzers allow to replace this set of steps common in Jet Clustering for DataSource based analysis:
```
# do jet clustering on all particles, except the muons
    df = df.Define("rps_no_muons", "FCCAnalyses::ReconstructedParticle::remove(ReconstructedParticles, muons)")
    df = df.Define("RP_px", "FCCAnalyses::ReconstructedParticle::get_px(rps_no_muons)")
    df = df.Define("RP_py", "FCCAnalyses::ReconstructedParticle::get_py(rps_no_muons)")
    df = df.Define("RP_pz","FCCAnalyses::ReconstructedParticle::get_pz(rps_no_muons)")
    df = df.Define("RP_e", "FCCAnalyses::ReconstructedParticle::get_e(rps_no_muons)")
    df = df.Define("pseudo_jets", "FCCAnalyses::JetClusteringUtils::set_pseudoJets(RP_px, RP_py, RP_pz, RP_e)")
```
to
```
# do jet clustering on all particles, except the muons
    df = df.Define("rps_no_muons", "ReconstructedParticle::remove(ReconstructedParticles, muons)")
    df = df.Define("pseudo_jets", "JetClustering::createPseudoJets(rps_no_muons)")
```