### PR TITLE
Link against ROOTVecOps to properly pick up dependencies

### DIFF
--- a/addons/FastJet/CMakeLists.txt
+++ b/addons/FastJet/CMakeLists.txt
@@ -9,6 +9,7 @@ fccanalyses_addon_build(FastJet
                         EXT_HEADERS ${FASTJET_INCLUDE_DIRS}
                         EXT_LIBS ${FASTJET_LIBRARIES}
                                  ROOT::MathCore
+                                 ROOT::ROOTVecOps
                         INSTALL_COMPONENT fastjet)
 
 add_custom_command(TARGET FastJet POST_BUILD

--- a/cmake/FCCAnalysesFunctions.cmake
+++ b/cmake/FCCAnalysesFunctions.cmake
@@ -87,7 +87,7 @@ macro(fccanalyses_addon_build _name)
     target_include_directories(${_name} PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/addons>
                                                $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/analyzers/dataframe>)
     if(ARG_EXT_LIBS)
-      target_link_libraries(${_name} ${ARG_EXT_LIBS})
+      target_link_libraries(${_name} PUBLIC ${ARG_EXT_LIBS})
     endif()
     if(ARG_EXT_HEADERS)
       target_include_directories(${_name} PUBLIC ${ARG_EXT_HEADERS})


### PR DESCRIPTION
Fix a minor issue that I just observed locally for the first time in some time. It looks like something has changed and we now need to explicitly link against `ROOTVecOps` to pick up all the necessary (mainly vdt) build dependencies.