### PR TITLE
Input ROOT files can be provided with a file list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@ __pycache__/
 # C extensions
 *.so
 
-# ROOT files
-*.root
-
 # HTCondor
 # ignores <lxplus-username>.cc file in the top FCCAnalyses directory
 /*.cc
@@ -40,6 +37,11 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+
+# Input
+*.root
+*.lst
+*.txt
 
 # Output
 outputs/

--- a/man/man1/fccanalysis-run.1
+++ b/man/man1/fccanalysis-run.1
@@ -1,6 +1,6 @@
 .\" Manpage for fccanalysis-run
 .\" Contact FCC-PED-SoftwareAndComputing-Analysis@cern.ch to correct errors or typos.
-.TH FCCANALYSIS\-RUN 1 "10 May 2025" "0.11.0" "fccanalysis-run man page"
+.TH FCCANALYSIS\-RUN 1 "12 June 2025" "0.11.0" "fccanalysis-run man page"
 
 .SH NAME
 \fBfccanalysis\-run\fR \- run FCC analysis
@@ -8,15 +8,17 @@
 .SH SYNOPSIS
 .B fccanalysis run
 [\fB\-h\fR | \fB\-\-help\fR]
-[\fB\-\-files\-list\fR \fIFILES_LIST\fR [\fIFILES_LIST\fR ...]]
+[\fB\-i\fR \fIINPUT_FILE\fR [\fIINPUT_FILE\fR ...], \fB\-\-input\fR \fIINPUT_FILE\fR [\fIINPUT_FILE\fR ...]]
+[\fB\-\-files\-list\fR \fIINPUT_FILE\fR [\fIINPUT_FILE\fR ...]]
+[\fB\-f\fR \fILIST_FILE\fR, \fB\-\-input\-file\-list\fR \fILIST_FILE\fR]
 [\fB\-\-output\fR \fIOUTPUT\fR]
 [\fB\-\-nevents\fR \fINEVENTS\fR]
-[\fB\-\-use-data-source\fR]
 [\fB\-\-test\fR]
 [\fB\-\-bench\fR]
 [\fB\-j\fR NCPUS | \fB\-\-ncpus\fR \fINCPUS\fR | \fB\-\-n-threads\fR \fINTHREADS\fR]
 [\fB\-g\fR]
 [\fB\-\-graph\-path\fR \fIGRAPH_PATH\fR]
+[\fB\-\-use-data-source\fR]
 .B analysis-script
 \-\-
 [\fIANALYSIS ARGUMENTS\fR]
@@ -40,8 +42,19 @@ Path to analysis script\&.
 .BR \-h ", " \-\-help
 Prints short help message and exits\&.
 .TP
-\fB\-\-files\-list\fR \fIFILES_LIST\fR [\fIFILES_LIST\fR ...]
-Directly specify analysis input files\&.
+\fB\-i\fR \fIINPUT_FILE\fR [\fIINPUT_FILE\fR ...], \fB\-\-input\fR \fIINPUT_FILE\fR [\fIINPUT_FILE\fR ...]
+Directly specify input ROOT files for the analysis\&. Takes precedence over the
+files provided in a file list or the files determined from the
+\fBprocess_list\fR of the analysis\&.
+.TP
+\fB\-\-files\-list\fR \fIINPUT_FILE\fR [\fIINPUT_FILE\fR ...]
+[DEPRECATED] Directly specify input ROOT files for the analysis\&.
+.TP
+\fB\-\-input\-file\-list\fR \fILIST_FILE\fR
+Specify file containing list of input ROOT files to be used for the analysis\&.
+Takes precedence over the files determined from the \fBprocess_list\fR of the
+analysis\&. Each input ROOT file needs to be on a separate line\&. Lines
+starting with "#" are ignored\&.
 .TP
 \fB\-\-output\fR \fIOUTPUT\fR
 Specify output file name, otherwise dataset name used.

--- a/python/batch.py
+++ b/python/batch.py
@@ -143,7 +143,7 @@ def create_subjob_script(config: dict[str, Any],
     scr += f'fccanalysis run {config["full-analysis-path"]}'
     scr += f' --output {sample_output_filepath}'
     scr += f' --n-threads {config["n-threads"]}'
-    scr += ' --files-list'
+    scr += ' --input'
     for file_path in chunk_list[chunk_num]:
         scr += f' {file_path}'
     if len(config['cli-arguments']['remaining']) > 0:

--- a/python/parsers.py
+++ b/python/parsers.py
@@ -126,14 +126,30 @@ def setup_run_parser(parser):
     '''
     parser.add_argument('anascript_path',
                         help='path to analysis script')
-    parser.add_argument('--files-list', nargs='+', default=[],
-                        help='specify input file(s) to bypass the processList')
+    parser.add_argument(
+        '-i', '--input',
+        default=None,
+        nargs='+',
+        metavar='INPUT_FILE',
+        help='location(s) of the input ROOT file(s)')
+    parser.add_argument(
+        '--files-list',
+        default=None,
+        nargs='+',
+        metavar='INPUT_FILE',
+        help='[DEPRECATED] location(s) of the input ROOT file(s)')
+    parser.add_argument(
+        '-f', '--input-file-list',
+        type=str,
+        default=None,
+        metavar='LIST_FILE',
+        help='location of the text file containing list of input ROOT files')
     parser.add_argument(
         '-o', '--output',
         type=str,
         default='output.root',
-        help='specify output file name to bypass the processList and or '
-             'outputList')
+        metavar='OUTPUT_FILE',
+        help='location of the output ROOT file')
     parser.add_argument('--nevents', type=int, default=-1,
                         help='specify max number of events to process')
     parser.add_argument('--test', action='store_true', default=False,


### PR DESCRIPTION
Adds ability to provide input ROOT files in a file list from a text file.

This PR removes CLI argument `--files-list` and replaces it with `-i` or `--input`, intended for providing input files directly, and `--input-file-list`, intended for file list in the form of a text file.

The text file with the list of files needs to have each file path specified on a separate line and lines starting with `#` are ignored.