### PR TITLE
Introduce PDG code enumeration

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/MCParticleCodes.h
+++ b/analyzers/dataframe/FCCAnalyses/MCParticleCodes.h
@@ -1,0 +1,46 @@
+
+#ifndef MCPARTICLECODES_H
+#define MCPARTICLECODES_H
+
+// This file contains the particle codes used in the FCC Analyses framework.
+namespace FCCAnalyses {
+
+  /// Particle codes following the PDG Monte Carlo particle numbering scheme.
+  enum class PDGCode {
+
+	UNKNOWN = 0,
+
+	// Leptons
+	ELECTRON = 11,
+	MUON = 13,
+	TAU = 15,
+	E_NEUTRINO = 12,
+	MU_NEUTRINO = 14,
+	TAU_NEUTRINO = 16,
+
+	// Partons
+	QUARK_UP = 1,
+	QUARK_DOWN = 2,
+	QUARK_CHARM = 4,
+	QUARK_STRANGE = 3,
+	QUARK_TOP = 6,
+	QUARK_BOTTOM = 5,
+	GLUON = 21,
+
+	// Bosons
+	PHOTON = 22,
+	Z = 23,
+	W = 24,
+	HIGGS = 25,
+
+	// Baryons
+	PION = 211,
+	KAON = 321,
+	PROTON = 2212,
+	NEUTRON = 2112,
+  };
+
+} // namespace FCCAnalyses
+
+
+#endif

--- a/analyzers/dataframe/FCCAnalyses/MCParticleCodes.h
+++ b/analyzers/dataframe/FCCAnalyses/MCParticleCodes.h
@@ -6,38 +6,34 @@
 namespace FCCAnalyses {
 
   /// Particle codes following the PDG Monte Carlo particle numbering scheme.
-  enum class PDGCode {
+  enum PDGCode : int {
 
-	UNKNOWN = 0,
+	PDG_UNKNOWN = 0,
 
 	// Leptons
-	ELECTRON = 11,
-	MUON = 13,
-	TAU = 15,
-	E_NEUTRINO = 12,
-	MU_NEUTRINO = 14,
-	TAU_NEUTRINO = 16,
+	PDG_ELECTRON = 11,
+	PDG_MUON = 13,
+	PDG_TAU = 15,
+	PDG_E_NEUTRINO = 12,
+	PDG_MU_NEUTRINO = 14,
+	PDG_TAU_NEUTRINO = 16,
 
 	// Partons
-	QUARK_UP = 1,
-	QUARK_DOWN = 2,
-	QUARK_CHARM = 4,
-	QUARK_STRANGE = 3,
-	QUARK_TOP = 6,
-	QUARK_BOTTOM = 5,
-	GLUON = 21,
+	PDG_QUARK_UP = 1,
+	PDG_QUARK_DOWN = 2,
+	PDG_QUARK_CHARM = 4,
+	PDG_QUARK_STRANGE = 3,
+	PDG_QUARK_TOP = 6,
+	PDG_QUARK_BOTTOM = 5,
+	PDG_GLUON = 21,
 
 	// Bosons
-	PHOTON = 22,
-	Z = 23,
-	W = 24,
-	HIGGS = 25,
+	PDG_PHOTON = 22,
+	PDG_Z = 23,
+	PDG_W = 24,
+	PDG_HIGGS = 25,
 
-	// Baryons
-	PION = 211,
-	KAON = 321,
-	PROTON = 2212,
-	NEUTRON = 2112,
+	// ...
   };
 
 } // namespace FCCAnalyses

--- a/analyzers/dataframe/src/JetTaggingUtils.cc
+++ b/analyzers/dataframe/src/JetTaggingUtils.cc
@@ -1,4 +1,5 @@
 #include "FCCAnalyses/JetTaggingUtils.h"
+#include "FCCAnalyses/PDGCodes.h"
 
 namespace FCCAnalyses {
 
@@ -11,13 +12,17 @@ get_flavour(ROOT::VecOps::RVec<fastjet::PseudoJet> in,
 
   int loopcount = 0;
   for (size_t i = 0; i < MCin.size(); ++i) {
+
     auto &parton = MCin[i];
+
     // Select partons only (for pythia8 71-79, for pythia6 2):
     if ((parton.generatorStatus > 80 || parton.generatorStatus < 70) &&
         parton.generatorStatus != 2)
       continue;
-    if (std::abs(parton.PDG) > 5 && parton.PDG != 21)
+
+    if (std::abs(parton.PDG) > PDGCode::QUARK_BOTTOM && parton.PDG != PDGCode::GLUON)
       continue;
+    
     ROOT::Math::PxPyPzMVector lv(parton.momentum.x, parton.momentum.y,
                                  parton.momentum.z, parton.mass);
 
@@ -39,14 +44,19 @@ get_flavour(ROOT::VecOps::RVec<fastjet::PseudoJet> in,
       Float_t angle = acos(dot / norm);
 
       if (angle <= 0.3) {
-        if (result[j] == 21 or result[j] == 0) {
+
+        if (result[j] == PDGCode::GLUON or result[j] == PDGCode::UNKNOWN) {
+
           // if no match before, or matched to gluon, match to
           // this particle (favour quarks over gluons)
           result[j] = std::abs(parton.PDG);
-        } else if (parton.PDG != 21) {
+
+        } else if (parton.PDG != PDGCode::GLUON) {
+
           // if matched to quark, and this is a quark, favour
           // heavier flavours
           result[j] = std::max(result[j], std::abs(parton.PDG));
+
         } else {
           // if matched to quark, and this is a gluon, keep
           // previous result (favour quark)
@@ -66,15 +76,20 @@ ROOT::VecOps::RVec<int> get_btag(ROOT::VecOps::RVec<int> in, float efficiency,
   ROOT::VecOps::RVec<int> result(in.size(), 0);
 
   for (size_t j = 0; j < in.size(); ++j) {
-    if (in.at(j) == 5 && gRandom->Uniform() <= efficiency)
+
+    if (in.at(j) == PDGCode::QUARK_BOTTOM && gRandom->Uniform() <= efficiency)
       result[j] = 1;
-    if (in.at(j) == 4 && gRandom->Uniform() <= mistag_c)
+
+    if (in.at(j) == PDGCode::QUARK_CHARM && gRandom->Uniform() <= mistag_c)
       result[j] = 1;
-    if (in.at(j) < 4 && gRandom->Uniform() <= mistag_l)
+
+    if (in.at(j) < PDGCode::QUARK_CHARM && gRandom->Uniform() <= mistag_l)
       result[j] = 1;
-    if (in.at(j) == 21 && gRandom->Uniform() <= mistag_g)
+
+    if (in.at(j) == PDGCode::GLUON && gRandom->Uniform() <= mistag_g)
       result[j] = 1;
   }
+
   return result;
 }
 
@@ -85,13 +100,17 @@ ROOT::VecOps::RVec<int> get_ctag(ROOT::VecOps::RVec<int> in, float efficiency,
   ROOT::VecOps::RVec<int> result(in.size(), 0);
 
   for (size_t j = 0; j < in.size(); ++j) {
-    if (in.at(j) == 4 && gRandom->Uniform() <= efficiency)
+
+    if (in.at(j) == PDGCode::QUARK_CHARM && gRandom->Uniform() <= efficiency)
       result[j] = 1;
-    if (in.at(j) == 5 && gRandom->Uniform() <= mistag_b)
+
+    if (in.at(j) == PDGCode::QUARK_BOTTOM && gRandom->Uniform() <= mistag_b)
       result[j] = 1;
-    if (in.at(j) < 4 && gRandom->Uniform() <= mistag_l)
+
+    if (in.at(j) < PDGCode::QUARK_CHARM && gRandom->Uniform() <= mistag_l)
       result[j] = 1;
-    if (in.at(j) == 21 && gRandom->Uniform() <= mistag_g)
+
+    if (in.at(j) == PDGCode::GLUON && gRandom->Uniform() <= mistag_g)
       result[j] = 1;
   }
   return result;
@@ -104,13 +123,17 @@ ROOT::VecOps::RVec<int> get_ltag(ROOT::VecOps::RVec<int> in, float efficiency,
   ROOT::VecOps::RVec<int> result(in.size(), 0);
 
   for (size_t j = 0; j < in.size(); ++j) {
-    if (in.at(j) < 4 && gRandom->Uniform() <= efficiency)
+
+    if (in.at(j) < PDGCode::QUARK_CHARM && gRandom->Uniform() <= efficiency)
       result[j] = 1;
-    if (in.at(j) == 5 && gRandom->Uniform() <= mistag_b)
+
+    if (in.at(j) == PDGCode::QUARK_BOTTOM && gRandom->Uniform() <= mistag_b)
       result[j] = 1;
-    if (in.at(j) == 4 && gRandom->Uniform() <= mistag_c)
+
+    if (in.at(j) == PDGCode::QUARK_CHARM && gRandom->Uniform() <= mistag_c)
       result[j] = 1;
-    if (in.at(j) == 21 && gRandom->Uniform() <= mistag_g)
+
+    if (in.at(j) == PDGCode::GLUON && gRandom->Uniform() <= mistag_g)
       result[j] = 1;
   }
   return result;
@@ -123,13 +146,17 @@ ROOT::VecOps::RVec<int> get_gtag(ROOT::VecOps::RVec<int> in, float efficiency,
   ROOT::VecOps::RVec<int> result(in.size(), 0);
 
   for (size_t j = 0; j < in.size(); ++j) {
-    if (in.at(j) == 21 && gRandom->Uniform() <= efficiency)
+
+    if (in.at(j) == PDGCode::GLUON && gRandom->Uniform() <= efficiency)
       result[j] = 1;
-    if (in.at(j) == 5 && gRandom->Uniform() <= mistag_b)
+
+    if (in.at(j) == PDGCode::QUARK_BOTTOM && gRandom->Uniform() <= mistag_b)
       result[j] = 1;
-    if (in.at(j) == 4 && gRandom->Uniform() <= mistag_c)
+
+    if (in.at(j) == PDGCode::QUARK_CHARM && gRandom->Uniform() <= mistag_c)
       result[j] = 1;
-    if (in.at(j) < 4 && gRandom->Uniform() <= mistag_l)
+
+    if (in.at(j) < PDGCode::QUARK_CHARM && gRandom->Uniform() <= mistag_l)
       result[j] = 1;
   }
   return result;

--- a/analyzers/dataframe/src/JetTaggingUtils.cc
+++ b/analyzers/dataframe/src/JetTaggingUtils.cc
@@ -1,5 +1,5 @@
 #include "FCCAnalyses/JetTaggingUtils.h"
-#include "FCCAnalyses/PDGCodes.h"
+#include "FCCAnalyses/MCParticleCodes.h"
 
 namespace FCCAnalyses {
 
@@ -20,7 +20,7 @@ get_flavour(ROOT::VecOps::RVec<fastjet::PseudoJet> in,
         parton.generatorStatus != 2)
       continue;
 
-    if (std::abs(parton.PDG) > PDGCode::QUARK_BOTTOM && parton.PDG != PDGCode::GLUON)
+    if (std::abs(parton.PDG) > PDG_QUARK_BOTTOM && parton.PDG != PDG_GLUON)
       continue;
     
     ROOT::Math::PxPyPzMVector lv(parton.momentum.x, parton.momentum.y,
@@ -45,13 +45,13 @@ get_flavour(ROOT::VecOps::RVec<fastjet::PseudoJet> in,
 
       if (angle <= 0.3) {
 
-        if (result[j] == PDGCode::GLUON or result[j] == PDGCode::UNKNOWN) {
+        if (result[j] == PDG_GLUON or result[j] == PDG_UNKNOWN) {
 
           // if no match before, or matched to gluon, match to
           // this particle (favour quarks over gluons)
           result[j] = std::abs(parton.PDG);
 
-        } else if (parton.PDG != PDGCode::GLUON) {
+        } else if (parton.PDG != PDG_GLUON) {
 
           // if matched to quark, and this is a quark, favour
           // heavier flavours
@@ -77,16 +77,16 @@ ROOT::VecOps::RVec<int> get_btag(ROOT::VecOps::RVec<int> in, float efficiency,
 
   for (size_t j = 0; j < in.size(); ++j) {
 
-    if (in.at(j) == PDGCode::QUARK_BOTTOM && gRandom->Uniform() <= efficiency)
+    if (in.at(j) == PDG_QUARK_BOTTOM && gRandom->Uniform() <= efficiency)
       result[j] = 1;
 
-    if (in.at(j) == PDGCode::QUARK_CHARM && gRandom->Uniform() <= mistag_c)
+    if (in.at(j) == PDG_QUARK_CHARM && gRandom->Uniform() <= mistag_c)
       result[j] = 1;
 
-    if (in.at(j) < PDGCode::QUARK_CHARM && gRandom->Uniform() <= mistag_l)
+    if (in.at(j) < PDG_QUARK_CHARM && gRandom->Uniform() <= mistag_l)
       result[j] = 1;
 
-    if (in.at(j) == PDGCode::GLUON && gRandom->Uniform() <= mistag_g)
+    if (in.at(j) == PDG_GLUON && gRandom->Uniform() <= mistag_g)
       result[j] = 1;
   }
 
@@ -101,16 +101,16 @@ ROOT::VecOps::RVec<int> get_ctag(ROOT::VecOps::RVec<int> in, float efficiency,
 
   for (size_t j = 0; j < in.size(); ++j) {
 
-    if (in.at(j) == PDGCode::QUARK_CHARM && gRandom->Uniform() <= efficiency)
+    if (in.at(j) == PDG_QUARK_CHARM && gRandom->Uniform() <= efficiency)
       result[j] = 1;
 
-    if (in.at(j) == PDGCode::QUARK_BOTTOM && gRandom->Uniform() <= mistag_b)
+    if (in.at(j) == PDG_QUARK_BOTTOM && gRandom->Uniform() <= mistag_b)
       result[j] = 1;
 
-    if (in.at(j) < PDGCode::QUARK_CHARM && gRandom->Uniform() <= mistag_l)
+    if (in.at(j) < PDG_QUARK_CHARM && gRandom->Uniform() <= mistag_l)
       result[j] = 1;
 
-    if (in.at(j) == PDGCode::GLUON && gRandom->Uniform() <= mistag_g)
+    if (in.at(j) == PDG_GLUON && gRandom->Uniform() <= mistag_g)
       result[j] = 1;
   }
   return result;
@@ -124,16 +124,16 @@ ROOT::VecOps::RVec<int> get_ltag(ROOT::VecOps::RVec<int> in, float efficiency,
 
   for (size_t j = 0; j < in.size(); ++j) {
 
-    if (in.at(j) < PDGCode::QUARK_CHARM && gRandom->Uniform() <= efficiency)
+    if (in.at(j) < PDG_QUARK_CHARM && gRandom->Uniform() <= efficiency)
       result[j] = 1;
 
-    if (in.at(j) == PDGCode::QUARK_BOTTOM && gRandom->Uniform() <= mistag_b)
+    if (in.at(j) == PDG_QUARK_BOTTOM && gRandom->Uniform() <= mistag_b)
       result[j] = 1;
 
-    if (in.at(j) == PDGCode::QUARK_CHARM && gRandom->Uniform() <= mistag_c)
+    if (in.at(j) == PDG_QUARK_CHARM && gRandom->Uniform() <= mistag_c)
       result[j] = 1;
 
-    if (in.at(j) == PDGCode::GLUON && gRandom->Uniform() <= mistag_g)
+    if (in.at(j) == PDG_GLUON && gRandom->Uniform() <= mistag_g)
       result[j] = 1;
   }
   return result;
@@ -147,16 +147,16 @@ ROOT::VecOps::RVec<int> get_gtag(ROOT::VecOps::RVec<int> in, float efficiency,
 
   for (size_t j = 0; j < in.size(); ++j) {
 
-    if (in.at(j) == PDGCode::GLUON && gRandom->Uniform() <= efficiency)
+    if (in.at(j) == PDG_GLUON && gRandom->Uniform() <= efficiency)
       result[j] = 1;
 
-    if (in.at(j) == PDGCode::QUARK_BOTTOM && gRandom->Uniform() <= mistag_b)
+    if (in.at(j) == PDG_QUARK_BOTTOM && gRandom->Uniform() <= mistag_b)
       result[j] = 1;
 
-    if (in.at(j) == PDGCode::QUARK_CHARM && gRandom->Uniform() <= mistag_c)
+    if (in.at(j) == PDG_QUARK_CHARM && gRandom->Uniform() <= mistag_c)
       result[j] = 1;
 
-    if (in.at(j) < PDGCode::QUARK_CHARM && gRandom->Uniform() <= mistag_l)
+    if (in.at(j) < PDG_QUARK_CHARM && gRandom->Uniform() <= mistag_l)
       result[j] = 1;
   }
   return result;

--- a/analyzers/dataframe/src/MCParticle.cc
+++ b/analyzers/dataframe/src/MCParticle.cc
@@ -1,4 +1,5 @@
 #include "FCCAnalyses/MCParticle.h"
+#include "FCCAnalyses/PDGCodes.h"
 #include <iostream>
 #include <algorithm>
 #include <set>
@@ -696,7 +697,7 @@ int get_lepton_origin(const edm4hep::MCParticleData &p,
  // std::cout  << std::endl << " enter in MCParticle::get_lepton_origin  PDG = " << p.PDG << std::endl;
 
  int pdg = std::abs( p.PDG ) ;
- if ( pdg != 11 && pdg != 13 && pdg  != 15 ) return -1;
+ if ( pdg != PDGCode::ELECTRON && pdg != PDGCode::MUON && pdg  != PDGCode::TAU ) return -1;
 
  int result  = 0;
 
@@ -706,25 +707,25 @@ int get_lepton_origin(const edm4hep::MCParticleData &p,
       int pdg_parent = in.at(index).PDG ;
       // std::cout  << " parent has pdg = " << in.at(index).PDG <<  "  status = " << in.at(index).generatorStatus << std::endl;
 
-      if ( abs( pdg_parent ) == 23 || abs( pdg_parent ) == 24 ) {
+      if ( abs( pdg_parent ) == PDGCode::W || abs( pdg_parent ) == PDGCode::Z ) {
         result = pdg_parent ;
         //std::cout <<  " ... Lepton is from W or Z ,  return code = " << result <<  std::endl;
         break;
       }
 
-      if ( abs( pdg_parent ) == 22 ) {
+      if ( abs( pdg_parent ) == PDGCode::PHOTON ) {
         result = pdg_parent ;
         //std::cout <<  " ... Lepton is from a virtual photon ,  return code = " << result <<  std::endl;
         break;
       }
 
-      if ( abs( pdg_parent ) == 15 ) {
+      if ( abs( pdg_parent ) == PDGCode::TAU ) {
          result = pdg_parent ;
          //std::cout <<  " ... Lepton is from a tau,  return code = " << result <<  std::endl;
          break;
       }
 
-      if ( abs( pdg_parent ) == 11 ) {    // beam particle ?
+      if ( abs( pdg_parent ) == PDGCode::ELECTRON ) {    // beam particle ?
 			// beam particles should have generatorStatus = 4,
 			// but that is not the case in files produced from Whizard + p6
         if ( in.at(index).generatorStatus == 4 || ind.at  ( in.at(index).parents_begin ) == 0 ) {
@@ -734,7 +735,7 @@ int get_lepton_origin(const edm4hep::MCParticleData &p,
         }
       }
 
-      if ( pdg == 11 && abs( pdg_parent ) == 13 ) {	// mu -> e
+      if ( pdg == PDGCode::ELECTRON && abs( pdg_parent ) == PDGCode::MUON ) {	// mu -> e
           result  = pdg_parent;
           //std::cout <<  " ... Electron from a muon decay, return code = " << result <<  std::endl;
           break;

--- a/analyzers/dataframe/src/MCParticle.cc
+++ b/analyzers/dataframe/src/MCParticle.cc
@@ -1,5 +1,5 @@
 #include "FCCAnalyses/MCParticle.h"
-#include "FCCAnalyses/PDGCodes.h"
+#include "FCCAnalyses/MCParticleCodes.h"
 #include <iostream>
 #include <algorithm>
 #include <set>
@@ -697,7 +697,7 @@ int get_lepton_origin(const edm4hep::MCParticleData &p,
  // std::cout  << std::endl << " enter in MCParticle::get_lepton_origin  PDG = " << p.PDG << std::endl;
 
  int pdg = std::abs( p.PDG ) ;
- if ( pdg != PDGCode::ELECTRON && pdg != PDGCode::MUON && pdg  != PDGCode::TAU ) return -1;
+ if ( pdg != PDG_ELECTRON && pdg != PDG_MUON && pdg  != PDG_TAU ) return -1;
 
  int result  = 0;
 
@@ -707,25 +707,25 @@ int get_lepton_origin(const edm4hep::MCParticleData &p,
       int pdg_parent = in.at(index).PDG ;
       // std::cout  << " parent has pdg = " << in.at(index).PDG <<  "  status = " << in.at(index).generatorStatus << std::endl;
 
-      if ( abs( pdg_parent ) == PDGCode::W || abs( pdg_parent ) == PDGCode::Z ) {
+      if ( abs( pdg_parent ) == PDG_W || abs( pdg_parent ) == PDG_Z ) {
         result = pdg_parent ;
         //std::cout <<  " ... Lepton is from W or Z ,  return code = " << result <<  std::endl;
         break;
       }
 
-      if ( abs( pdg_parent ) == PDGCode::PHOTON ) {
+      if ( abs( pdg_parent ) == PDG_PHOTON ) {
         result = pdg_parent ;
         //std::cout <<  " ... Lepton is from a virtual photon ,  return code = " << result <<  std::endl;
         break;
       }
 
-      if ( abs( pdg_parent ) == PDGCode::TAU ) {
+      if ( abs( pdg_parent ) == PDG_TAU ) {
          result = pdg_parent ;
          //std::cout <<  " ... Lepton is from a tau,  return code = " << result <<  std::endl;
          break;
       }
 
-      if ( abs( pdg_parent ) == PDGCode::ELECTRON ) {    // beam particle ?
+      if ( abs( pdg_parent ) == PDG_ELECTRON ) {    // beam particle ?
 			// beam particles should have generatorStatus = 4,
 			// but that is not the case in files produced from Whizard + p6
         if ( in.at(index).generatorStatus == 4 || ind.at  ( in.at(index).parents_begin ) == 0 ) {
@@ -735,7 +735,7 @@ int get_lepton_origin(const edm4hep::MCParticleData &p,
         }
       }
 
-      if ( pdg == PDGCode::ELECTRON && abs( pdg_parent ) == PDGCode::MUON ) {	// mu -> e
+      if ( pdg == PDG_ELECTRON && abs( pdg_parent ) == PDG_MUON ) {	// mu -> e
           result  = pdg_parent;
           //std::cout <<  " ... Electron from a muon decay, return code = " << result <<  std::endl;
           break;


### PR DESCRIPTION
This pull request introduces a PDG code enumeration `PDGCode` which can be used as an integer value to reference particles by name. For example:

```cpp
if (in[j] ==  21 || in[j] == 15)
      result[j] = 1;
```

becomes

```cpp
if (in[j] == PDG_GLUON || in[j] == PDG_TAU)
      result[j] = 1;
```

The PDG codes are defined in the `MCParticleCodes.h` header file, which has no dependencies. Currently, only basic particles have been defined, but more may be added when needed.

## Advantages:
- Improves code readability
- Reduces human error
- By using an unscoped enumeration, legacy code does not need to change. Software already using FCCAnalyses will not need to change, but new code may use this feature
