### PR TITLE
Fix errors with GCC 14 and GCC 13

### DIFF
--- a/tests/unittest/myutils.cpp
+++ b/tests/unittest/myutils.cpp
@@ -165,10 +165,10 @@ TEST_CASE("distanceVertex", "[basic]") {
 
 TEST_CASE("distanceErrorVertex", "[basic]") {
   edm4hep::VertexData v1;
-  v1.covMatrix = {.1, .2, .3, .43, .67, .11};
+  v1.covMatrix = edm4hep::CovMatrix3f{.1, .2, .3, .43, .67, .11};
   v1.position = {1., 2., 3.};
   edm4hep::VertexData v2;
-  v2.covMatrix = {.34, .2, .46, .43, .67, .003};
+  v2.covMatrix = edm4hep::CovMatrix3f{.34, .2, .46, .43, .67, .003};
   v2.position = {0., 0., 0.};
 
   float err = FCCAnalyses::myUtils::get_distanceErrorVertex(v1, v2, 0);


### PR DESCRIPTION
The issue is that multiple candidates exist:
```
edm4hep::CovMatrix3f::operator=(const std::array<float, 6>&)
edm4hep::CovMatrix3f& edm4hep::CovMatrix3f::operator=(const edm4hep::CovMatrix3f&)
edm4hep::CovMatrix3f& edm4hep::CovMatrix3f::operator=(edm4hep::CovMatrix3f&&)
```
Does not happen with GCC 15 and Clang 20
Error message:

``` 
/Workarea/08_fccanalyses/tests/unittest/myutils.cpp:168:44: error: ambiguous overload for 'operator=' (operand types are 'edm4hep::CovMatrix3f' and '<brace-enclosed initializer list>')
  168 |   v1.covMatrix = {.1, .2, .3, .43, .67, .11};
```

Seen in 
https://github.com/key4hep/EDM4hep/actions/runs/16903913318/job/47983617539?pr=435#logs
Doesn't break the nightlies because the tests are not built in the nightlies.