### PR TITLE
Do not ignore CMakeLists.txt in the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ MANIFEST
 *.root
 *.lst
 *.txt
+!CMakeLists.txt
 
 # Output
 outputs/


### PR DESCRIPTION
Tools that read .gitignore to know which files to ignore will ignore CMakeLists.txt files as it is, plus every time a new one is added it has to be added explicitly with, for example, `git add -f`.