### PR TITLE
Create first the library and then the dictionary for analyses

### DIFF
--- a/case-studies/CMakeLists.txt
+++ b/case-studies/CMakeLists.txt
@@ -1,3 +1,4 @@
+find_package(Python3 COMPONENTS Development REQUIRED)
 macro(build_analysis dir)
   file(GLOB headers "${dir}/include/*.h")
   file(GLOB sources "${dir}/src/*.cc")
@@ -7,30 +8,28 @@ macro(build_analysis dir)
   set(lib_name "FCCAnalysis_${dir}")
   #--- generate the ROOT dictionary using a REFLEX selection
   set(CMAKE_ROOTTEST_NOROOTMAP OFF)
-  reflex_generate_dictionary(lib${lib_name} ${headers} ${classes}
-                             SELECTION ${reflex_sel})
   #--- build the analysis library (linked against FCCAnalyses)
-  add_library(${lib_name} SHARED ${sources} ${headers} lib${lib_name}.cxx)
+  add_library(${lib_name} SHARED)
   target_include_directories(${lib_name} PUBLIC ${dir}/include
                                                 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                                                 $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/addons>
                                                 $<INSTALL_INTERFACE:include>)
   target_link_libraries(${lib_name} PUBLIC FCCAnalyses)
   set_target_properties(${lib_name} PROPERTIES PUBLIC_HEADER "${headers}")
+  reflex_generate_dictionary(${lib_name} ${headers} ${classes}
+                             SELECTION ${reflex_sel})
   message(STATUS "analysis-------------------------- ${dir}: ${lib_name}")
   install(TARGETS ${lib_name}
           RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
           LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT shlib
           PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}/${dir}"
           COMPONENT analyses)
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lib${lib_name}.rootmap"
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${lib_name}.rootmap"
           DESTINATION "${INSTALL_LIB_DIR}"
           COMPONENT analyses)
-  if(${ROOT_VERSION} GREATER 6)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lib${lib_name}_rdict.pcm"
-            DESTINATION "${INSTALL_LIB_DIR}"
-            COMPONENT analyses)
-  endif()
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${lib_name}_rdict.pcm"
+          DESTINATION "${INSTALL_LIB_DIR}"
+          COMPONENT analyses)
   foreach(_test ${ci_tests})
     get_filename_component(test_name ${_test} NAME_WE)
     add_generic_test("${lib_name}_${test_name}" ${_test})


### PR DESCRIPTION
This allows to inherit the included directories when generating the dictionaries.

Fixes an issue related to not finding `Python.h` that is now in one of the headers in podio after https://github.com/AIDASoft/podio/pull/810, since linking through `FCCAnalyses` which links to `podio::podio` which includes the python folder will make it work. This is currently preventing the nightlies from building.

The test `FCCAnalysis_analysis_example_run_analysis` maybe because the old (from the stack) and new dictionaries exist at the same time? I tried running after `k4_local_repo` and all the tests passed.