### PR TITLE
Use the new target names for ACTS

### DIFF
--- a/analyzers/dataframe/CMakeLists.txt
+++ b/analyzers/dataframe/CMakeLists.txt
@@ -83,7 +83,7 @@ if(WITH_DD4HEP)
 endif()
 
 if(WITH_ACTS)
-  target_link_libraries(FCCAnalyses PUBLIC ActsCore)
+  target_link_libraries(FCCAnalyses PUBLIC Acts::Core)
   target_compile_definitions(FCCAnalyses PRIVATE "ACTS_VERSION_MAJOR=${Acts_VERSION_MAJOR}")
 endif()
 


### PR DESCRIPTION
Acts has switched to namespaced targets in v42. This little change makes things work again for newer versions.

@kjvbrt do we want to have backwards compatibility? That would be relatively straight forward to add, see e.g.: https://github.com/key4hep/k4ActsTracking/pull/26

I would like to have this in, because then I would also be able to add this to a newly created Acts CI workflow that tests Key4hep dependencies, so that we can get a ping earlier if things break: https://github.com/acts-project/acts/pull/4663