### PR TITLE
Fix: Update get_dndx to match EDM4hep RecDqdxData type

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/JetConstituentsUtils.h
@@ -4,7 +4,7 @@
 #include "ROOT/RVec.hxx"
 #include "edm4hep/ReconstructedParticle.h"
 #include "edm4hep/MCParticle.h"
-#include "edm4hep/Quantity.h"
+#include "edm4hep/RecDqdxData.h"
 #if __has_include("edm4hep/TrackerHit3DData.h")
 #include "edm4hep/TrackerHit3DData.h"
 #else
@@ -142,7 +142,7 @@ namespace FCCAnalyses {
 
 
     rv::RVec<FCCAnalysesJetConstituentsData> get_dndx(const rv::RVec<FCCAnalysesJetConstituents>& jcs,
-                                                      const rv::RVec<edm4hep::Quantity>& dNdx,
+                                                      const rv::RVec<edm4hep::RecDqdxData>& dNdx,
 						      const rv::RVec<edm4hep::TrackData>& trackdata,
 						      const rv::RVec<FCCAnalysesJetConstituentsData> JetsConstituents_isChargedHad);
 

--- a/analyzers/dataframe/src/JetConstituentsUtils.cc
+++ b/analyzers/dataframe/src/JetConstituentsUtils.cc
@@ -363,7 +363,7 @@ namespace FCCAnalyses
     // neutrals are set to 0; muons and electrons are also set to 0;
     //  only charged hads are considered (mtof used to disctriminate charged kaons and pions)
     rv::RVec<FCCAnalysesJetConstituentsData> get_dndx(const rv::RVec<FCCAnalysesJetConstituents> &jcs,
-                                                      const rv::RVec<edm4hep::Quantity> &dNdx,       // ETrackFlow_2
+                                                      const rv::RVec<edm4hep::RecDqdxData> &dNdx,       // ETrackFlow_2
                                                       const rv::RVec<edm4hep::TrackData> &trackdata, // Eflowtrack
                                                       const rv::RVec<FCCAnalysesJetConstituentsData> JetsConstituents_isChargedHad)
     {


### PR DESCRIPTION
This PR addresses a type mismatch error identified in [this FCCSW-Forum post.](https://fccsw-forum.web.cern.ch/t/fcc-tutorial-2-4-2-part-ii-produce-a-flat-tree-and-analyse-events-error-no-member-named-trackerhitdata-in-namespace-edm4hep/253)

`DelphesPythia8_EDM4HEP` from the latest Key4hep stack [`-r 2025-05-29`] generates EDM4hep files where the `"dNdx"`  collection (`"EFlowTrack_dNdx"`) is stored as `RVec<edm4hep::RecDqdxData>`. 

FCCAnalyses previously expected this collection to be of type `RVec<edm4hep::Quantity>` , leading to the following error:
```
input_line_171:2:288: error: no viable conversion from 'RVec<edm4hep::RecDqdxData>' to 'const RVec<edm4hep::Quantity>'
  ...>& var3){return JetConstituentsUtils::get_dndx(var3, var1, var2, var0)
```

To resolve this incompatibility, this PR modifies the `get_dndx()` function in `JetConstituentsUtils`. The function has been updated to accept `RVec<edm4hep::RecDqdxData>` as the input type for the `"dNdx"` collection, aligning it with the data format generated by the current Key4hep stack.

This change can be tested by running the [FCC tutorial 2.4.2 analysis](https://hep-fcc.github.io/fcc-tutorials/main/fast-sim-and-analysis/fccanalyses/doc/starterkit/FccFastSimAnalysis/Readme.html#part-ii-produce-a-flat-tree-and-analyse-events) on new EDM4hep files generated with the Key4hep stack `-r 2025-05-29`.