### PR TITLE
[fix] Always write out final histograms

### DIFF
--- a/python/run_final_analysis.py
+++ b/python/run_final_analysis.py
@@ -521,7 +521,7 @@ def run(rdf_module, args) -> None:
                     if do_scale:
                         hist.Scale(gen_sf * int_lumi /
                                    process_events[process_name])
-                        outfile.WriteObject(hist.GetValue(), hist.GetName())
+                    outfile.WriteObject(hist.GetValue(), hist.GetName())
 
                 # write all metadata info to the output file
                 param = ROOT.TParameter(int)("eventsProcessed",


### PR DESCRIPTION
The final histograms were not written out in case the user chose to not do the scaling of the histograms.