### PR TITLE
Use the common Key4hepConfig.cmake to set flags and other settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ find_package(FastJet REQUIRED)
 
 find_package( Delphes REQUIRED )
 
+include(cmake/Key4hepConfig.cmake)
 
 if(WITH_ACTS)
   find_package( Acts COMPONENTS Core )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,15 +51,6 @@ set(INSTALL_INCLUDE_DIR include CACHE PATH
 set(INSTALL_SHARE_DIR "${CMAKE_INSTALL_PREFIX}/share" CACHE PATH
     "Installation directory for shared resources")
 
-
-#--- Declare C++ Standard -----------------------------------------------------
-
-set(CMAKE_CXX_STANDARD 20 CACHE STRING "")
-if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
-  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
-endif()
-message (STATUS "C++ standard: ${CMAKE_CXX_STANDARD}")
-
 #--- Dependencies -------------------------------------------------------------
 
 find_package(ROOT REQUIRED COMPONENTS ROOTVecOps ROOTDataFrame TMVA TMVAUtils)


### PR DESCRIPTION
As part of having common settings, I just updated this file for all repos but it's not being used in FCCAnalyses.