### PR TITLE
Add a new method to pre-selection and final-selection. Also add some features to do_plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ benchmark*json
 # Graphviz graphs
 *.dot
 *.png
+
+# Other
+.cache

--- a/python/do_plots.py
+++ b/python/do_plots.py
@@ -922,15 +922,11 @@ def draw_plot(config: dict[str, Any],
             latex.SetTextSize(0.035)
             latex.DrawLatex(0.18, 0.4-dy*0.05, text)
 
-            stry = str(yields[y][1])
-            stry = stry.split('.', maxsplit=1)[0]
-            text = '#bf{#it{' + stry + '}}'
+            text = '#bf{#it{' + f'{yields[y][1]:,.0f}' + '}}'
             latex.SetTextSize(0.035)
             latex.DrawLatex(0.5, 0.4-dy*0.05, text)
 
-            stry = str(yields[y][2])
-            stry = stry.split('.', maxsplit=1)[0]
-            text = '#bf{#it{' + stry + '}}'
+            text = '#bf{#it{' + f'{yields[y][2]:,.0f}' + '}}'
             latex.SetTextSize(0.035)
             latex.DrawLatex(0.75, 0.4-dy*0.05, text)
 

--- a/python/do_plots.py
+++ b/python/do_plots.py
@@ -62,6 +62,36 @@ def formatStatUncHist(hists, name, hstyle=3254):
     return hist_tot
 
 
+def get_xrange_strict(histos: list[Any],
+                      xmin: float,
+                      xmax: float):
+    '''
+    Find min and max values for the x-axis among the provided histograms
+    while not considering bins with 0 content
+    '''
+    if len(histos) == 0:
+        LOGGER.warning('Histograms not provided!')
+        return 1e-5, 1
+
+    hist_name = 'hist_tot_' + random_string(12)
+    hist_tot = histos[0].Clone(hist_name)
+    for hist in histos[1:]:
+        hist_tot.Add(hist)
+
+    start_bin = hist_tot.FindBin(xmin)
+    end_bin   = hist_tot.FindBin(xmax)
+
+    vals_min, vals_max = [], []
+    for i in range(start_bin, end_bin + 1):
+        if hist_tot.GetBinContent(i) != 0:
+            vals_min.append(hist_tot.GetBinLowEdge(i))
+            vals_max.append(hist_tot.GetBinLowEdge(i+1))
+    if len(vals_min) == 0 or len(vals_max) == 0:
+        return 1e-5, 1
+
+    return min(vals_min), max(vals_max)
+
+
 # _____________________________________________________________________________
 def get_minmax_range(histos: list[Any],
                      xmin: float,
@@ -79,12 +109,13 @@ def get_minmax_range(histos: list[Any],
     for hist in histos[1:]:
         hist_tot.Add(hist)
 
+    start_bin = hist_tot.FindBin(xmin)
+    end_bin   = hist_tot.FindBin(xmax)
+
     vals = []
-    for i in range(0, hist_tot.GetNbinsX()+1):
-        if hist_tot.GetBinLowEdge(i) > xmin or \
-                hist_tot.GetBinLowEdge(i+1) < xmax:
-            if hist_tot.GetBinContent(i) != 0:
-                vals.append(hist_tot.GetBinContent(i))
+    for i in range(start_bin, end_bin + 1):
+        if hist_tot.GetBinContent(i) != 0:
+            vals.append(hist_tot.GetBinContent(i))
     if len(vals) == 0:
         return 1e-5, 1
 
@@ -400,7 +431,7 @@ def runPlots(config: dict[str, Any],
                        'stack-sig': 'stack'}
         draw_plot(config, plot_params,
                   var,
-                  'events', leg, lt, rt,
+                  'Events', leg, lt, rt,
                   script_module.formats,
                   script_module.outdir + "/" + sel, histos,
                   colors, script_module.ana_tex, extralab,
@@ -423,7 +454,7 @@ def runPlots(config: dict[str, Any],
                     plot_name += '_' + yaxis_scaling + 'y'
                 draw_plot(config, plot_params_x_y,
                           plot_name,
-                          'events', leg, lt, rt,
+                          'Events', leg, lt, rt,
                           script_module.formats,
                           script_module.outdir + "/" + sel,
                           histos, colors, script_module.ana_tex,
@@ -573,13 +604,13 @@ def runPlotsHistmaker(config: dict[str, Any],
               xtitle=xtitle)
 
     if 'dumpTable' in hist_cfg and hist_cfg['dumpTable']:
-        if type(xtitle) != list:
+        if not isinstance(xtitle, list):
             LOGGER.error('Can only dump a table of yields for cutflow plots.')
             quit()
         procs = list(hsignal.keys()) + list(hbackgrounds.keys())
         hists = hsignal | hbackgrounds
         scaleSig = hist_cfg['scaleSig'] if 'scaleSig' in hist_cfg else 1.
-        hists[procs[0]][0].Scale(1./scaleSig) # undo signal scaling
+        hists[procs[0]][0].Scale(1./scaleSig)  # undo signal scaling
         cuts = xtitle
 
         out_orig = sys.stdout
@@ -593,7 +624,7 @@ def runPlotsHistmaker(config: dict[str, Any],
                 s = hists[procs[0]][0].GetBinContent(i+1)
                 s_plus_b = sum([hists[p][0].GetBinContent(i+1) for p in procs])
                 significance = s/(s_plus_b**0.5) if s_plus_b > 0 else 0
-                row = ["Cut %d"%i, "%.3f"%significance]
+                row = [f"Cut {i}", f"{significance:.3f}"]
                 for j,proc in enumerate(procs):
                     yield_ = hists[proc][0].GetBinContent(i+1)
                     row.append("%.4e" % (yield_))
@@ -630,6 +661,9 @@ def draw_plot(config: dict[str, Any],
     else:
         canvas.SetLogy(1)
     canvas.SetTicks(1, 1)
+    if config['set_grid']:
+        canvas.SetGridx(1)
+        canvas.SetGridy(1)
     canvas.SetLeftMargin(0.14)
     canvas.SetRightMargin(0.08)
 
@@ -723,6 +757,10 @@ def draw_plot(config: dict[str, Any],
         xmax = hStack.GetStack().Last().GetBinLowEdge(
             hStack.GetStack().Last().GetNbinsX() + 1
         )
+
+    if config['strict-x-range']:
+        xmin, xmax = get_xrange_strict(hStack.GetHists(), xmin, xmax)
+
     if plot_params['xaxis'] == 'log':
         if xmin <= 0.:
             LOGGER.error('Log scale for x-axis can\'t start at: %g\n'
@@ -752,7 +790,7 @@ def draw_plot(config: dict[str, Any],
     if ymin == -1:
         ymin = ymin_*0.1 if plot_params['yaxis'] == 'log' else 0
     if ymax == -1:
-        ymax = ymax_*1000. if plot_params['yaxis'] == 'log' else 1.4*ymax_
+        ymax = ymax_*10000. if plot_params['yaxis'] == 'log' else 1.7*ymax_
     if plot_params['yaxis'] == 'log':
         if ymin <= 0.:
             LOGGER.error('Log scale for y-axis can\'t start at: %g\n'
@@ -1089,6 +1127,14 @@ def run(args):
         config['legend_text_size'] = script_module.legendTextSize
     if args.legend_text_size is not None:
         config['legend_text_size'] = args.legend_text_size
+
+    config['strict-x-range'] = False
+    if hasattr(script_module, "strictRange"):
+        config['strict-x-range'] = script_module.strictRange
+
+    config['set_grid'] = False
+    if hasattr(script_module, "setGrid"):
+        config['set_grid'] = script_module.setGrid
 
     # Label for the integrated luminosity
     config['int_lumi_label'] = None

--- a/python/do_plots.py
+++ b/python/do_plots.py
@@ -1160,6 +1160,8 @@ def run(args):
 
     counter = 0
     LOGGER.info('Plotting staged analysis plots...')
+    l = max(len(v) for v in script_module.variables)
+    ll = max(len(sel) for sel in script_module.selections)
     for var_index, var in enumerate(script_module.variables):
         for label, sels in script_module.selections.items():
             for sel in sels:
@@ -1168,9 +1170,7 @@ def run(args):
                     if len(script_module.rebin) == \
                             len(script_module.variables):
                         rebin_tmp = script_module.rebin[var_index]
-
-                LOGGER.info('  var: %s     label: %s     selection: %s',
-                            var, label, sel)
+                LOGGER.info(f'  var: {var:<{l}}  label: {label:<{ll}}  selections: {sel}')
 
                 hsignal, hbackgrounds = load_hists(var,
                                                    label,

--- a/python/run_final_analysis.py
+++ b/python/run_final_analysis.py
@@ -444,6 +444,102 @@ def run(rdf_module, args) -> None:
                 # run
                 snapshots.append(dframe_cut.Snapshot("events", fout, "", opts))
 
+        # Adding custom histogram to the output
+        custom_hists = get_attribute(rdf_module, "customHists", {})
+        if len(custom_hists)>0:
+            LOGGER.info('Found customHists in script, searching for'
+                        ' custom histogram in input files')
+            custom_hists_dict = {}
+
+            # Going through all the files
+            found_directories, found_histos = [], []
+            for file_name in file_list[process_name]:
+                with ROOT.TFile(str(file_name), 'READ') as fIn:
+                    # Searching for custom_objects, aborting if not found
+                    custom_dir = fIn.GetDirectory('custom_objects')
+                    if not custom_dir:
+                        LOGGER.warning('No TDirectory named custom_objects found.\n'
+                                       'Aborting custom histogram search')
+                        break
+                    else:
+                        # Getting element inside custom_objects
+                        keys = custom_dir.GetListOfKeys()
+                        for key in keys:
+                            obj = key.ReadObj()
+
+                            # Searching for a TDirectory containing histograms
+                            if obj.IsA().InheritsFrom('TDirectory') and 'TH' in key.GetName():
+                                if key.GetName() not in found_directories:
+                                    found_directories.append(key.GetName())
+
+                                hist_keys = obj.GetListOfKeys()
+                                # Going through the histograms inside the sub-TDirectory
+                                for hist_key in hist_keys:
+                                    hist_obj = hist_key.ReadObj()
+                                    if hist_obj is None:
+                                        LOGGER.warning(f'Could not read object "{hist_key.GetName()}" in {str(file_name)}')
+                                        continue
+                                    hist_name = hist_key.GetName()
+
+                                    # Checking if the histogram is in customHist
+                                    if hist_name in custom_hists.keys():
+                                        if hist_name not in found_histos:
+                                            found_histos.append(hist_name)
+                                        # Clone and detach from file
+                                        hist_clone = hist_obj.Clone()
+                                        hist_clone.SetDirectory(0)
+                                        # Adding histogram if going through chunks
+                                        if hist_name in custom_hists_dict:
+                                            custom_hists_dict[hist_name].Add(hist_clone)
+                                        else:
+                                            custom_hists_dict[hist_name] = hist_clone
+
+            if len(found_histos)==0:
+                LOGGER.warning("Did not find any histogram in custom_objects")
+            else:
+                if len(found_directories)==1:
+                    directories = found_directories[0]
+                elif len(found_directories)>1:
+                    directories = ', '.join(found_directories[:-1]) + ' and ' + found_directories[-1]
+                LOGGER.info(f'Found {len(found_histos)} histograms in {directories}')
+                # Applying cutsom settings like in histoList
+                histos_to_write = []
+                for custom_hist_name, custom_params in custom_hists.items():
+                    if custom_hist_name not in custom_hists_dict:
+                        LOGGER.warning('Custom histogram "%s" not found in input files!',
+                                       custom_hist_name)
+                        continue
+
+                    hist = custom_hists_dict[custom_hist_name]
+                    if 'title' in custom_params:
+                        hist.GetXaxis().SetTitle(custom_params['title'])
+                    else:
+                        LOGGER.warning(f"No 'xtitle' was found in customHisto for {hist.GetName()}")
+                    if 'name' in custom_params:
+                        hist.GetXaxis().SetTitle(custom_params['name'])
+
+                    if 'xmin' in custom_params:
+                        bin_min = hist.GetXaxis().FindBin(custom_params['xmin'])
+                    else:
+                        bin_min = hist.GetXaxis().GetFirst()
+                    if 'xmax' in custom_params:
+                        bin_max = hist.GetXaxis().FindBin(custom_params['xmax'])
+                    else:
+                        bin_max = hist.GetXaxis().GetNbins()
+                    hist.GetXaxis().SetRange(bin_min, bin_max)
+                    histos_to_write.append(hist)
+
+                # Adding custom histogram for all cuts
+                for h_list in histos_list:
+                    h_list.extend(histos_to_write)
+                if len(histos_to_write)==0:
+                    LOGGER.info('No histogram compatible with customHists was found.'
+                                'Did you properly name your histogram(s)?')
+                elif len(histos_to_write)==1:
+                    LOGGER.info('1 compatible histogram with customHists found, will save it')
+                elif len(histos_to_write)>1:
+                    LOGGER.info(f'{len(histos_to_write)} compatible histograms with customHists found, will save them')
+
         # Now perform the loop and evaluate everything at once.
         LOGGER.info('Evaluating...')
         all_events_raw = dframe.Count().GetValue()
@@ -515,13 +611,25 @@ def run(rdf_module, args) -> None:
             fhisto = os.path.join(output_dir,
                                   process_name + '_' + cut + '_histo.root')
             with ROOT.TFile(fhisto, 'RECREATE') as outfile:
-                for hist in histos_list[i]:
-                    hist_name = hist.GetName() + '_raw'
-                    outfile.WriteObject(hist.GetValue(), hist_name)
+                # Sorting the histograms by name
+                histos_sorted = sorted(histos_list[i], key=lambda h: h.GetName())
+                for hist in histos_sorted:
+                    hist_name = hist.GetName()
+                    hist_name_raw = hist_name + '_raw'
+                    try:
+                        # This line won't work for custom histogram
+                        outfile.WriteObject(hist.GetValue(), hist_name_raw)
+                    except AttributeError:
+                        outfile.WriteObject(hist, hist_name_raw)
+
                     if do_scale:
                         hist.Scale(gen_sf * int_lumi /
                                    process_events[process_name])
-                        outfile.WriteObject(hist.GetValue(), hist.GetName())
+                        try:
+                            # This line won't work with custom histogram
+                            outfile.WriteObject(hist.GetValue(), hist_name)
+                        except AttributeError:
+                            outfile.WriteObject(hist, hist_name)
 
                 # write all metadata info to the output file
                 param = ROOT.TParameter(int)("eventsProcessed",

--- a/python/run_final_analysis.py
+++ b/python/run_final_analysis.py
@@ -453,6 +453,7 @@ def run(rdf_module, args) -> None:
 
             # Going through all the files
             found_directories, found_histos = [], []
+            all_histos = 0
             for file_name in file_list[process_name]:
                 with ROOT.TFile(str(file_name), 'READ') as fIn:
                     # Searching for custom_objects, aborting if not found
@@ -480,6 +481,7 @@ def run(rdf_module, args) -> None:
                                         LOGGER.warning(f'Could not read object "{hist_key.GetName()}" in {str(file_name)}')
                                         continue
                                     hist_name = hist_key.GetName()
+                                    all_histos += 1
 
                                     # Checking if the histogram is in customHist
                                     if hist_name in custom_hists.keys():
@@ -494,14 +496,14 @@ def run(rdf_module, args) -> None:
                                         else:
                                             custom_hists_dict[hist_name] = hist_clone
 
-            if len(found_histos)==0:
+            if all_histos==0:
                 LOGGER.warning("Did not find any histogram in custom_objects")
             else:
                 if len(found_directories)==1:
                     directories = found_directories[0]
                 elif len(found_directories)>1:
                     directories = ', '.join(found_directories[:-1]) + ' and ' + found_directories[-1]
-                LOGGER.info(f'Found {len(found_histos)} histograms in {directories}')
+                LOGGER.info(f'Found {all_histos} histograms in {directories}')
                 # Applying cutsom settings like in histoList
                 histos_to_write = []
                 for custom_hist_name, custom_params in custom_hists.items():
@@ -516,7 +518,7 @@ def run(rdf_module, args) -> None:
                     else:
                         LOGGER.warning(f"No 'xtitle' was found in customHisto for {hist.GetName()}")
                     if 'name' in custom_params:
-                        hist.GetXaxis().SetTitle(custom_params['name'])
+                        hist.SetName(custom_params['name'])
 
                     if 'xmin' in custom_params:
                         bin_min = hist.GetXaxis().FindBin(custom_params['xmin'])

--- a/python/run_rdfgraph_analysis.py
+++ b/python/run_rdfgraph_analysis.py
@@ -9,13 +9,12 @@ import shutil
 import json
 import logging
 import subprocess
-import importlib.util
 import datetime
 import numpy as np
 
 import ROOT  # type: ignore
 from anascript import get_element, get_element_dict, get_attribute
-from process import get_process_info, get_process_dict
+from process import get_process_info
 from frame import generate_graph
 
 LOGGER = logging.getLogger('FCCAnalyses.run')
@@ -320,10 +319,33 @@ def initialize(args, rdf_module, anapath: str):
 
 
 # _____________________________________________________________________________
-def run_rdf(rdf_module,
-            input_list: list[str],
-            out_file: str,
-            args) -> int:
+def write_object_to_directory(root_file, obj, category: str):
+    '''
+    Write an object to an organized directory structure in a ROOT file.
+    Creates custom_objects/<category>/ directory if it doesn't exist.
+    '''
+    # Create the custom_objects directory if it doesn't exist
+    if not root_file.GetDirectory("custom_objects"):
+        root_file.mkdir("custom_objects")
+
+    custom_dir = root_file.GetDirectory("custom_objects")
+
+    # Create the category subdirectory if it doesn't exist
+    if not custom_dir.GetDirectory(category):
+        custom_dir.mkdir(category)
+
+    # Write the object to the appropriate subdirectory
+    category_dir = custom_dir.GetDirectory(category)
+    category_dir.cd()
+    obj.Write()
+
+
+# _____________________________________________________________________________
+def run_rdf_graph(rdf_module,
+                  input_list: list[str],
+                  out_file: str,
+                  process_name: str,
+                  args) -> int:
     '''
     Create RDataFrame and snapshot it.
     '''
@@ -336,21 +358,46 @@ def run_rdf(rdf_module,
         dframe2 = dframe
 
     try:
-        evtcount_init = dframe2.Count()
-        dframe3 = get_element(rdf_module.RDFanalysis, "analysers")(dframe2)
+        dframe3, params = get_element(rdf_module.RDFgraph, "analysers")(dframe2, process_name)
 
-        branch_list = ROOT.vector('string')()
-        blist = get_element(rdf_module.RDFanalysis, "output")()
-        for bname in blist:
-            branch_list.push_back(bname)
-
-        evtcount_final = dframe3.Count()
+        blist = get_element(rdf_module.RDFgraph, "output")()
+        branch_list = ROOT.vector('string')(blist)
 
         # Generate computational graph of the analysis
         if args.graph:
             generate_graph(dframe, args)
 
         dframe3.Snapshot("events", out_file, branch_list)
+
+        # Separate histograms and other parameters
+        hists_to_write, params_to_write = {}, []
+        for param in params:
+            class_name = param.IsA().GetName()
+            if 'TH' in class_name:
+                hist = param.GetValue()
+                hName = hist.GetName()
+                if hName in hists_to_write:
+                    hists_to_write[hName].Add(hist)
+                else:
+                    hists_to_write[hName] = hist
+            else:
+                params_to_write.append(param)
+
+        # Get event counts
+        evtcount_init  = dframe2.Count()
+        evtcount_final = dframe3.Count()
+
+        # Batch write all objects to file in single UPDATE operation
+        with ROOT.TFile(out_file, 'UPDATE') as outfile:
+            # Write params first
+            for param in params_to_write:
+                obj_type = param.IsA().GetName()
+                write_object_to_directory(outfile, param, obj_type)
+            # Then write histograms
+            for hist in hists_to_write.values():
+                obj_type = hist.IsA().GetName()
+                write_object_to_directory(outfile, hist, obj_type)
+
     except Exception as excp:
         LOGGER.error('During the execution of the analysis file exception '
                      'occurred:\n%s', excp)
@@ -468,7 +515,7 @@ def apply_filepath_rewrites(filepath: str) -> str:
 
 
 # _____________________________________________________________________________
-def run_local(rdf_module, infile_list, args):
+def run_local(rdf_module, infile_list, process_name, args):
     '''
     Run analysis locally.
     '''
@@ -525,7 +572,7 @@ def run_local(rdf_module, infile_list, args):
 
     # Run RDF
     start_time = time.time()
-    inn, outn = run_rdf(rdf_module, file_list, outfile_path, args)
+    inn, outn = run_rdf_graph(rdf_module, file_list, outfile_path, process_name, args)
     elapsed_time = time.time() - start_time
 
     # replace nevents_local by inn = the amount of processed events
@@ -582,7 +629,7 @@ def run_local(rdf_module, infile_list, args):
 
 
 # _____________________________________________________________________________
-def run_stages(args, rdf_module, anapath):
+def run_rdfgraph(args, rdf_module, anapath):
     '''
     Run regular stage.
     '''
@@ -608,7 +655,8 @@ def run_stages(args, rdf_module, anapath):
         directory, _ = os.path.split(args.output)
         if directory:
             os.system(f'mkdir -p {directory}')
-        run_local(rdf_module, [testfile_path], args)
+        # Can't give process_name at this stage
+        run_local(rdf_module, [testfile_path], "", args)
         sys.exit(0)
 
     # Check if files are specified, and if so run the analysis on it/them (this
@@ -618,7 +666,8 @@ def run_stages(args, rdf_module, anapath):
         directory, _ = os.path.split(args.output)
         if directory:
             os.system(f'mkdir -p {directory}')
-        run_local(rdf_module, args.files_list, args)
+        # Can't give process_name at this stage
+        run_local(rdf_module, args.files_list, "", args)
         sys.exit(0)
 
     # Check if batch mode is available
@@ -696,298 +745,8 @@ def run_stages(args, rdf_module, anapath):
             LOGGER.info('Running locally...')
             if len(chunk_list) == 1:
                 args.output = f'{output_stem}.root'
-                run_local(rdf_module, chunk_list[0], args)
+                run_local(rdf_module, chunk_list[0], process_name, args)
             else:
                 for index, chunk in enumerate(chunk_list):
                     args.output = f'{output_stem}/chunk{index}.root'
-                    run_local(rdf_module, chunk, args)
-
-
-def run_histmaker(args, rdf_module, anapath):
-    '''
-    Run the analysis using histmaker (all stages integrated into one).
-    '''
-
-    # set ncpus, load header files, custom dicts, ...
-    initialize(args, rdf_module, anapath)
-
-    # load process dictionary
-    proc_dict_location = get_element(rdf_module, "procDict", True)
-    if not proc_dict_location:
-        LOGGER.error('Location of the procDict not provided.\nAborting...')
-        sys.exit(3)
-
-    proc_dict = get_process_dict(proc_dict_location)
-
-    # check if outputDir exist and if not create it
-    output_dir = get_element(rdf_module, "outputDir")
-    if not os.path.exists(output_dir) and output_dir != '':
-        os.system(f'mkdir -p {output_dir}')
-
-    do_scale = get_element(rdf_module, "doScale", True)
-    int_lumi = get_element(rdf_module, "intLumi", True)
-
-    # check if the process list is specified, and create graphs for them
-    process_list = get_element(rdf_module, "processList")
-    graph_function = getattr(rdf_module, "build_graph")
-    results = []  # all the histograms
-    hweights = []  # all the weights
-    evtcounts = []  # event count of the input file
-    # number of events processed per process, in a potential previous step
-    events_processed_dict = {}
-    for process in process_list:
-        try:
-            process_input_dir = process_list[process]['inputDir']
-        except KeyError:
-            process_input_dir = None
-        file_list, event_list = get_process_info(
-            process,
-            get_element(rdf_module, "prodTag"),
-            get_element(rdf_module, "inputDir"),
-            process_input_dir)
-        if len(file_list) == 0:
-            LOGGER.error('No files to process!\nAborting...')
-            sys.exit(3)
-        fraction = 1
-        output = process
-        chunks = 1
-        try:
-            if get_element_dict(process_list[process], 'fraction') is not None:
-                fraction = get_element_dict(process_list[process], 'fraction')
-            if get_element_dict(process_list[process], 'output') is not None:
-                output = get_element_dict(process_list[process], 'output')
-            if get_element_dict(process_list[process], 'chunks') is not None:
-                chunks = get_element_dict(process_list[process], 'chunks')
-        except TypeError:
-            LOGGER.warning('No values set for process %s will use default '
-                           'values!', process)
-        if fraction < 1:
-            file_list = get_subfile_list(file_list, event_list, fraction)
-
-        # get the number of events processed, in a potential previous step
-        file_list_root = ROOT.vector('string')()
-        # amount of events processed in previous stage (= 0 if it is the first
-        # stage)
-        nevents_meta = 0
-        for file_name in file_list:
-            file_name = apply_filepath_rewrites(file_name)
-            file_list_root.push_back(file_name)
-            # Skip check for processed events in case of first stage
-            if get_element(rdf_module, "prodTag") is None:
-                infile = ROOT.TFile.Open(str(file_name), 'READ')
-                for key in infile.GetListOfKeys():
-                    if 'eventsProcessed' == key.GetName():
-                        nevents_meta += infile.eventsProcessed.GetVal()
-                        break
-                infile.Close()
-            if args.test:
-                break
-        events_processed_dict[process] = nevents_meta
-        info_msg = f'Add process "{process}" with:'
-        info_msg += f'\n\tfraction = {fraction}'
-        info_msg += f'\n\tnFiles = {len(file_list_root):,}'
-        info_msg += f'\n\toutput = {output}\n\tchunks = {chunks}'
-        LOGGER.info(info_msg)
-
-        dframe = ROOT.ROOT.RDataFrame("events", file_list_root)
-        evtcount = dframe.Count()
-
-        res, hweight = graph_function(dframe, process)
-        results.append(res)
-        hweights.append(hweight)
-        evtcounts.append(evtcount)
-
-    # Generate computational graph of the analysis
-    if args.graph:
-        generate_graph(dframe, args)
-
-    LOGGER.info('Starting the event loop...')
-    start_time = time.time()
-    ROOT.ROOT.RDF.RunGraphs(evtcounts)
-    LOGGER.info('Event loop done!')
-    elapsed_time = time.time() - start_time
-
-    LOGGER.info('Writing out output files...')
-    nevents_tot = 0
-    for process, res, hweight, evtcount in zip(process_list,
-                                               results,
-                                               hweights,
-                                               evtcounts):
-        # get the cross-sections etc. First try locally, then the procDict
-        if 'crossSection' in process_list[process]:
-            cross_section = process_list[process]['crossSection']
-        elif process in proc_dict and 'crossSection' in proc_dict[process]:
-            cross_section = proc_dict[process]['crossSection']
-        else:
-            LOGGER.warning('Can\'t find cross-section for process %s in '
-                           'processList or procDict!\nUsing default value '
-                           'of 1', process)
-            cross_section = 1
-
-        if 'kfactor' in process_list[process]:
-            kfactor = process_list[process]['kfactor']
-        elif process in proc_dict and 'kfactor' in proc_dict[process]:
-            kfactor = proc_dict[process]['kfactor']
-        else:
-            kfactor = 1
-
-        if 'matchingEfficiency' in process_list[process]:
-            matching_efficiency = process_list[process]['matchingEfficiency']
-        elif process in proc_dict \
-                and 'matchingEfficiency' in proc_dict[process]:
-            matching_efficiency = proc_dict[process]['matchingEfficiency']
-        else:
-            matching_efficiency = 1
-
-        events_processed = events_processed_dict[process] \
-            if events_processed_dict[process] != 0 else evtcount.GetValue()
-        scale = cross_section*kfactor*matching_efficiency/events_processed
-
-        nevents_tot += evtcount.GetValue()
-
-        hists_to_write = {}
-        for r in res:
-            hist = r.GetValue()
-            hname = hist.GetName()
-            # merge histograms in case histogram exists
-            if hist.GetName() in hists_to_write:
-                hists_to_write[hname].Add(hist)
-            else:
-                hists_to_write[hname] = hist
-
-        LOGGER.info('Writing out process %s, nEvents processed %s',
-                    process, f'{evtcount.GetValue():,}')
-        with ROOT.TFile(f'{output_dir}/{process}.root', 'RECREATE'):
-            for hist in hists_to_write.values():
-                if do_scale:
-                    hist.Scale(scale * int_lumi)
-                hist.Write()
-
-            # write all meta info to the output file
-            p = ROOT.TParameter(int)("eventsProcessed", events_processed)
-            p.Write()
-            p = ROOT.TParameter(float)("sumOfWeights", hweight.GetValue())
-            p.Write()
-            p = ROOT.TParameter(float)("intLumi", int_lumi)
-            p.Write()
-            p = ROOT.TParameter(float)("crossSection", cross_section)
-            p.Write()
-            p = ROOT.TParameter(float)("kfactor", kfactor)
-            p.Write()
-            p = ROOT.TParameter(float)("matchingEfficiency",
-                                       matching_efficiency)
-            p.Write()
-
-    info_msg = f"{' SUMMARY ':=^80}\n"
-    info_msg += 'Elapsed time (H:M:S):    '
-    info_msg += time.strftime('%H:%M:%S', time.gmtime(elapsed_time))
-    info_msg += '\nEvents processed/second: '
-    info_msg += f'{int(nevents_tot/elapsed_time):,}'
-    info_msg += f'\nTotal events processed:  {nevents_tot:,}'
-    info_msg += '\n'
-    info_msg += 80 * '='
-    info_msg += '\n'
-    LOGGER.info(info_msg)
-
-
-def run(parser):
-    '''
-    Set things in motion.
-    '''
-
-    args, unknown_args = parser.parse_known_args()
-    # Add unknown arguments including unknown input files
-    unknown_args += [x for x in args.files_list if not x.endswith('.root')]
-    args.unknown = unknown_args
-    args.files_list = [x for x in args.files_list if x.endswith('.root')]
-
-    if not hasattr(args, 'command'):
-        LOGGER.error('Error occurred during subcommand routing!\nAborting...')
-        sys.exit(3)
-
-    if args.command != 'run':
-        LOGGER.error('Unknow sub-command "%s"!\nAborting...')
-        sys.exit(3)
-
-    # Check that the analysis file exists
-    anapath = args.anascript_path
-    if not os.path.isfile(anapath):
-        LOGGER.error('Analysis script %s not found!\nAborting...',
-                     anapath)
-        sys.exit(3)
-
-    # Set verbosity level of the RDataFrame
-    if args.verbose:
-        # ROOT.Experimental.ELogLevel.kInfo verbosity level is more
-        # equivalent to DEBUG in other log systems
-        LOGGER.debug('Setting verbosity level "kInfo" for RDataFrame...')
-        verbosity = ROOT.Experimental.RLogScopedVerbosity(
-            ROOT.Detail.RDF.RDFLogChannel(),
-            ROOT.Experimental.ELogLevel.kInfo)
-        LOGGER.debug(verbosity)
-    if args.more_verbose:
-        LOGGER.debug('Setting verbosity level "kDebug" for RDataFrame...')
-        verbosity = ROOT.Experimental.RLogScopedVerbosity(
-            ROOT.Detail.RDF.RDFLogChannel(),
-            ROOT.Experimental.ELogLevel.kDebug)
-        LOGGER.debug(verbosity)
-    if args.most_verbose:
-        LOGGER.debug('Setting verbosity level "kDebug+10" for '
-                     'RDataFrame...')
-        verbosity = ROOT.Experimental.RLogScopedVerbosity(
-            ROOT.Detail.RDF.RDFLogChannel(),
-            ROOT.Experimental.ELogLevel.kDebug+10)
-        LOGGER.debug(verbosity)
-
-    # Load pre compiled analyzers
-    LOGGER.info('Loading analyzers from libFCCAnalyses...')
-    ROOT.gSystem.Load("libFCCAnalyses")
-    # Is this still needed?? 01/04/2022 still to be the case
-    fcc_loaded = ROOT.dummyLoader()
-    if fcc_loaded:
-        LOGGER.debug('Succesfuly loaded main FCCanalyses analyzers.')
-
-    # Load the analysis script as a module
-    anapath = os.path.abspath(anapath)
-    LOGGER.info('Loading analysis file:\n%s', anapath)
-    rdf_spec = importlib.util.spec_from_file_location("fcc_analysis_module",
-                                                      anapath)
-    rdf_module = importlib.util.module_from_spec(rdf_spec)
-    rdf_spec.loader.exec_module(rdf_module)
-
-    # Merge configuration from analysis script file with command line arguments
-    if get_element(rdf_module, 'graph'):
-        args.graph = True
-
-    if get_element(rdf_module, 'graphPath') != '':
-        args.graph_path = get_element(rdf_module, 'graphPath')
-
-    n_ana_styles = 0
-    for analysis_style in ["build_graph", "RDFanalysis", "Analysis", "RDFgraph"]:
-        if hasattr(rdf_module, analysis_style):
-            LOGGER.debug("Analysis style found: %s", analysis_style)
-            n_ana_styles += 1
-
-    if n_ana_styles == 0:
-        LOGGER.error('Analysis file does not contain required objects!\n'
-                     'Provide either RDFanalysis class, Analysis class, or '
-                     'build_graph function.')
-        sys.exit(3)
-
-    if n_ana_styles > 1:
-        LOGGER.error('Analysis file ambiguous!\n'
-                     'Multiple analysis styles used!\n'
-                     'Provide only one out of "RDFanalysis", "Analysis", '
-                     'or "build_graph".')
-        sys.exit(3)
-
-    if hasattr(rdf_module, "Analysis"):
-        from run_fccanalysis import run_fccanalysis
-        run_fccanalysis(args, rdf_module)
-    if hasattr(rdf_module, "RDFanalysis"):
-        run_stages(args, rdf_module, anapath)
-    if hasattr(rdf_module, "RDFgraph"):
-        from run_rdfgraph_analysis import run_rdfgraph
-        run_rdfgraph(args, rdf_module, anapath)
-    if hasattr(rdf_module, "build_graph"):
-        run_histmaker(args, rdf_module, anapath)
+                    run_local(rdf_module, chunk, process_name, args)


### PR DESCRIPTION
Hi,
I have written a new method to run the pre-selection. This method has the same properties of `RDFanalysis` but takes the `process_name` as a second argument in `analysers` and return the dataframe and a list of histogram or `TParameter` that will be written in the output file in a `TDirectory` called `custom_objects`.

In `custom_object`, the objects to write will be put in sub-`TDirectory` depending on their class (TH1D, TParameter<int>, etc.) to be more readable.

I called this new class `RDFgraph` because I wanted to take the advantages of `RDFanalysis` and `build_graph` and I named the `TDirectory` `custom_objects` but if you have more inspiration, you can change the names.

During the final-selection, a dictionary similar to `histoList` can optionally be added to include the histograms in the final-selection output file called `customHist` This new variable takes this form:

```python
customHists = {
    'leps_iso': {'name':'ConeIsolation', 'title':'I_{rel}', 'xmin':0, 'xmax':10},
    'leps_no':  {'name':'n_leptons', 'title':'N_{leptons}'}
}
```

to modify the histogram. If you don't want to modify your histogram, you can just leave the dictionary empty.

I made this method to be able to easily make a cuflow and histograms before a filter since `RDFanalysis` only return the branches after all the filters.

For the final-selection, we could use an eventual cutflow that is in `custom_objects/TH1D` to add new cuts from `cutList` but I think it's too difficult for me to implement it.

I also modified `do_plots` to have a strict x-range to not display bins with zero content and to set grid on the plot.
To do this you can add `strictRange = True` and `setGrid = True` to the plot script.
This apply to all the variables but we could make a list like for `rebin` to do implement it on chosen variables.

We could also make a dictionary with `rebin`, `grid`, `strictRange` and other parameters for all the variables in this form:

```python
variables = {
    'zll_m': {'rebin': 2, 'strict': False, 'grid': True},
    'zll_p': {'strict': True, 'grid': False}
}
```

with the keys optional.

I ran it on my setup and it works fine but I don't know if it works for other setup or if I followed the coding conventions. I timed `RDFanalysis` and my new method and they take the same time to run so I don't think there is much optimization to do.

If I was not clear enough or you need more information, I am available to answer your questions. I hope my modifications can be implemented as I think they could be useful for `FCCAnalyses` users.