### PR TITLE
Visual display of cutflow in final analysis

### DIFF
--- a/examples/FCCee/higgs/mH-recoil/mumu/analysis_final.py
+++ b/examples/FCCee/higgs/mH-recoil/mumu/analysis_final.py
@@ -41,6 +41,8 @@ doScale = True
 # Number of threads to use
 nCPUS = 2
 
+doTerminalDump = True
+
 # Whether to produce ROOT TTrees, default is False
 doTree = True
 

--- a/python/run_final_analysis.py
+++ b/python/run_final_analysis.py
@@ -394,6 +394,14 @@ def run(rdf_module, config, args) -> None:
         LOGGER.error('No histograms defined!\nAborting...')
         sys.exit(3)
 
+    do_terminal_dump = get_attribute(rdf_module, "doTerminalDump", False)
+    if do_terminal_dump:
+        try:
+            import plotext as plt
+        except ModuleNotFoundError:
+            LOGGER.error("plotext module was not found. Disabling the terminal dump.")
+            do_terminal_dump = False
+
     # Check whether to scale the results to the luminosity
     do_scale = get_attribute(rdf_module, "doScale", True)
     if do_scale:
@@ -640,6 +648,14 @@ def run(rdf_module, config, args) -> None:
                                           'fccanalysis_graph.dot')
             generate_graph(dframe, graph_path)
             args.graph = False
+
+        if do_terminal_dump:
+            cut_labels, n_events, n_events_raw = zip(*[(cut_name, cut_result["n_events"], cut_result["n_events_raw"]) \
+                                                     for cut_name, cut_result in results[process_name].items()])
+            plt.simple_bar(cut_labels, n_events, width=100, title="Weighted events passing cut")
+            plt.show()
+            plt.simple_bar(cut_labels, n_events_raw, width=100, title="Unweighted events passing cut")
+            plt.show()
 
         # And save everything
         LOGGER.info('Saving the outputs...')


### PR DESCRIPTION
This PR introduces the terminal plotting of an analysis cutflow to help inspecting it visually. It may be switched on using the `doTerminalDump` parameter in the final analysis steering card, provided the [`plotext`](https://github.com/piccolomo/plotext) Python package is present on the system/stack.

To test the changes introduced through this PR, and the potential addition of `plotext` in the dependencies stack, this can be tested on a working environment using e.g. a standard `venv` preparation:

```sh
python -m venv plotext
source plotext/bin/activate
pip install plotext
```

Using the H+recoil example amended here, this produces the following output:

<img width="756" height="552" alt="image" src="https://github.com/user-attachments/assets/f5ef9294-a90a-45ff-8c06-cd1cc7dd4133" />

FYI: @kjvbrt 