### PR TITLE
Update Zenodo metadata: Contributors, Description, and Community

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -55,7 +55,8 @@
 	},
 	{
 	    "affiliation": "CERN",
-	    "name": "Smieško, Juraj"
+	    "name": "Smieško, Juraj",
+	    "orcid": "0000-0003-3725-2984"
 	},
 	{
 	    "affiliation": "CERN",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,9 +1,42 @@
 {
     "creators": [
 	{
+	    "affiliation": "CERN",
+	    "name": "Carceller, Juan Miguel"
+	},
+	{
+	    "affiliation": "University of Adelaide",
+	    "name": "Desai, Aman"
+	},
+	{
+	    "affiliation": "CERN",
+	    "name": "Eysermans, Jan"
+	},
+	{
+	    "affiliation": "CERN",
+	    "name": "Forthomme, Laurent",
+	    "orcid": "0000-0002-3302-336X"
+	},
+	{
+	    "affiliation": "CERN",
+	    "name": "Francois, Brieuc"
+	},
+	{
 	    "affiliation": "Ecole Polytechnique Fédérale de Lausanne",
 	    "name": "Helsens, Clement",
 	    "orcid": "0000-0002-9243-7554"
+	},
+	{
+	    "affiliation": "CERN",
+	    "name": "Jamin, David Olivier"
+	},
+	{
+	    "affiliation": "DESY",
+	    "name": "Madlener, Thomas"
+	},
+	{
+	    "affiliation": "University of Copenhagen",
+	    "name": "Munch Torndal, Julie"
 	},
 	{
 	    "affiliation": "CERN",
@@ -17,45 +50,12 @@
 	},
 	{
 	    "affiliation": "CERN",
-	    "name": "Volkl, Valentin",
-	    "orcid": "0000-0002-9172-6629"
-	},
-	{
-	    "affiliation": "CERN",
-	    "name": "Forthomme, Laurent",
-	    "orcid": "0000-0002-3302-336X"
-	},
-	{
-	    "affiliation": "University of Copenhagen",
-	    "name": "Munch Torndal, Julie"
-	},
-	{
-	    "affiliation": "CERN",
 	    "name": "Smieško, Juraj"
 	},
 	{
 	    "affiliation": "CERN",
-	    "name": "Jamin, David Olivier"
-	},
-	{
-	    "affiliation": "CERN",
-	    "name": "Francois, Brieuc"
-	},
-	{
-	    "affiliation": "CERN",
-	    "name": "Eysermans, Jan"
-	},
-	{
-	    "affiliation": "CERN",
-	    "name": "Carceller, Juan Miguel"
-	},
-	{
-	    "affiliation": "DESY",
-	    "name": "Madlener, Thomas"
-	},
-	{
-	    "affiliation": "University of Adelaide",
-	    "name": "Desai, Aman"
+	    "name": "Volkl, Valentin",
+	    "orcid": "0000-0002-9172-6629"
 	}
     ],
     "description": "FCCAnalyses is a common framework for Future Circular Collider (FCC) related analyses. It allows users to write full analyses by taking EDM4hep input ROOT files, processing them using ROOT RDataFrame, and producing histograms and plots. The framework is designed to be efficient and modular, supporting various FCC-ee and FCC-hh physics studies.",
@@ -74,4 +74,3 @@
     "license": "Apache-2.0",
     "upload_type": "software"
 }
-

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -22,6 +22,11 @@
 	    "name": "Francois, Brieuc"
 	},
 	{
+	    "affiliation": "CERN",
+	    "name": "Ganis, Gerardo",
+	    "orcid": "0000-0002-8432-2183"
+	},
+	{
 	    "affiliation": "Ecole Polytechnique Fédérale de Lausanne",
 	    "name": "Helsens, Clement",
 	    "orcid": "0000-0002-9243-7554"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -28,7 +28,41 @@
 	{
 	    "affiliation": "University of Copenhagen",
 	    "name": "Munch Torndal, Julie"
+	},
+	{
+	    "affiliation": "CERN",
+	    "name": "Smieško, Juraj"
+	},
+	{
+	    "affiliation": "CERN",
+	    "name": "Jamin, David Olivier"
+	},
+	{
+	    "affiliation": "CERN",
+	    "name": "Francois, Brieuc"
+	},
+	{
+	    "affiliation": "CERN",
+	    "name": "Eysermans, Jan"
+	},
+	{
+	    "affiliation": "CERN",
+	    "name": "Carceller, Juan Miguel"
+	},
+	{
+	    "affiliation": "DESY",
+	    "name": "Madlener, Thomas"
+	},
+	{
+	    "affiliation": "University of Adelaide",
+	    "name": "Desai, Aman"
 	}
+    ],
+    "description": "FCCAnalyses is a common framework for Future Circular Collider (FCC) related analyses. It allows users to write full analyses by taking EDM4hep input ROOT files, processing them using ROOT RDataFrame, and producing histograms and plots. The framework is designed to be efficient and modular, supporting various FCC-ee and FCC-hh physics studies.",
+    "communities": [
+        {
+            "identifier": "fcc-phex"
+        }
     ],
     "keywords": [
 	"data analyses",


### PR DESCRIPTION
This PR updates the `.zenodo.json` file to improve the metadata for Zenodo releases, ensuring all major contributors are credited.

## Changes:
- **Creators:** Expanded the author list to include contributors with 5 or more pull requests, as well as principal authors listed in the documentation.
- **Alphabetical Ordering:** Re-sorted the entire creator list alphabetically by surname.
- **Description:** Added a project overview to help with discovery on Zenodo.
- **Community:** Updated the community identifier to `fcc-phex`.

## Contributors and PR Counts:
The following list includes authors meeting the 5+ PR threshold (or listed as principal authors), ordered by the estimated number of merged pull requests:

1.  **Helsens, Clement** (86 PRs)
2.  **Smieško, Juraj** (55 PRs) - *New*
3.  **Jamin, David Olivier** (35 PRs) - *New*
4.  **Volkl, Valentin** (32 PRs)
5.  **Perez, Emmanuel** (31 PRs)
6.  **Selvaggi, Michele** (19 PRs)
7.  **Carceller, Juan Miguel** (12 PRs) - *New*
8.  **Forthomme, Laurent** (12 PRs)
9.  **Madlener, Thomas** (10 PRs) - *New*
10. **Francois, Brieuc** (8 PRs) - *New*
11. **Desai, Aman** (7 PRs) - *New*
12. **Eysermans, Jan** (5 PRs) - *New*
13. **Ganis, Gerardo** (Principal Author in manual pages) - *New*
14. **Munch Torndal, Julie** (2 PRs)

*Note: PR counts were estimated by analyzing merge commits and branch origins.*

This update ensures that the project metadata accurately reflects the collaborative effort of the FCCAnalyses community.