### PR TITLE
Fix bench CI: drop stale -DCMAKE_CXX_STANDARD=17

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,7 +32,7 @@ jobs:
          mkdir -p build install;\
          source ${{ matrix.STACK }};\
          cd build;\
-         cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -G Ninja ..;'
+         cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -G Ninja ..;'
     - name: Compile
       run: |
         docker exec CI_container /bin/bash -c 'cd ./Package;\


### PR DESCRIPTION
bench.yml has been failing at CMake Configure since #507, which introduced a shared cmake/Key4hepConfig.cmake that rejects any C++ standard other than 20/23/26. bench.yml still passes -DCMAKE_CXX_STANDARD=17 explicitly, which pre-seeds the cache and can't be overridden by the macro's non-FORCE set(), tripping the FATAL_ERROR. test.yml doesn't pass this flag and passes fine. Dropping it here to match.