### PR TITLE
Test against 2025-05-29 and 2026 stack releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,12 @@ jobs:
         include:
           - STACK: '/cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh'
             OS: 'ubuntu24'
+          - STACK: '/cvmfs/sw.hsf.org/key4hep/setup.sh -r 2026-04-08'
+            OS: 'ubuntu22'
+          - STACK: '/cvmfs/sw.hsf.org/key4hep/setup.sh -r 2026-02-01'
+            OS: 'ubuntu22'
+          - STACK: '/cvmfs/sw.hsf.org/key4hep/setup.sh -r 2025-05-29'
+            OS: 'ubuntu22'
     steps:
     - uses: actions/checkout@v6
     - name: Start container

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ jobs:
       fail-fast: false
       matrix:
         STACK: ['/cvmfs/sw.hsf.org/key4hep/setup.sh',
+                '/cvmfs/sw.hsf.org/key4hep/setup.sh -r 2026-04-08',
+                '/cvmfs/sw.hsf.org/key4hep/setup.sh -r 2026-02-01',
+                '/cvmfs/sw.hsf.org/key4hep/setup.sh -r 2025-05-29',
+                '/cvmfs/sw.hsf.org/key4hep/setup.sh -r 2025-01-28',
                 '/cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh']
         OS: ['alma9',
             ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # 2025-01-28 is excluded: it ships podio 1.1, and the
+        # WITH_PODIO_DATASOURCE feature needs podio >= 1.3.
         STACK: ['/cvmfs/sw.hsf.org/key4hep/setup.sh',
                 '/cvmfs/sw.hsf.org/key4hep/setup.sh -r 2026-04-08',
                 '/cvmfs/sw.hsf.org/key4hep/setup.sh -r 2026-02-01',
                 '/cvmfs/sw.hsf.org/key4hep/setup.sh -r 2025-05-29',
-                '/cvmfs/sw.hsf.org/key4hep/setup.sh -r 2025-01-28',
                 '/cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh']
         OS: ['alma9',
             ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,9 @@ jobs:
           - STACK: '/cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh'
             OS: 'ubuntu24'
           - STACK: '/cvmfs/sw.hsf.org/key4hep/setup.sh -r 2026-04-08'
-            OS: 'ubuntu22'
+            OS: 'ubuntu24'
           - STACK: '/cvmfs/sw.hsf.org/key4hep/setup.sh -r 2026-02-01'
-            OS: 'ubuntu22'
-          - STACK: '/cvmfs/sw.hsf.org/key4hep/setup.sh -r 2025-05-29'
-            OS: 'ubuntu22'
+            OS: 'ubuntu24'
     steps:
     - uses: actions/checkout@v6
     - name: Start container


### PR DESCRIPTION
Adds the latest, both 2026 (2026-02-01, 2026-04-08, also on ubuntu24), and 2025-05-29 key4hep stack releases to the test matrix, alongside the existing nightly legs.