### PR TITLE
Add --output-format option for TTree and RNTuple output

### DIFF
--- a/examples/FCCee/higgs/mH-recoil/mumu/analysis_stage1.py
+++ b/examples/FCCee/higgs/mH-recoil/mumu/analysis_stage1.py
@@ -48,6 +48,9 @@ class Analysis():
         self.output_dir = 'outputs/FCCee/higgs/mH-recoil/mumu/' \
                           f'stage1_{self.ana_args.muon_pt}'
 
+        # Optional: output file format, default is 'ttree'
+        # self.output_format = 'rntuple'
+
         # Optional: analysis name, default is ''
         # self.analysis_name = 'My Analysis'
 

--- a/examples/FCCee/higgs/mH-recoil/mumu/analysis_stage1.py
+++ b/examples/FCCee/higgs/mH-recoil/mumu/analysis_stage1.py
@@ -48,7 +48,7 @@ class Analysis():
         self.output_dir = 'outputs/FCCee/higgs/mH-recoil/mumu/' \
                           f'stage1_{self.ana_args.muon_pt}'
 
-        # Optional: output file format, default is 'ttree'
+        # Optional: output ROOT file format, default is 'ttree'
         # self.output_format = 'rntuple'
 
         # Optional: analysis name, default is ''

--- a/man/man1/fccanalysis-run.1
+++ b/man/man1/fccanalysis-run.1
@@ -20,6 +20,7 @@
 [\fB\-\-graph\-path\fR \fIGRAPH_PATH\fR]
 [\fB\-\-use-data-source\fR]
 [\fB\-\-output\-dir\fR \fIOUTPUT_DIR\fR]
+[\fB\-\-output\-format\fR {\fBttree\fR,\fBrntuple\fR}]
 [\fB\-a\fR \fIANALYSIS_NAME\fR | \fB\-\-analysis\-name\fR \fIANALYSIS_NAME\fR]
 [\fB\-\-apply\-filepath\-rewrites\fR | \fB\-\-no\-filepath\-rewrites\fR]
 [\fB\-s\fR \fISAMPLE_NAME\fR | \fB\-\-sample\-name\fR \fISAMPLE_NAME\fR]
@@ -77,6 +78,11 @@ Load events through podio::DataSource\&.
 .TP
 \fB\-\-output\-dir\fR \fIOUTPUT_DIR\fR
 Set global output directory for the analysis.
+.TP
+\fB\-\-output\-format\fR {\fBttree\fR, \fBrntuple\fR}
+Specify the output file format.
+.br
+Default value: \fBttree\fR.
 .TP
 \fB\-a\fR \fIANALYSIS_NAME\fR, \fB\-\-analysis\-name\fR \fIANALYSIS_NAME\fR
 Set analysis name, mostly used for the output path.

--- a/man/man1/fccanalysis-run.1
+++ b/man/man1/fccanalysis-run.1
@@ -80,7 +80,7 @@ Load events through podio::DataSource\&.
 Set global output directory for the analysis.
 .TP
 \fB\-\-output\-format\fR {\fBttree\fR, \fBrntuple\fR}
-Specify the output file format.
+Specify the output ROOT file format.
 .br
 Default value: \fBttree\fR.
 .TP

--- a/man/man7/fccanalysis-script.7
+++ b/man/man7/fccanalysis-script.7
@@ -149,6 +149,11 @@ the sub-folders of $FCCDICTSDIR\&.
 \fBoutput_dir\fR (mandatory)
 User can specify the directory for the output files\&.
 .TP
+\fBoutput_format\fR (optional)
+Specifies the output file format. Accepted values are \fBttree\fR and \fBrntuple\fR.
+.br
+Default value: ttree
+.TP
 \fBanalysis_name\fR (optional)
 Optional name for the analysis
 .br

--- a/man/man7/fccanalysis-script.7
+++ b/man/man7/fccanalysis-script.7
@@ -150,7 +150,7 @@ the sub-folders of $FCCDICTSDIR\&.
 User can specify the directory for the output files\&.
 .TP
 \fBoutput_format\fR (optional)
-Specifies the output file format. Accepted values are \fBttree\fR and \fBrntuple\fR.
+Specifies the output ROOT file format. Accepted values are \fBttree\fR and \fBrntuple\fR.
 .br
 Default value: ttree
 .TP

--- a/python/job.py
+++ b/python/job.py
@@ -30,7 +30,8 @@ class Job:
     def __init__(self,
                  input_file_list: list[str],
                  analysis_chain: Callable,
-                 use_data_source: bool = False):
+                 use_data_source: bool = False,
+                 output_format: str = 'ttree'):
         '''
         Initialize all required parameters.
         '''
@@ -55,6 +56,9 @@ class Job:
 
         # Setup analysis chain
         self._analysis_chain: Callable = analysis_chain
+
+        # Output format
+        self._output_format: str = output_format
 
         # Output of the job
         self._output_file_path: Optional[str] = None
@@ -247,9 +251,16 @@ class Job:
         start_time = time.time()
         try:
             LOGGER.info('Snapshoting...')
-            final_dframe.Snapshot("events",
-                                  self._output_file_path,
-                                  self._output_variables)
+            options = ROOT.RDF.RSnapshotOptions()
+            if self._output_format == 'rntuple':
+                options.fOutputFormat = ROOT.RDF.ESnapshotOutputFormat.kRNTuple
+
+            final_dframe.Snapshot(
+                "events",
+                self._output_file_path,
+                self._output_variables,
+                options
+            )
             LOGGER.info('Finished snapshoting...')
         except TypeError as err:
             LOGGER.error('A problem encountered during the execution of the '

--- a/python/job.py
+++ b/python/job.py
@@ -30,8 +30,7 @@ class Job:
     def __init__(self,
                  input_file_list: list[str],
                  analysis_chain: Callable,
-                 use_data_source: bool = False,
-                 output_format: str = 'ttree'):
+                 use_data_source: bool = False):
         '''
         Initialize all required parameters.
         '''
@@ -56,9 +55,6 @@ class Job:
 
         # Setup analysis chain
         self._analysis_chain: Callable = analysis_chain
-
-        # Output format
-        self._output_format: str = output_format
 
         # Output of the job
         self._output_file_path: Optional[str] = None
@@ -151,11 +147,14 @@ class Job:
 
     def setup_output(self,
                      output_filepath: str,
-                     output_variables: Callable[[], list[str]]) -> None:
+                     output_variables: Callable[[], list[str]],
+                     output_format: str = 'ttree') -> None:
         '''
         Setup output of this work unit, output variables and output file path.
         '''
         self._output_file_path = output_filepath
+
+        self._output_format: str = output_format
 
         self._output_variables = output_variables()
 

--- a/python/parsers.py
+++ b/python/parsers.py
@@ -111,7 +111,7 @@ def setup_run_parser(parser):
         '--output-format',
         choices=('ttree', 'rntuple'),
         default=None,
-        help='choose the output file format'
+        help='choose the output ROOT file format'
     )
     parser.add_argument(
         '-j', '--ncpus', '--n-threads',

--- a/python/parsers.py
+++ b/python/parsers.py
@@ -192,6 +192,12 @@ def setup_run_parser(parser):
         default=None,
         help='specify how to stride through the events'
     )
+    parser.add_argument(
+        '--output-format',
+        choices=('ttree', 'rntuple'),
+        default='ttree',
+        help='choose the output file format'
+    )
 
     # Testing
     test_group = parser.add_argument_group('Tests and benchmarking')

--- a/python/parsers.py
+++ b/python/parsers.py
@@ -108,6 +108,12 @@ def setup_run_parser(parser):
         help='global output directory'
     )
     parser.add_argument(
+        '--output-format',
+        choices=('ttree', 'rntuple'),
+        default=None,
+        help='choose the output file format'
+    )
+    parser.add_argument(
         '-j', '--ncpus', '--n-threads',
         type=int,
         default=None,
@@ -191,12 +197,6 @@ def setup_run_parser(parser):
         type=int,
         default=None,
         help='specify how to stride through the events'
-    )
-    parser.add_argument(
-        '--output-format',
-        choices=('ttree', 'rntuple'),
-        default=None,
-        help='choose the output file format'
     )
 
     # Testing

--- a/python/parsers.py
+++ b/python/parsers.py
@@ -195,7 +195,7 @@ def setup_run_parser(parser):
     parser.add_argument(
         '--output-format',
         choices=('ttree', 'rntuple'),
-        default='ttree',
+        default=None,
         help='choose the output file format'
     )
 

--- a/python/run_fccanalysis.py
+++ b/python/run_fccanalysis.py
@@ -464,7 +464,11 @@ def merge_config(args: argparse.Namespace,
         config['output-dir'] = args.output_dir
 
     # Check output file format
-    config['output-format'] = args.output_format
+    config['output-format'] = 'ttree'
+    if hasattr(analysis_class, 'output_format'):
+        config['output-format'] = analysis_class.output_format
+    if args.output_format is not None:
+        config['output-format'] = args.output_format
 
     # Check for number of output chunks
     config['n-chunks'] = None
@@ -636,12 +640,12 @@ def run_fccanalysis(args, anascript_module) -> None:
 
         dframe_job = Job(job['input-file-list'],
                          config['analysis-chain'],
-                         config['use-data-source'],
-                         config['output-format']
+                         config['use-data-source']
         )
 
         dframe_job.setup_output(job['output-file'],
-                                config['output-variables'])
+                                config['output-variables'],
+                                config['output-format'])
 
         if config['enable-progress-bar']:
             dframe_job.enable_progress_bar()

--- a/python/run_fccanalysis.py
+++ b/python/run_fccanalysis.py
@@ -463,6 +463,9 @@ def merge_config(args: argparse.Namespace,
     if args.output_dir is not None:
         config['output-dir'] = args.output_dir
 
+    # Check output file format
+    config['output-format'] = args.output_format
+
     # Check for number of output chunks
     config['n-chunks'] = None
     if args.n_chunks is not None:
@@ -633,7 +636,9 @@ def run_fccanalysis(args, anascript_module) -> None:
 
         dframe_job = Job(job['input-file-list'],
                          config['analysis-chain'],
-                         config['use-data-source'])
+                         config['use-data-source'],
+                         config['output-format']
+        )
 
         dframe_job.setup_output(job['output-file'],
                                 config['output-variables'])

--- a/python/run_fccanalysis.py
+++ b/python/run_fccanalysis.py
@@ -463,7 +463,7 @@ def merge_config(args: argparse.Namespace,
     if args.output_dir is not None:
         config['output-dir'] = args.output_dir
 
-    # Check output file format
+    # Check output ROOT file format
     config['output-format'] = 'ttree'
     if hasattr(analysis_class, 'output_format'):
         config['output-format'] = analysis_class.output_format


### PR DESCRIPTION
Added a new command-line option to select the output format, either TTree or RNTuple. The default output format remains TTree, so the behavior of the code does not change. When `--output-format rntuple` is specified, the output is written as an RNTuple using `ROOT.RDF.RSnapshotOptions`.

```bash
fccanalysis run <analysis.py> --output-format rntuple