### PR TITLE
Update FCCAnalyses website links to fccanalyses.web.cern.ch

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ website.
 ## Documentation
 
 Detailed documentation can be found at the
-[FCCAnalyses](https://hep-fcc.github.io/FCCAnalyses/) webpage.
+[FCCAnalyses](https://fccanalyses.web.cern.ch/) webpage.
 
 
 ## Contributing
@@ -70,7 +70,7 @@ your feature/analysis and submit a pull requests.
 ### Code Formating
 
 The preferred style of the C++ code in the
-[FCCAnalyses](https://hep-fcc.github.io/FCCAnalyses/) is LLVM, which is checked
+[FCCAnalyses](https://fccanalyses.web.cern.ch/) is LLVM, which is checked
 by a CI job.
 
 To apply formatting to a file:

--- a/doc/DoxygenLayout.xml
+++ b/doc/DoxygenLayout.xml
@@ -4,7 +4,7 @@
   <!-- Navigation index tabs for HTML output -->
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
-    <tab type="user" visible="yes" title="FCCAnalyses website" url="https://hep-fcc.github.io/FCCAnalyses/"/>
+    <tab type="user" visible="yes" title="FCCAnalyses website" url="https://fccanalyses.web.cern.ch/"/>
     <tab type="user" visible="yes" title="EDM4hep" url="https://cern.ch/edm4hep"/>
     <tab type="user" visible="yes" title="ROOT RDataFrame" url="https://root.cern/doc/master/classROOT_1_1RDataFrame.html"/>
     <tab type="pages" visible="yes" title="" intro=""/>


### PR DESCRIPTION
The FCCAnalyses website has moved from GitHub Pages
(hep-fcc.github.io/FCCAnalyses) to CERN's WebEOS hosting
(fccanalyses.web.cern.ch). Updates the 3 remaining links in
README.md and doc/DoxygenLayout.xml.

The old GitHub Pages site now redirects to the new one; doc/latest,
man/, and dev/bench stay hosted on GitHub Pages as before.