### PR TITLE
Fix ACTS build against nightlies (ACTS >= 45)

### DIFF
--- a/analyzers/dataframe/src/VertexFinderActs.cc
+++ b/analyzers/dataframe/src/VertexFinderActs.cc
@@ -46,12 +46,12 @@ VertexFinderAMVF(ROOT::VecOps::RVec<edm4hep::TrackState> tracks ){
   using Propagator = Acts::Propagator<Acts::EigenStepper<>>;
 
   // Create a test context
-  //Acts::GeometryContext geoContext = Acts::GeometryContext();
-  //Acts::MagneticFieldContext magFieldContext = Acts::MagneticFieldContext();
+  // Acts::GeometryContext geoContext = Acts::GeometryContext();
+  // Acts::MagneticFieldContext magFieldContext = Acts::MagneticFieldContext();
   // GeometryContext's default constructor became private (in favor of
   // dangerouslyDefaultConstruct()) starting with ACTS 45.
 #if ACTS_VERSION_MAJOR >= 45
-  const auto& geoContext = Acts::GeometryContext::dangerouslyDefaultConstruct();
+  const auto &geoContext = Acts::GeometryContext::dangerouslyDefaultConstruct();
 #else
   const auto& geoContext = Acts::GeometryContext();
 #endif

--- a/analyzers/dataframe/src/VertexFinderActs.cc
+++ b/analyzers/dataframe/src/VertexFinderActs.cc
@@ -48,7 +48,13 @@ VertexFinderAMVF(ROOT::VecOps::RVec<edm4hep::TrackState> tracks ){
   // Create a test context
   //Acts::GeometryContext geoContext = Acts::GeometryContext();
   //Acts::MagneticFieldContext magFieldContext = Acts::MagneticFieldContext();
+  // GeometryContext's default constructor became private (in favor of
+  // dangerouslyDefaultConstruct()) starting with ACTS 45.
+#if ACTS_VERSION_MAJOR >= 45
+  const auto& geoContext = Acts::GeometryContext::dangerouslyDefaultConstruct();
+#else
   const auto& geoContext = Acts::GeometryContext();
+#endif
   const auto& magFieldContext = Acts::MagneticFieldContext();
 
   // Set up EigenStepper
@@ -164,7 +170,7 @@ VertexFinderAMVF(ROOT::VecOps::RVec<edm4hep::TrackState> tracks ){
     }
 
     // Get track covariance vector
-    using Covariance = Acts::BoundSquareMatrix;
+    using Covariance = Acts::BoundMatrix;
 
     Covariance covMat;
     covMat <<

--- a/analyzers/dataframe/src/VertexFitterActs.cc
+++ b/analyzers/dataframe/src/VertexFitterActs.cc
@@ -3,7 +3,13 @@
 #include "FCCAnalyses/ReconstructedParticle2MC.h"
 
 // ACTS
+// BoundTrackParameters.hpp replaced the umbrella TrackParameters.hpp header
+// starting with ACTS 45.
+#if ACTS_VERSION_MAJOR >= 45
+#include "Acts/EventData/BoundTrackParameters.hpp"
+#else
 #include "Acts/EventData/TrackParameters.hpp"
+#endif
 #include "Acts/MagneticField/ConstantBField.hpp"
 #include "Acts/Propagator/EigenStepper.hpp"
 #include "Acts/Propagator/Propagator.hpp"
@@ -39,7 +45,13 @@ VertexingUtils::FCCAnalysesVertex VertexFitterFullBilloir(ROOT::VecOps::RVec<edm
   // Create a test context
   //Acts::GeometryContext geoContext = Acts::GeometryContext();
   //Acts::MagneticFieldContext magFieldContext = Acts::MagneticFieldContext();
+  // GeometryContext's default constructor became private (in favor of
+  // dangerouslyDefaultConstruct()) starting with ACTS 45.
+#if ACTS_VERSION_MAJOR >= 45
+  const auto& geoContext = Acts::GeometryContext::dangerouslyDefaultConstruct();
+#else
   const auto& geoContext = Acts::GeometryContext();
+#endif
   const auto& magFieldContext = Acts::MagneticFieldContext();
 
   // Set up EigenStepper
@@ -111,7 +123,7 @@ VertexingUtils::FCCAnalysesVertex VertexFitterFullBilloir(ROOT::VecOps::RVec<edm
     }
 
     // Get track covariance vector
-    using Covariance = Acts::BoundSquareMatrix;
+    using Covariance = Acts::BoundMatrix;
     Covariance covMat;
     covMat <<
       covACTS(0,0), covACTS(1,0), covACTS(2,0), covACTS(3,0), covACTS(4,0), covACTS(5,0),

--- a/analyzers/dataframe/src/VertexFitterActs.cc
+++ b/analyzers/dataframe/src/VertexFitterActs.cc
@@ -41,14 +41,13 @@ VertexingUtils::FCCAnalysesVertex VertexFitterFullBilloir(ROOT::VecOps::RVec<edm
   // retrieve the tracks associated to the recoparticles
   ROOT::VecOps::RVec<edm4hep::TrackState> tracks = ReconstructedParticle2Track::getRP2TRK( recoparticles, thetracks );
 
-
   // Create a test context
-  //Acts::GeometryContext geoContext = Acts::GeometryContext();
-  //Acts::MagneticFieldContext magFieldContext = Acts::MagneticFieldContext();
+  // Acts::GeometryContext geoContext = Acts::GeometryContext();
+  // Acts::MagneticFieldContext magFieldContext = Acts::MagneticFieldContext();
   // GeometryContext's default constructor became private (in favor of
   // dangerouslyDefaultConstruct()) starting with ACTS 45.
 #if ACTS_VERSION_MAJOR >= 45
-  const auto& geoContext = Acts::GeometryContext::dangerouslyDefaultConstruct();
+  const auto &geoContext = Acts::GeometryContext::dangerouslyDefaultConstruct();
 #else
   const auto& geoContext = Acts::GeometryContext();
 #endif


### PR DESCRIPTION
- `--acts-on` builds fail against the Key4hep nightlies stack (ACTS `develop`) due to three API changes: `Acts/EventData/TrackParameters.hpp` was split (the used type moved to `BoundTrackParameters.hpp`), `Acts::GeometryContext`'s default constructor became private in favor of `dangerouslyDefaultConstruct()`, and `Acts::BoundSquareMatrix` was renamed to `Acts::BoundMatrix`
- `BoundMatrix` exists under both old and new naming, so that rename applies unconditionally
- The header and `GeometryContext` construction are gated on `ACTS_VERSION_MAJOR` (already injected by CMake, just unused until now) so both the pinned release and nightlies build cleanly
- Note: `ACTS_VERSION_MAJOR` gating like this existed before and was removed in #450 to simplify down to one minimum ACTS version — reintroducing it here since release and nightlies have genuinely diverged again; worth revisiting once nightlies' API stabilizes into a release
- Verified with clean `--acts-on` builds against both stacks
- This only fixes the build — the physics output of the ACTS-based vertexing was not validated against either stack and may be affected