### PR TITLE
Fix compiler warnings

### DIFF
--- a/addons/FastJet/JetClustering.h
+++ b/addons/FastJet/JetClustering.h
@@ -8,8 +8,11 @@
 #include "fastjet/ClusterSequence.hh"
 #include "fastjet/ClusterSequenceArea.hh"
 #include "fastjet/JetDefinition.hh"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #include "fastjet/EECambridgePlugin.hh"
 #include "fastjet/JadePlugin.hh"
+#pragma GCC diagnostic pop
 
 #include "FastJet/ValenciaPlugin.h"
 

--- a/addons/FastJet/ValenciaPlugin.h
+++ b/addons/FastJet/ValenciaPlugin.h
@@ -55,6 +55,7 @@ FASTJET_BEGIN_NAMESPACE  // defined in fastjet/internal/base.hh
 
     /// copy constructor
     ValenciaPlugin(const ValenciaPlugin &plugin) { *this = plugin; }
+    ValenciaPlugin &operator=(const ValenciaPlugin &) = default;
 
     // the things that are required by base class
     virtual std::string description() const;

--- a/addons/FastJet/src/JetClustering.cc
+++ b/addons/FastJet/src/JetClustering.cc
@@ -24,7 +24,6 @@ namespace JetClustering {
     _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
     //define the clustering sequence and jet definition
-    fastjet::ClusterSequence _cs;
     _def = fastjet::JetDefinition(_jetAlgorithm, _radius, _recombScheme);
     if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
       _def.set_recombiner(new ExternalRecombiner(_recombination));
@@ -65,7 +64,6 @@ namespace JetClustering {
     _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
     //define the clustering sequence and jet definition
-    fastjet::ClusterSequence _cs;
     _def = fastjet::JetDefinition(_jetAlgorithm, _radius, _recombScheme);
     if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
       _def.set_recombiner(new ExternalRecombiner(_recombination));
@@ -105,7 +103,6 @@ namespace JetClustering {
     _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
     //define the clustering sequence and jet definition
-    fastjet::ClusterSequence _cs;
     _def = fastjet::JetDefinition(_jetAlgorithm, _radius, _recombScheme);
     if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
       _def.set_recombiner(new ExternalRecombiner(_recombination));
@@ -141,7 +138,6 @@ namespace JetClustering {
     _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
     //define the clustering sequence and jet definition
-    fastjet::ClusterSequence _cs;
     _def = fastjet::JetDefinition(_jetAlgorithm, _recombScheme);
     if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
       _def.set_recombiner(new ExternalRecombiner(_recombination));
@@ -180,7 +176,6 @@ namespace JetClustering {
     _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
     //define the clustering sequence and jet definition
-    fastjet::ClusterSequence _cs;
     _def = fastjet::JetDefinition(_jetAlgorithm, _radius, _exponent, _recombScheme);
     if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
       _def.set_recombiner(new ExternalRecombiner(_recombination));
@@ -219,7 +214,6 @@ namespace JetClustering {
     _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
     //define the clustering sequence and jet definition
-    fastjet::ClusterSequence _cs;
     _def = fastjet::JetDefinition(_jetAlgorithm, _radius, _exponent, _recombScheme);
     if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
       _def.set_recombiner(new ExternalRecombiner(_recombination));
@@ -264,7 +258,6 @@ namespace JetClustering {
     _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
     //define the clustering sequence and jet definition
-    fastjet::ClusterSequence _cs;
     _def = fastjet::JetDefinition(_jetAlgorithm);
     _def.set_recombination_scheme(_recombScheme);
     if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
@@ -300,12 +293,11 @@ namespace JetClustering {
     _jetAlgorithm = new fastjet::JadePlugin();
 
     // initialize recombination scheme
-    fastjet::RecombinationScheme _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
+    fastjet::RecombinationScheme recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
-    fastjet::ClusterSequence _cs;
     _def = fastjet::JetDefinition(_jetAlgorithm);
-    _def.set_recombination_scheme(_recombScheme);
-    if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
+    _def.set_recombination_scheme(recombScheme);
+    if (recombScheme == fastjet::RecombinationScheme::external_scheme)
       _def.set_recombiner(new ExternalRecombiner(_recombination));
   }
 

--- a/addons/FastJet/src/JetClustering.cc
+++ b/addons/FastJet/src/JetClustering.cc
@@ -23,7 +23,7 @@ namespace JetClustering {
     // initialize recombination scheme
     _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
-    //define the clustering sequence and jet definition
+    // define the clustering sequence and jet definition
     _def = fastjet::JetDefinition(_jetAlgorithm, _radius, _recombScheme);
     if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
       _def.set_recombiner(new ExternalRecombiner(_recombination));
@@ -63,7 +63,7 @@ namespace JetClustering {
     // initialize recombination scheme
     _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
-    //define the clustering sequence and jet definition
+    // define the clustering sequence and jet definition
     _def = fastjet::JetDefinition(_jetAlgorithm, _radius, _recombScheme);
     if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
       _def.set_recombiner(new ExternalRecombiner(_recombination));
@@ -102,7 +102,7 @@ namespace JetClustering {
     // initialize recombination scheme
     _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
-    //define the clustering sequence and jet definition
+    // define the clustering sequence and jet definition
     _def = fastjet::JetDefinition(_jetAlgorithm, _radius, _recombScheme);
     if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
       _def.set_recombiner(new ExternalRecombiner(_recombination));
@@ -137,7 +137,7 @@ namespace JetClustering {
     // initialize recombination scheme
     _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
-    //define the clustering sequence and jet definition
+    // define the clustering sequence and jet definition
     _def = fastjet::JetDefinition(_jetAlgorithm, _recombScheme);
     if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
       _def.set_recombiner(new ExternalRecombiner(_recombination));
@@ -175,7 +175,7 @@ namespace JetClustering {
     // initialize recombination scheme
     _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
-    //define the clustering sequence and jet definition
+    // define the clustering sequence and jet definition
     _def = fastjet::JetDefinition(_jetAlgorithm, _radius, _exponent, _recombScheme);
     if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
       _def.set_recombiner(new ExternalRecombiner(_recombination));
@@ -213,7 +213,7 @@ namespace JetClustering {
     // initialize recombination scheme
     _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
-    //define the clustering sequence and jet definition
+    // define the clustering sequence and jet definition
     _def = fastjet::JetDefinition(_jetAlgorithm, _radius, _exponent, _recombScheme);
     if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
       _def.set_recombiner(new ExternalRecombiner(_recombination));
@@ -257,7 +257,7 @@ namespace JetClustering {
     // initialize recombination scheme
     _recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
-    //define the clustering sequence and jet definition
+    // define the clustering sequence and jet definition
     _def = fastjet::JetDefinition(_jetAlgorithm);
     _def.set_recombination_scheme(_recombScheme);
     if (_recombScheme == fastjet::RecombinationScheme::external_scheme)
@@ -293,7 +293,8 @@ namespace JetClustering {
     _jetAlgorithm = new fastjet::JadePlugin();
 
     // initialize recombination scheme
-    fastjet::RecombinationScheme recombScheme = FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
+    fastjet::RecombinationScheme recombScheme =
+        FCCAnalyses::JetClusteringUtils::recomb_scheme(_recombination);
 
     _def = fastjet::JetDefinition(_jetAlgorithm);
     _def.set_recombination_scheme(recombScheme);

--- a/addons/ONNXRuntime/WeaverInterface.h
+++ b/addons/ONNXRuntime/WeaverInterface.h
@@ -47,7 +47,7 @@ private:
     size_t min_length{0}, max_length{0};
     std::vector<std::string> var_names;
     std::unordered_map<std::string, VarInfo> var_info_map;
-    VarInfo info(const std::string& name) const { return var_info_map.at(name); }
+    VarInfo info(const std::string& variableName) const { return var_info_map.at(variableName); }
     void dumpVars() const;
   };
   std::vector<float> center_norm_pad(const rv::RVec<float>& input,

--- a/addons/ONNXRuntime/WeaverInterface.h
+++ b/addons/ONNXRuntime/WeaverInterface.h
@@ -47,7 +47,9 @@ private:
     size_t min_length{0}, max_length{0};
     std::vector<std::string> var_names;
     std::unordered_map<std::string, VarInfo> var_info_map;
-    VarInfo info(const std::string& variableName) const { return var_info_map.at(variableName); }
+    VarInfo info(const std::string &variableName) const {
+      return var_info_map.at(variableName);
+    }
     void dumpVars() const;
   };
   std::vector<float> center_norm_pad(const rv::RVec<float>& input,

--- a/addons/ONNXRuntime/src/ONNXRuntime.cc
+++ b/addons/ONNXRuntime/src/ONNXRuntime.cc
@@ -71,7 +71,7 @@ ONNXRuntime::Tensor<T> ONNXRuntime::run(Tensor<T>& input,
     } else {
       input_dims = input_shapes[input_pos];
       // rely on the given input_shapes to set the batch size
-      if (input_dims[0] != batch_size)
+      if (static_cast<unsigned long long>(input_dims[0]) != batch_size)
         throw std::runtime_error("The first element of `input_shapes` (" + std::to_string(input_dims[0]) +
                                  ") does not match the given `batch_size` (" + std::to_string(batch_size) + ")");
     }

--- a/addons/TMVAHelper/src/TMVAHelper.cc
+++ b/addons/TMVAHelper/src/TMVAHelper.cc
@@ -1,5 +1,7 @@
 #include "TMVAHelper/TMVAHelper.h"
 
+#include <cstddef>
+
 #include "RVersion.h"
 
 tmva_helper_xgb::tmva_helper_xgb(const std::string &filename,
@@ -20,8 +22,8 @@ tmva_helper_xgb::tmva_helper_xgb(const std::string &filename,
 
 ROOT::VecOps::RVec<float>
 tmva_helper_xgb::operator()(const ROOT::VecOps::RVec<float> vars) {
-  auto const tbb_slot =
-      std::max(tbb::this_task_arena::current_thread_index(), 0);
+  const auto tbb_slot = static_cast<std::size_t>(
+      std::max(tbb::this_task_arena::current_thread_index(), 0));
   if (tbb_slot >= m_interpreters.size()) {
     throw std::runtime_error(
         "Not enough interpreters allocated for number of tbb threads");

--- a/analyzers/dataframe/FCCAnalyses/myUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/myUtils.h
@@ -51,8 +51,8 @@ namespace myUtils{
 
 
 
-  struct build_tau23pi {
-    build_tau23pi( float arg_masslow, float arg_masshigh, float arg_p, float arg_angle, bool arg_rho);
+  struct sel_tau23pi {
+    sel_tau23pi(float arg_masslow, float arg_masshigh, float arg_p, float arg_angle, bool arg_rho);
     float m_masslow=0.05;
     float m_masshigh=3.0;
     float m_p=1.;

--- a/analyzers/dataframe/FCCAnalyses/myUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/myUtils.h
@@ -49,10 +49,9 @@ namespace myUtils{
 							 ROOT::VecOps::RVec<int> pvindex);
   };
 
-
-
   struct sel_tau23pi {
-    sel_tau23pi(float arg_masslow, float arg_masshigh, float arg_p, float arg_angle, bool arg_rho);
+    sel_tau23pi(float arg_masslow, float arg_masshigh, float arg_p,
+                float arg_angle, bool arg_rho);
     float m_masslow=0.05;
     float m_masshigh=3.0;
     float m_p=1.;
@@ -61,8 +60,6 @@ namespace myUtils{
     ROOT::VecOps::RVec<FCCAnalysesComposite2> operator() (ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
 							  ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop);
   };
-
-
 
   struct sel_PV {
     sel_PV(bool arg_closest);

--- a/analyzers/dataframe/src/Algorithms.cc
+++ b/analyzers/dataframe/src/Algorithms.cc
@@ -1,5 +1,6 @@
 #include "FCCAnalyses/Algorithms.h"
 #include "FCCAnalyses/Utils.h"
+#include <cstddef>
 
 #include "Math/Minimizer.h"
 #include "Math/IFunction.h"
@@ -490,7 +491,7 @@ JetClustering::FCCAnalysesJet jets_TwoHemispheres::operator() (
  float pz_minus=0;
  float e_minus=0;
 
- for ( int i=0; i < RP_costheta.size(); i++) {
+ for ( std::size_t i=0; i < RP_costheta.size(); i++) {
      if ( RP_costheta[i] > 0 ) {
         constituents_JetPlus.push_back( i );
 	px_plus += RP_px[i];

--- a/analyzers/dataframe/src/Algorithms.cc
+++ b/analyzers/dataframe/src/Algorithms.cc
@@ -5,8 +5,10 @@
 #include "Math/IFunction.h"
 #include "Math/Factory.h"
 #include "Math/Functor.h"
+#include <array>
 #include <algorithm>
 #include <iostream>
+#include <vector>
 #include <numeric>
 
 #include "Math/IFunction.h"
@@ -197,13 +199,14 @@ ROOT::VecOps::RVec<float> Algorithms::calculate_thrust::operator()(
 
   // Array to store x, y, z and magnitude squared of the particles.
   // 0 -- magnitude squared, 1 -- x, 2 -- y, 3 -- z
-  float pArr[nParticles][4];
+  std::vector<std::array<float, 4>> pArr(nParticles);
   float pSum = 0.;
   for (size_t i = 0; i < nParticles; ++i) {
     pArr[i][1] = px[i];
     pArr[i][2] = py[i];
     pArr[i][3] = pz[i];
-    mag2(pArr[i]);
+    pArr[i][0] = pArr[i][1] * pArr[i][1] + pArr[i][2] * pArr[i][2] +
+                 pArr[i][3] * pArr[i][3];
     pSum += std::sqrt(pArr[i][0]);
   }
 
@@ -214,7 +217,7 @@ ROOT::VecOps::RVec<float> Algorithms::calculate_thrust::operator()(
   for (size_t i = 0; i < nParticles - 1; ++i) {
     for (size_t j = i + 1; j < nParticles; ++j) {
       float nRef[4];
-      cross(nRef, pArr[i], pArr[j]);
+      cross(nRef, pArr[i].data(), pArr[j].data());
       mag2(nRef);
       unit(nRef);
 
@@ -224,29 +227,29 @@ ROOT::VecOps::RVec<float> Algorithms::calculate_thrust::operator()(
           continue;
         }
 
-        if (dot(nRef, pArr[k]) > 0.) {
-          plus(pPart, pPart, pArr[k]);
+        if (dot(nRef, pArr[k].data()) > 0.) {
+          plus(pPart, pPart, pArr[k].data());
         } else {
-          minus(pPart, pPart, pArr[k]);
+          minus(pPart, pPart, pArr[k].data());
         }
       }
 
       float pFullArr[4][4];
       // pPart + pArr[i] + pArr[j]
-      plus(pFullArr[0], pPart, pArr[i]);
-      plus(pFullArr[0], pFullArr[0], pArr[j]);
+      plus(pFullArr[0], pPart, pArr[i].data());
+      plus(pFullArr[0], pFullArr[0], pArr[j].data());
 
       // pPart + pArr[i] - pArr[j]
-      plus(pFullArr[1], pPart, pArr[i]);
-      minus(pFullArr[1], pFullArr[1], pArr[j]);
+      plus(pFullArr[1], pPart, pArr[i].data());
+      minus(pFullArr[1], pFullArr[1], pArr[j].data());
 
       // pPart - pArr[i] + pArr[j]
-      minus(pFullArr[2], pPart, pArr[i]);
-      plus(pFullArr[2], pFullArr[2], pArr[j]);
+      minus(pFullArr[2], pPart, pArr[i].data());
+      plus(pFullArr[2], pFullArr[2], pArr[j].data());
 
       // pPart - pArr[i] - pArr[j]
-      minus(pFullArr[3], pPart, pArr[i]);
-      minus(pFullArr[3], pFullArr[3], pArr[j]);
+      minus(pFullArr[3], pPart, pArr[i].data());
+      minus(pFullArr[3], pFullArr[3], pArr[j].data());
 
       for (size_t k = 0; k < 4; ++k) {
         mag2(pFullArr[k]);

--- a/analyzers/dataframe/src/Algorithms.cc
+++ b/analyzers/dataframe/src/Algorithms.cc
@@ -2,15 +2,15 @@
 #include "FCCAnalyses/Utils.h"
 #include <cstddef>
 
-#include "Math/Minimizer.h"
-#include "Math/IFunction.h"
 #include "Math/Factory.h"
 #include "Math/Functor.h"
-#include <array>
+#include "Math/IFunction.h"
+#include "Math/Minimizer.h"
 #include <algorithm>
+#include <array>
 #include <iostream>
-#include <vector>
 #include <numeric>
+#include <vector>
 
 #include "Math/IFunction.h"
 #include "Math/Factory.h"
@@ -491,23 +491,21 @@ JetClustering::FCCAnalysesJet jets_TwoHemispheres::operator() (
  float pz_minus=0;
  float e_minus=0;
 
- for ( std::size_t i=0; i < RP_costheta.size(); i++) {
-     if ( RP_costheta[i] > 0 ) {
-        constituents_JetPlus.push_back( i );
-	px_plus += RP_px[i];
-	py_plus += RP_py[i];
-	pz_plus += RP_pz[i];
-	e_plus += RP_e[i];
-     }
-     else {
-	constituents_JetMimus.push_back( i );
-        px_minus += RP_px[i];
-        py_minus += RP_py[i];
-        pz_minus += RP_pz[i];
-        e_minus += RP_e[i];
-     }
+ for (std::size_t i = 0; i < RP_costheta.size(); i++) {
+   if (RP_costheta[i] > 0) {
+     constituents_JetPlus.push_back(i);
+     px_plus += RP_px[i];
+     py_plus += RP_py[i];
+     pz_plus += RP_pz[i];
+     e_plus += RP_e[i];
+   } else {
+     constituents_JetMimus.push_back(i);
+     px_minus += RP_px[i];
+     py_minus += RP_py[i];
+     pz_minus += RP_pz[i];
+     e_minus += RP_e[i];
+   }
  }
-
 
  float pt_plus = sqrt( pow( px_plus,2) + pow( py_plus,2) + pow( pz_plus, 2) ) ;
  float pt_minus = sqrt( pow( px_minus, 2) + pow( py_minus, 2) + pow( pz_minus, 2) ) ;

--- a/analyzers/dataframe/src/Analysis_FCChh.cc
+++ b/analyzers/dataframe/src/Analysis_FCChh.cc
@@ -487,8 +487,6 @@ int AnalysisFCChh::findTopDecayChannel(
       auto first_child_index = truth_part.daughters_begin;
       auto last_child_index = truth_part.daughters_end;
 
-      auto children_size = last_child_index - first_child_index;
-
       // skip intermediate tops that just have another top as children
       if (last_child_index - first_child_index != 2) {
         continue;
@@ -560,8 +558,6 @@ int AnalysisFCChh::findHiggsDecayChannel(
       // check what children the top has:
       auto first_child_index = truth_part.daughters_begin;
       auto last_child_index = truth_part.daughters_end;
-
-      auto children_size = last_child_index - first_child_index;
 
       // skip intermediate tops that just have another Higgs as children
       if (last_child_index - first_child_index != 2) {
@@ -860,7 +856,7 @@ AnalysisFCChh::getJet_tag(ROOT::VecOps::RVec<int> index,
 // return the list of c hadrons
 ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getChadron(
     ROOT::VecOps::RVec<edm4hep::MCParticleData> truth_particles,
-    ROOT::VecOps::RVec<podio::ObjectID> parent_ids) {
+    ROOT::VecOps::RVec<podio::ObjectID>) {
 
   ROOT::VecOps::RVec<edm4hep::MCParticleData> c_had_list;
   for (auto &truth_part : truth_particles) {
@@ -875,7 +871,7 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getChadron(
 // return the list of b hadrons
 ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getBhadron(
     ROOT::VecOps::RVec<edm4hep::MCParticleData> truth_particles,
-    ROOT::VecOps::RVec<podio::ObjectID> parent_ids) {
+    ROOT::VecOps::RVec<podio::ObjectID>) {
 
   ROOT::VecOps::RVec<edm4hep::MCParticleData> b_had_list;
   for (auto &truth_part : truth_particles) {
@@ -2481,12 +2477,11 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getLepsFromTau(
 
 ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTau(
     ROOT::VecOps::RVec<edm4hep::MCParticleData> truth_particles,
-    ROOT::VecOps::RVec<podio::ObjectID> daughter_ids,
+    ROOT::VecOps::RVec<podio::ObjectID>,
     ROOT::VecOps::RVec<podio::ObjectID> parent_ids, TString type) {
 
   ROOT::VecOps::RVec<edm4hep::MCParticleData> tau_list;
   for (auto &truth_part : truth_particles) {
-    bool flagchildren = false;
     if (isTau(truth_part)) {
 
       // check also if from Higgs to count only from Higgs ones
@@ -2905,7 +2900,7 @@ AnalysisFCChh::find_reco_matched(
 ROOT::VecOps::RVec<float> AnalysisFCChh::get_IP_delphes(
     ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> test_parts,
     ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> reco_parts_all,
-    float dR_min, float pT_min, bool exclude_light_leps) {
+  float dR_min, float pT_min, bool) {
 
   ROOT::VecOps::RVec<float> out_vector;
 
@@ -3322,7 +3317,6 @@ AnalysisFCChh::find_reco_matches_exclusive(
   }
 
   for (auto &truth_part : truth_parts) {
-    bool excludedMatch = false;
     ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> reco_match_vector =
         find_reco_matched_particle(truth_part, reco_particles, dR_thres);
     ROOT::VecOps::RVec<edm4hep::MCParticleData> mc_excluded_vector =

--- a/analyzers/dataframe/src/Analysis_FCChh.cc
+++ b/analyzers/dataframe/src/Analysis_FCChh.cc
@@ -1,4 +1,5 @@
 #include "FCCAnalyses/Analysis_FCChh.h"
+#include <cstddef>
 // #include "FCCAnalyses/lester_mt2_bisect.h"
 
 #include <iostream>
@@ -191,7 +192,7 @@ bool AnalysisFCChh::isFromHadron(
 
   // loop over all parents (usually onle 1, but sometimes more for reasons not
   // understood?):
-  for (int parent_i = first_parent_index; parent_i < last_parent_index;
+  for (unsigned int parent_i = first_parent_index; parent_i < last_parent_index;
        parent_i++) {
     // first get the index from the parent
     auto parent_MC_index = parent_ids.at(parent_i).index;
@@ -219,7 +220,7 @@ bool AnalysisFCChh::hasHiggsParent(
 
   // loop over all parents (usually onle 1, but sometimes more for reasons not
   // understood?):
-  for (int parent_i = first_parent_index; parent_i < last_parent_index;
+  for (unsigned int parent_i = first_parent_index; parent_i < last_parent_index;
        parent_i++) {
     // first get the index from the parent
     auto parent_MC_index = parent_ids.at(parent_i).index;
@@ -249,7 +250,7 @@ bool AnalysisFCChh::isFromHiggsDirect(
 
   // loop over all parents (usually only 1, but sometimes more for reasons not
   // understood?):
-  for (int parent_i = first_parent_index; parent_i < last_parent_index;
+  for (unsigned int parent_i = first_parent_index; parent_i < last_parent_index;
        parent_i++) {
     // first get the index from the parent
     auto parent_MC_index = parent_ids.at(parent_i).index;
@@ -278,7 +279,7 @@ bool AnalysisFCChh::isChildOfTauFromHiggs(
 
   // loop over all parents (usually onle 1, but sometimes more for reasons not
   // understood?):
-  for (int parent_i = first_parent_index; parent_i < last_parent_index;
+  for (unsigned int parent_i = first_parent_index; parent_i < last_parent_index;
        parent_i++) {
     // first get the index from the parent
     auto parent_MC_index = parent_ids.at(parent_i).index;
@@ -311,7 +312,7 @@ bool AnalysisFCChh::isChildOfZFromHiggs(
 
   // loop over all parents (usually onle 1, but sometimes more for reasons not
   // understood?):
-  for (int parent_i = first_parent_index; parent_i < last_parent_index;
+  for (unsigned int parent_i = first_parent_index; parent_i < last_parent_index;
        parent_i++) {
     // first get the index from the parent
     auto parent_MC_index = parent_ids.at(parent_i).index;
@@ -344,7 +345,7 @@ bool AnalysisFCChh::isChildOfWFromHiggs(
 
   // loop over all parents (usually only 1, but sometimes more for reasons not
   // understood?):
-  for (int parent_i = first_parent_index; parent_i < last_parent_index;
+  for (unsigned int parent_i = first_parent_index; parent_i < last_parent_index;
        parent_i++) {
     // first get the index from the parent
     auto parent_MC_index = parent_ids.at(parent_i).index;
@@ -2251,7 +2252,7 @@ AnalysisFCChh::get_immediate_children(
 
   // std::cout << "children size: " << children_size << std::endl;
 
-  for (int child_i = 0; child_i < children_size; child_i++) {
+  for (unsigned int child_i = 0; child_i < children_size; child_i++) {
     auto child_i_index = daughter_ids.at(first_child_index + child_i).index;
     auto child = truth_particles.at(child_i_index);
     // std::cout << "PDG ID of child number " << child_i << " : " << child.PDG
@@ -2500,7 +2501,7 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTau(
         std::cout << " found tau neither from Higgs or from Had" << std::endl;
         auto first_parent_index = truth_part.parents_begin;
         auto last_parent_index = truth_part.parents_end;
-        for (int parent_i = first_parent_index; parent_i < last_parent_index;
+        for (unsigned int parent_i = first_parent_index; parent_i < last_parent_index;
              parent_i++) {
           auto parent_MC_index = parent_ids.at(parent_i).index;
           auto parent = truth_particles.at(parent_MC_index);
@@ -2545,7 +2546,7 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTauLeps(
         std::cout << " found tau neither from Higgs or from Had" << std::endl;
         auto first_parent_index = truth_part.parents_begin;
         auto last_parent_index = truth_part.parents_end;
-        for (int parent_i = first_parent_index; parent_i < last_parent_index;
+        for (unsigned int parent_i = first_parent_index; parent_i < last_parent_index;
              parent_i++) {
           auto parent_MC_index = parent_ids.at(parent_i).index;
           auto parent = truth_particles.at(parent_MC_index);
@@ -2560,7 +2561,7 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTauLeps(
         auto last_child_index = truth_part.daughters_end;
         // auto child_1_MC_index = daughter_ids.at(first_child_index).index;
         // auto hild_2_MC_index = daughter_ids.at(last_child_index-1).index;
-        for (int child_i = first_child_index; child_i < last_child_index;
+        for (unsigned int child_i = first_child_index; child_i < last_child_index;
              child_i++) {
           auto child = truth_particles.at(daughter_ids.at(child_i).index);
           if (abs(child.PDG) == 15) {
@@ -2576,7 +2577,7 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTauLeps(
       // std::cout << " found tau with children" << std::endl;
       auto first_child_index = truth_part.daughters_begin;
       auto last_child_index = truth_part.daughters_end;
-      for (int ch_i = first_child_index; ch_i < last_child_index; ch_i++) {
+      for (unsigned int ch_i = first_child_index; ch_i < last_child_index; ch_i++) {
         auto ch = truth_particles.at(daughter_ids.at(ch_i).index);
         std::cout << "Child ID: " << ch.PDG << std::endl;
         if (isLep(ch)) {
@@ -2622,7 +2623,7 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTauHads(
         std::cout << " found tau neither from Higgs or from Had" << std::endl;
         auto first_parent_index = truth_part.parents_begin;
         auto last_parent_index = truth_part.parents_end;
-        for (int parent_i = first_parent_index; parent_i < last_parent_index;
+        for (unsigned int parent_i = first_parent_index; parent_i < last_parent_index;
              parent_i++) {
           auto parent_MC_index = parent_ids.at(parent_i).index;
           auto parent = truth_particles.at(parent_MC_index);
@@ -2637,7 +2638,7 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTauHads(
         auto last_child_index = truth_part.daughters_end;
         // auto child_1_MC_index = daughter_ids.at(first_child_index).index;
         // auto hild_2_MC_index = daughter_ids.at(last_child_index-1).index;
-        for (int child_i = first_child_index; child_i < last_child_index;
+        for (unsigned int child_i = first_child_index; child_i < last_child_index;
              child_i++) {
           auto child = truth_particles.at(daughter_ids.at(child_i).index);
           if (abs(child.PDG) == 15) {
@@ -2653,7 +2654,7 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTauHads(
       // std::cout << " found tau with children" << std::endl;
       auto first_child_index = truth_part.daughters_begin;
       auto last_child_index = truth_part.daughters_end;
-      for (int ch_i = first_child_index; ch_i < last_child_index; ch_i++) {
+      for (unsigned int ch_i = first_child_index; ch_i < last_child_index; ch_i++) {
         auto ch = truth_particles.at(daughter_ids.at(ch_i).index);
         std::cout << "Child ID: " << ch.PDG << std::endl;
         if (isHadron(ch)) {
@@ -3173,7 +3174,7 @@ ROOT::VecOps::RVec<int> AnalysisFCChh::find_reco_matched_index(
 
   TLorentzVector truth_part_tlv = getTLV_MC(truth_part_to_match);
 
-  for (int i = 0; i < check_reco_parts.size(); ++i) {
+  for (std::size_t i = 0; i < check_reco_parts.size(); ++i) {
 
     edm4hep::ReconstructedParticleData check_reco_part = check_reco_parts[i];
 

--- a/analyzers/dataframe/src/Analysis_FCChh.cc
+++ b/analyzers/dataframe/src/Analysis_FCChh.cc
@@ -2501,8 +2501,8 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTau(
         std::cout << " found tau neither from Higgs or from Had" << std::endl;
         auto first_parent_index = truth_part.parents_begin;
         auto last_parent_index = truth_part.parents_end;
-        for (unsigned int parent_i = first_parent_index; parent_i < last_parent_index;
-             parent_i++) {
+        for (unsigned int parent_i = first_parent_index;
+             parent_i < last_parent_index; parent_i++) {
           auto parent_MC_index = parent_ids.at(parent_i).index;
           auto parent = truth_particles.at(parent_MC_index);
           std::cout << "Parent PDG:" << std::endl;
@@ -2546,8 +2546,8 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTauLeps(
         std::cout << " found tau neither from Higgs or from Had" << std::endl;
         auto first_parent_index = truth_part.parents_begin;
         auto last_parent_index = truth_part.parents_end;
-        for (unsigned int parent_i = first_parent_index; parent_i < last_parent_index;
-             parent_i++) {
+        for (unsigned int parent_i = first_parent_index;
+             parent_i < last_parent_index; parent_i++) {
           auto parent_MC_index = parent_ids.at(parent_i).index;
           auto parent = truth_particles.at(parent_MC_index);
           std::cout << "Parent PDG:" << std::endl;
@@ -2561,8 +2561,8 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTauLeps(
         auto last_child_index = truth_part.daughters_end;
         // auto child_1_MC_index = daughter_ids.at(first_child_index).index;
         // auto hild_2_MC_index = daughter_ids.at(last_child_index-1).index;
-        for (unsigned int child_i = first_child_index; child_i < last_child_index;
-             child_i++) {
+        for (unsigned int child_i = first_child_index;
+             child_i < last_child_index; child_i++) {
           auto child = truth_particles.at(daughter_ids.at(child_i).index);
           if (abs(child.PDG) == 15) {
             isItself = true;
@@ -2577,7 +2577,8 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTauLeps(
       // std::cout << " found tau with children" << std::endl;
       auto first_child_index = truth_part.daughters_begin;
       auto last_child_index = truth_part.daughters_end;
-      for (unsigned int ch_i = first_child_index; ch_i < last_child_index; ch_i++) {
+      for (unsigned int ch_i = first_child_index; ch_i < last_child_index;
+           ch_i++) {
         auto ch = truth_particles.at(daughter_ids.at(ch_i).index);
         std::cout << "Child ID: " << ch.PDG << std::endl;
         if (isLep(ch)) {
@@ -2623,8 +2624,8 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTauHads(
         std::cout << " found tau neither from Higgs or from Had" << std::endl;
         auto first_parent_index = truth_part.parents_begin;
         auto last_parent_index = truth_part.parents_end;
-        for (unsigned int parent_i = first_parent_index; parent_i < last_parent_index;
-             parent_i++) {
+        for (unsigned int parent_i = first_parent_index;
+             parent_i < last_parent_index; parent_i++) {
           auto parent_MC_index = parent_ids.at(parent_i).index;
           auto parent = truth_particles.at(parent_MC_index);
           std::cout << "Parent PDG:" << std::endl;
@@ -2638,8 +2639,8 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTauHads(
         auto last_child_index = truth_part.daughters_end;
         // auto child_1_MC_index = daughter_ids.at(first_child_index).index;
         // auto hild_2_MC_index = daughter_ids.at(last_child_index-1).index;
-        for (unsigned int child_i = first_child_index; child_i < last_child_index;
-             child_i++) {
+        for (unsigned int child_i = first_child_index;
+             child_i < last_child_index; child_i++) {
           auto child = truth_particles.at(daughter_ids.at(child_i).index);
           if (abs(child.PDG) == 15) {
             isItself = true;
@@ -2654,7 +2655,8 @@ ROOT::VecOps::RVec<edm4hep::MCParticleData> AnalysisFCChh::getTruthTauHads(
       // std::cout << " found tau with children" << std::endl;
       auto first_child_index = truth_part.daughters_begin;
       auto last_child_index = truth_part.daughters_end;
-      for (unsigned int ch_i = first_child_index; ch_i < last_child_index; ch_i++) {
+      for (unsigned int ch_i = first_child_index; ch_i < last_child_index;
+           ch_i++) {
         auto ch = truth_particles.at(daughter_ids.at(ch_i).index);
         std::cout << "Child ID: " << ch.PDG << std::endl;
         if (isHadron(ch)) {
@@ -2901,7 +2903,7 @@ AnalysisFCChh::find_reco_matched(
 ROOT::VecOps::RVec<float> AnalysisFCChh::get_IP_delphes(
     ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> test_parts,
     ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> reco_parts_all,
-  float dR_min, float pT_min, bool) {
+    float dR_min, float pT_min, bool) {
 
   ROOT::VecOps::RVec<float> out_vector;
 

--- a/analyzers/dataframe/src/EventFilter.cc
+++ b/analyzers/dataframe/src/EventFilter.cc
@@ -4,7 +4,7 @@
 
 namespace FCCAnalyses ::EventFilter {
 // ----------------------------------------------------------------------------
-stride::stride(const ULong64_t stride) : m_stride(stride) {}
+stride::stride(const ULong64_t value) : m_stride(value) {}
 
 bool
 stride::operator()(const ULong64_t rdfEntry) {

--- a/analyzers/dataframe/src/JetClusteringUtils.cc
+++ b/analyzers/dataframe/src/JetClusteringUtils.cc
@@ -1,6 +1,8 @@
 #include "FCCAnalyses/JetClusteringUtils.h"
 #include "TLorentzVector.h"
 
+#include <cstddef>
+
 namespace FCCAnalyses {
 namespace JetClusteringUtils {
 
@@ -16,14 +18,16 @@ get_constituents(const JetClustering::FCCAnalysesJet &jets) {
 
 float get_exclusive_dmerge(const JetClustering::FCCAnalysesJet &in, int n) {
   float d = -1;
-  if (n >= 1 && n <= Nmax_dmerge && in.exclusive_dmerge.size() > n - 1)
+  if (n >= 1 && n <= Nmax_dmerge &&
+      static_cast<std::size_t>(n) <= in.exclusive_dmerge.size())
     d = in.exclusive_dmerge[n - 1];
   return d;
 }
 
 float get_exclusive_dmerge_max(const JetClustering::FCCAnalysesJet &in, int n) {
   float d = -1;
-  if (n >= 1 && n <= Nmax_dmerge && in.exclusive_dmerge.size() > n - 1)
+  if (n >= 1 && n <= Nmax_dmerge &&
+      static_cast<std::size_t>(n) <= in.exclusive_dmerge_max.size())
     d = in.exclusive_dmerge_max[n - 1];
   return d;
 }
@@ -258,7 +262,7 @@ std::vector<float> exclusive_dmerge(fastjet::ClusterSequence &cs,
 }
 
 bool check(unsigned int n, int exclusive, float cut) {
-  if (exclusive > 0 && n < int(cut))
+  if (exclusive > 0 && cut > 0 && n < static_cast<unsigned int>(cut))
     return false;
   return true;
 }

--- a/analyzers/dataframe/src/JetConstituentsUtils.cc
+++ b/analyzers/dataframe/src/JetConstituentsUtils.cc
@@ -1,5 +1,6 @@
 #include "FCCAnalyses/JetConstituentsUtils.h"
 
+#include <cstddef>
 // EDM4hep
 #include "edm4hep/EDM4hepVersion.h"
 // FastJet
@@ -166,7 +167,7 @@ namespace FCCAnalyses
         nconst.push_back(jet.particles_end - jet.particles_begin);
       }
       auto indices = ROOT::VecOps::Argsort(nconst);
-      for (int index = 0; index < jets.size(); ++index)
+      for (std::size_t index = 0; index < jets.size(); ++index)
       {
         out.push_back(jets.at(indices.at(indices.size() - 1 - index)));
       }
@@ -182,7 +183,7 @@ namespace FCCAnalyses
         energy.push_back(jet.energy);
       }
       auto indices = ROOT::VecOps::Argsort(energy);
-      for (int index = 0; index < jets.size(); ++index)
+      for (std::size_t index = 0; index < jets.size(); ++index)
       {
         out.push_back(jets.at(indices.at(indices.size() - 1 - index)));
       }
@@ -400,11 +401,11 @@ namespace FCCAnalyses
       rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
       rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
 
-      for (int i = 0; i < jets.size(); ++i)
+      for (std::size_t i = 0; i < jets.size(); ++i)
       {
         TVector2 p(jets[i].momentum.x, jets[i].momentum.y);
         FCCAnalysesJetConstituentsData cprojs;
-        for (int j = 0; j < jcs[i].size(); ++j)
+        for (std::size_t j = 0; j < jcs[i].size(); ++j)
         {
           if (D0.at(i).at(j) != -9)
           {
@@ -429,11 +430,11 @@ namespace FCCAnalyses
       rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
       rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
 
-      for (int i = 0; i < jets.size(); ++i)
+      for (std::size_t i = 0; i < jets.size(); ++i)
       {
         TVector2 p(jets[i].px(), jets[i].py());
         FCCAnalysesJetConstituentsData cprojs;
-        for (int j = 0; j < jcs[i].size(); ++j)
+        for (std::size_t j = 0; j < jcs[i].size(); ++j)
         {
           if (D0.at(i).at(j) != -9)
           {
@@ -457,11 +458,11 @@ namespace FCCAnalyses
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
 
-      for (int i = 0; i < jets.size(); ++i)
+      for (std::size_t i = 0; i < jets.size(); ++i)
       {
         TVector2 p(jets[i].px(), jets[i].py());
         FCCAnalysesJetConstituentsData cprojs;
-        for (int j = 0; j < D0[i].size(); ++j)
+        for (std::size_t j = 0; j < D0[i].size(); ++j)
         {
           if (D0.at(i).at(j) != -9)
           {
@@ -484,10 +485,10 @@ namespace FCCAnalyses
                                                           const rv::RVec<FCCAnalysesJetConstituentsData> &err2_D0)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (int i = 0; i < Sip2dVals.size(); ++i)
+      for (std::size_t i = 0; i < Sip2dVals.size(); ++i)
       {
         FCCAnalysesJetConstituentsData s;
-        for (int j = 0; j < Sip2dVals.at(i).size(); ++j)
+        for (std::size_t j = 0; j < Sip2dVals.at(i).size(); ++j)
         {
           if (err2_D0.at(i).at(j) > 0)
           {
@@ -512,11 +513,11 @@ namespace FCCAnalyses
       rv::RVec<FCCAnalysesJetConstituentsData> Z0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Z0);
       rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
 
-      for (int i = 0; i < jets.size(); ++i)
+      for (std::size_t i = 0; i < jets.size(); ++i)
       {
         TVector3 p(jets[i].momentum.x, jets[i].momentum.y, jets[i].momentum.z);
         FCCAnalysesJetConstituentsData cprojs;
-        for (int j = 0; j < jcs[i].size(); ++j)
+        for (std::size_t j = 0; j < jcs[i].size(); ++j)
         {
           if (D0.at(i).at(j) != -9)
           {
@@ -542,11 +543,11 @@ namespace FCCAnalyses
       rv::RVec<FCCAnalysesJetConstituentsData> Z0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Z0);
       rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
 
-      for (int i = 0; i < jets.size(); ++i)
+      for (std::size_t i = 0; i < jets.size(); ++i)
       {
         TVector3 p(jets[i].px(), jets[i].py(), jets[i].pz());
         FCCAnalysesJetConstituentsData cprojs;
-        for (int j = 0; j < jcs[i].size(); ++j)
+        for (std::size_t j = 0; j < jcs[i].size(); ++j)
         {
           if (D0.at(i).at(j) != -9)
           {
@@ -571,11 +572,11 @@ namespace FCCAnalyses
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
 
-      for (int i = 0; i < jets.size(); ++i)
+      for (std::size_t i = 0; i < jets.size(); ++i)
       {
         TVector3 p(jets[i].px(), jets[i].py(), jets[i].pz());
         FCCAnalysesJetConstituentsData cprojs;
-        for (int j = 0; j < D0[i].size(); ++j)
+        for (std::size_t j = 0; j < D0[i].size(); ++j)
         {
           if (D0.at(i).at(j) != -9)
           {
@@ -597,10 +598,10 @@ namespace FCCAnalyses
                                                           const rv::RVec<FCCAnalysesJetConstituentsData> &err2_Z0)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (int i = 0; i < Sip3dVals.size(); ++i)
+      for (std::size_t i = 0; i < Sip3dVals.size(); ++i)
       {
         FCCAnalysesJetConstituentsData s;
-        for (int j = 0; j < Sip3dVals.at(i).size(); ++j)
+        for (std::size_t j = 0; j < Sip3dVals.at(i).size(); ++j)
         {
           if (err2_D0.at(i).at(j) > 0.)
           {
@@ -624,12 +625,12 @@ namespace FCCAnalyses
       rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
       rv::RVec<FCCAnalysesJetConstituentsData> Z0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Z0);
       rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
-      for (int i = 0; i < jets.size(); ++i)
+      for (std::size_t i = 0; i < jets.size(); ++i)
       {
         FCCAnalysesJetConstituentsData tmp;
         TVector3 p_jet(jets[i].momentum.x, jets[i].momentum.y, jets[i].momentum.z);
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (int j = 0; j < ct.size(); ++j)
+        for (std::size_t j = 0; j < ct.size(); ++j)
         {
           if (D0.at(i).at(j) != -9)
           {
@@ -657,12 +658,12 @@ namespace FCCAnalyses
       rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
       rv::RVec<FCCAnalysesJetConstituentsData> Z0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Z0);
       rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
-      for (int i = 0; i < jets.size(); ++i)
+      for (std::size_t i = 0; i < jets.size(); ++i)
       {
         FCCAnalysesJetConstituentsData tmp;
         TVector3 p_jet(jets[i].px(), jets[i].py(), jets[i].pz());
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (int j = 0; j < ct.size(); ++j)
+        for (std::size_t j = 0; j < ct.size(); ++j)
         {
           if (D0.at(i).at(j) != -9)
           {
@@ -691,12 +692,12 @@ namespace FCCAnalyses
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
 
-      for (int i = 0; i < jets.size(); ++i)
+      for (std::size_t i = 0; i < jets.size(); ++i)
       {
         FCCAnalysesJetConstituentsData tmp;
         TVector3 p_jet(jets[i].px(), jets[i].py(), jets[i].pz());
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (int j = 0; j < ct.size(); ++j)
+        for (std::size_t j = 0; j < ct.size(); ++j)
         {
           if (D0.at(i).at(j) != -9)
           {
@@ -721,10 +722,10 @@ namespace FCCAnalyses
                                                             const rv::RVec<FCCAnalysesJetConstituentsData> &err2_Z0)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (int i = 0; i < JetDistVal.size(); ++i)
+      for (std::size_t i = 0; i < JetDistVal.size(); ++i)
       {
         FCCAnalysesJetConstituentsData tmp;
-        for (int j = 0; j < JetDistVal.at(i).size(); ++j)
+        for (std::size_t j = 0; j < JetDistVal.at(i).size(); ++j)
         {
           if (err2_D0.at(i).at(j) > 0)
           {
@@ -765,11 +766,11 @@ namespace FCCAnalyses
     )
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (int i = 0; i < jcs.size(); ++i)
+      for (std::size_t i = 0; i < jcs.size(); ++i)
       {
         FCCAnalysesJetConstituents ct = jcs.at(i);
         FCCAnalysesJetConstituentsData tmp;
-        for (int j = 0; j < ct.size(); ++j)
+        for (std::size_t j = 0; j < ct.size(); ++j)
         {
           if (ct.at(j).clusters_begin < nhdata.size() + gammadata.size())
           {
@@ -1086,11 +1087,11 @@ namespace FCCAnalyses
     rv::RVec<FCCAnalysesJetConstituentsData> get_isEl(const rv::RVec<FCCAnalysesJetConstituents> &jcs)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (int i = 0; i < jcs.size(); ++i)
+      for (std::size_t i = 0; i < jcs.size(); ++i)
       {
         FCCAnalysesJetConstituentsData is_El;
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (int j = 0; j < ct.size(); ++j)
+        for (std::size_t j = 0; j < ct.size(); ++j)
         {
           if (std::abs(ct.at(j).charge) > 0 and std::abs(ct.at(j).mass - 0.000510999) < 1.e-05)
           {
@@ -1110,11 +1111,11 @@ namespace FCCAnalyses
     rv::RVec<FCCAnalysesJetConstituentsData> get_isMu(const rv::RVec<FCCAnalysesJetConstituents> &jcs)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (int i = 0; i < jcs.size(); ++i)
+      for (std::size_t i = 0; i < jcs.size(); ++i)
       {
         FCCAnalysesJetConstituentsData is_Mu;
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (int j = 0; j < ct.size(); ++j)
+        for (std::size_t j = 0; j < ct.size(); ++j)
         {
           if (std::abs(ct.at(j).charge) > 0 and std::abs(ct.at(j).mass - 0.105658) < 1.e-03)
           {
@@ -1134,11 +1135,11 @@ namespace FCCAnalyses
     rv::RVec<FCCAnalysesJetConstituentsData> get_isChargedHad(const rv::RVec<FCCAnalysesJetConstituents> &jcs)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (int i = 0; i < jcs.size(); ++i)
+      for (std::size_t i = 0; i < jcs.size(); ++i)
       {
         FCCAnalysesJetConstituentsData is_ChargedHad;
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (int j = 0; j < ct.size(); ++j)
+        for (std::size_t j = 0; j < ct.size(); ++j)
         {
           if (std::abs(ct.at(j).charge) > 0 and std::abs(ct.at(j).mass - 0.13957) < 1.e-03)
           {
@@ -1158,11 +1159,11 @@ namespace FCCAnalyses
     rv::RVec<FCCAnalysesJetConstituentsData> get_isNeutralHad(const rv::RVec<FCCAnalysesJetConstituents> &jcs)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (int i = 0; i < jcs.size(); ++i)
+      for (std::size_t i = 0; i < jcs.size(); ++i)
       {
         FCCAnalysesJetConstituentsData is_NeutralHad;
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (int j = 0; j < ct.size(); ++j)
+        for (std::size_t j = 0; j < ct.size(); ++j)
         {
 #if edm4hep_VERSION > EDM4HEP_VERSION(0, 10, 5)
           if (ct.at(j).PDG == 130)
@@ -1183,11 +1184,11 @@ namespace FCCAnalyses
     rv::RVec<FCCAnalysesJetConstituentsData> get_isGamma(const rv::RVec<FCCAnalysesJetConstituents> &jcs)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (int i = 0; i < jcs.size(); ++i)
+      for (std::size_t i = 0; i < jcs.size(); ++i)
       {
         FCCAnalysesJetConstituentsData is_NeutralHad;
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (int j = 0; j < ct.size(); ++j)
+        for (std::size_t j = 0; j < ct.size(); ++j)
         {
 #if edm4hep_VERSION > EDM4HEP_VERSION(0, 10, 5)
           if (ct.at(j).PDG == 22)
@@ -1214,7 +1215,7 @@ namespace FCCAnalyses
     rv::RVec<int> count_consts(rv::RVec<FCCAnalysesJetConstituents> jets)
     {
       rv::RVec<int> out;
-      for (int i = 0; i < jets.size(); ++i)
+      for (std::size_t i = 0; i < jets.size(); ++i)
       {
         out.push_back(jets.at(i).size());
       }
@@ -1224,11 +1225,11 @@ namespace FCCAnalyses
     rv::RVec<int> count_type(const rv::RVec<FCCAnalysesJetConstituentsData> &isType)
     {
       rv::RVec<int> out;
-      for (int i = 0; i < isType.size(); ++i)
+      for (std::size_t i = 0; i < isType.size(); ++i)
       {
         int count = 0;
         rv::RVec<float> istype = isType.at(i);
-        for (int j = 0; j < istype.size(); ++j)
+        for (std::size_t j = 0; j < istype.size(); ++j)
         {
           if ((int)(istype.at(j)) == 1)
             count++;
@@ -1254,7 +1255,7 @@ namespace FCCAnalyses
     rv::RVec<TLorentzVector> sum_tlv_constituents(const rv::RVec<FCCAnalysesJetConstituents> &jets)
     {
       rv::RVec<TLorentzVector> out;
-      for (int i = 0; i < jets.size(); ++i)
+      for (std::size_t i = 0; i < jets.size(); ++i)
       {
         TLorentzVector sum_tlv; // initialized by (0., 0., 0., 0.)
         FCCAnalysesJetConstituents jcs = jets.at(i);
@@ -1291,11 +1292,11 @@ namespace FCCAnalyses
       if(AllJets.size() < 2) return InvariantMasses;
 
       // For each jet, take its invariant mass with the remaining jets. Stop at last jet.
-      for(int i = 0; i < AllJets.size()-1; ++i) {
+      for(std::size_t i = 0; i + 1 < AllJets.size(); ++i) {
 
         tlv1 = AllJets.at(i); 
 
-        for(int j=i+1; j < AllJets.size(); ++j){ // go until end
+        for(std::size_t j=i+1; j < AllJets.size(); ++j){ // go until end
           tlv2 = AllJets.at(j);
           E = tlv1.E() + tlv2.E();
           px = tlv1.Px() + tlv2.Px();
@@ -1314,7 +1315,7 @@ namespace FCCAnalyses
     rv::RVec<double> compute_residue_energy(const rv::RVec<TLorentzVector>& tlv_jet, const rv::RVec<TLorentzVector>& sum_tlv_jcs) {
     
       rv::RVec<double> out;
-      for (int i = 0; i < tlv_jet.size(); ++i)
+      for (std::size_t i = 0; i < tlv_jet.size(); ++i)
       {
         float de = (sum_tlv_jcs.at(i).E() - tlv_jet.at(i).E()) / tlv_jet.at(i).E();
         out.push_back(de);
@@ -1325,7 +1326,7 @@ namespace FCCAnalyses
     rv::RVec<double> compute_residue_px(const rv::RVec<TLorentzVector> &tlv_jet, const rv::RVec<TLorentzVector> &sum_tlv_jcs)
     {
       rv::RVec<double> out;
-      for (int i = 0; i < tlv_jet.size(); ++i)
+      for (std::size_t i = 0; i < tlv_jet.size(); ++i)
       {
         float dpx = (sum_tlv_jcs.at(i).Px() - tlv_jet.at(i).Px()) / tlv_jet.at(i).Px();
         out.push_back(dpx);
@@ -1336,7 +1337,7 @@ namespace FCCAnalyses
     rv::RVec<double> compute_residue_py(const rv::RVec<TLorentzVector> &tlv_jet, const rv::RVec<TLorentzVector> &sum_tlv_jcs)
     {
       rv::RVec<double> out;
-      for (int i = 0; i < tlv_jet.size(); ++i)
+      for (std::size_t i = 0; i < tlv_jet.size(); ++i)
       {
         float dpy = (sum_tlv_jcs.at(i).Py() - tlv_jet.at(i).Py()) / tlv_jet.at(i).Py();
         out.push_back(dpy);
@@ -1347,7 +1348,7 @@ namespace FCCAnalyses
     rv::RVec<double> compute_residue_pz(const rv::RVec<TLorentzVector> &tlv_jet, const rv::RVec<TLorentzVector> &sum_tlv_jcs)
     {
       rv::RVec<double> out;
-      for (int i = 0; i < tlv_jet.size(); ++i)
+      for (std::size_t i = 0; i < tlv_jet.size(); ++i)
       {
         float dpz = (sum_tlv_jcs.at(i).Pz() - tlv_jet.at(i).Pz()) / tlv_jet.at(i).Pz();
         out.push_back(dpz);
@@ -1358,7 +1359,7 @@ namespace FCCAnalyses
     rv::RVec<double> compute_residue_pt(const rv::RVec<TLorentzVector> &tlv_jet, const rv::RVec<TLorentzVector> &sum_tlv_jcs)
     {
       rv::RVec<double> out;
-      for (int i = 0; i < tlv_jet.size(); ++i)
+      for (std::size_t i = 0; i < tlv_jet.size(); ++i)
       {
         double pt_jet = std::sqrt(tlv_jet.at(i).Px() * tlv_jet.at(i).Px() + tlv_jet.at(i).Py() * tlv_jet.at(i).Py());
         double pt_jcs = std::sqrt(sum_tlv_jcs.at(i).Px() * sum_tlv_jcs.at(i).Px() + sum_tlv_jcs.at(i).Py() * sum_tlv_jcs.at(i).Py());
@@ -1371,7 +1372,7 @@ namespace FCCAnalyses
     rv::RVec<double> compute_residue_phi(const rv::RVec<TLorentzVector> &tlv_jet, const rv::RVec<TLorentzVector> &sum_tlv_jcs)
     {
       rv::RVec<double> out;
-      for (int i = 0; i < tlv_jet.size(); ++i)
+      for (std::size_t i = 0; i < tlv_jet.size(); ++i)
       {
         double phi_jet = tlv_jet.at(i).Phi();
         double phi_jcs = sum_tlv_jcs.at(i).Phi();
@@ -1384,7 +1385,7 @@ namespace FCCAnalyses
     rv::RVec<double> compute_residue_theta(const rv::RVec<TLorentzVector> &tlv_jet, const rv::RVec<TLorentzVector> &sum_tlv_jcs)
     {
       rv::RVec<double> out;
-      for (int i = 0; i < tlv_jet.size(); ++i)
+      for (std::size_t i = 0; i < tlv_jet.size(); ++i)
       {
         double theta_jet = tlv_jet.at(i).Theta();
         double theta_jcs = sum_tlv_jcs.at(i).Theta();

--- a/analyzers/dataframe/src/JetConstituentsUtils.cc
+++ b/analyzers/dataframe/src/JetConstituentsUtils.cc
@@ -35,7 +35,6 @@ namespace FCCAnalyses
         for (auto it = jet.particles_begin; it < jet.particles_end; ++it)
         {
           jc.emplace_back(rps.at(it));
-
         }
       }
       return jcs;
@@ -167,8 +166,7 @@ namespace FCCAnalyses
         nconst.push_back(jet.particles_end - jet.particles_begin);
       }
       auto indices = ROOT::VecOps::Argsort(nconst);
-      for (std::size_t index = 0; index < jets.size(); ++index)
-      {
+      for (std::size_t index = 0; index < jets.size(); ++index) {
         out.push_back(jets.at(indices.at(indices.size() - 1 - index)));
       }
       return out;
@@ -183,8 +181,7 @@ namespace FCCAnalyses
         energy.push_back(jet.energy);
       }
       auto indices = ROOT::VecOps::Argsort(energy);
-      for (std::size_t index = 0; index < jets.size(); ++index)
-      {
+      for (std::size_t index = 0; index < jets.size(); ++index) {
         out.push_back(jets.at(indices.at(indices.size() - 1 - index)));
       }
       return out;
@@ -401,12 +398,10 @@ namespace FCCAnalyses
       rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
       rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
 
-      for (std::size_t i = 0; i < jets.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jets.size(); ++i) {
         TVector2 p(jets[i].momentum.x, jets[i].momentum.y);
         FCCAnalysesJetConstituentsData cprojs;
-        for (std::size_t j = 0; j < jcs[i].size(); ++j)
-        {
+        for (std::size_t j = 0; j < jcs[i].size(); ++j) {
           if (D0.at(i).at(j) != -9)
           {
             TVector2 d0(-D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)), D0.at(i).at(j) * TMath::Cos(phi0.at(i).at(j)));
@@ -430,12 +425,10 @@ namespace FCCAnalyses
       rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
       rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
 
-      for (std::size_t i = 0; i < jets.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jets.size(); ++i) {
         TVector2 p(jets[i].px(), jets[i].py());
         FCCAnalysesJetConstituentsData cprojs;
-        for (std::size_t j = 0; j < jcs[i].size(); ++j)
-        {
+        for (std::size_t j = 0; j < jcs[i].size(); ++j) {
           if (D0.at(i).at(j) != -9)
           {
             TVector2 d0(-D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)), D0.at(i).at(j) * TMath::Cos(phi0.at(i).at(j)));
@@ -451,19 +444,17 @@ namespace FCCAnalyses
       return out;
     }
 
-    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dVal_clusterV(const rv::RVec<fastjet::PseudoJet> &jets,
-                                                                   const rv::RVec<FCCAnalysesJetConstituentsData> &D0,
-                                                                   const rv::RVec<FCCAnalysesJetConstituentsData> &phi0,
-                                                                   const float)
-    {
+    rv::RVec<FCCAnalysesJetConstituentsData>
+    get_Sip2dVal_clusterV(const rv::RVec<fastjet::PseudoJet> &jets,
+                          const rv::RVec<FCCAnalysesJetConstituentsData> &D0,
+                          const rv::RVec<FCCAnalysesJetConstituentsData> &phi0,
+                          const float) {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
 
-      for (std::size_t i = 0; i < jets.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jets.size(); ++i) {
         TVector2 p(jets[i].px(), jets[i].py());
         FCCAnalysesJetConstituentsData cprojs;
-        for (std::size_t j = 0; j < D0[i].size(); ++j)
-        {
+        for (std::size_t j = 0; j < D0[i].size(); ++j) {
           if (D0.at(i).at(j) != -9)
           {
             TVector2 d0(-D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)), D0.at(i).at(j) * TMath::Cos(phi0.at(i).at(j)));
@@ -485,11 +476,9 @@ namespace FCCAnalyses
                                                           const rv::RVec<FCCAnalysesJetConstituentsData> &err2_D0)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (std::size_t i = 0; i < Sip2dVals.size(); ++i)
-      {
+      for (std::size_t i = 0; i < Sip2dVals.size(); ++i) {
         FCCAnalysesJetConstituentsData s;
-        for (std::size_t j = 0; j < Sip2dVals.at(i).size(); ++j)
-        {
+        for (std::size_t j = 0; j < Sip2dVals.at(i).size(); ++j) {
           if (err2_D0.at(i).at(j) > 0)
           {
             s.push_back(Sip2dVals.at(i).at(j) / std::sqrt(err2_D0.at(i).at(j)));
@@ -513,12 +502,10 @@ namespace FCCAnalyses
       rv::RVec<FCCAnalysesJetConstituentsData> Z0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Z0);
       rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
 
-      for (std::size_t i = 0; i < jets.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jets.size(); ++i) {
         TVector3 p(jets[i].momentum.x, jets[i].momentum.y, jets[i].momentum.z);
         FCCAnalysesJetConstituentsData cprojs;
-        for (std::size_t j = 0; j < jcs[i].size(); ++j)
-        {
+        for (std::size_t j = 0; j < jcs[i].size(); ++j) {
           if (D0.at(i).at(j) != -9)
           {
             TVector3 d(-D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)), D0.at(i).at(j) * TMath::Cos(phi0.at(i).at(j)), Z0.at(i).at(j));
@@ -543,12 +530,10 @@ namespace FCCAnalyses
       rv::RVec<FCCAnalysesJetConstituentsData> Z0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Z0);
       rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
 
-      for (std::size_t i = 0; i < jets.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jets.size(); ++i) {
         TVector3 p(jets[i].px(), jets[i].py(), jets[i].pz());
         FCCAnalysesJetConstituentsData cprojs;
-        for (std::size_t j = 0; j < jcs[i].size(); ++j)
-        {
+        for (std::size_t j = 0; j < jcs[i].size(); ++j) {
           if (D0.at(i).at(j) != -9)
           {
             TVector3 d(-D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)), D0.at(i).at(j) * TMath::Cos(phi0.at(i).at(j)), Z0.at(i).at(j));
@@ -564,20 +549,18 @@ namespace FCCAnalyses
       return out;
     }
 
-    rv::RVec<FCCAnalysesJetConstituentsData> get_Sip3dVal_clusterV(const rv::RVec<fastjet::PseudoJet> &jets,
-                                                                   const rv::RVec<FCCAnalysesJetConstituentsData> &D0,
-                                                                   const rv::RVec<FCCAnalysesJetConstituentsData> &Z0,
-                                                                   const rv::RVec<FCCAnalysesJetConstituentsData> &phi0,
-                                                                   const float)
-    {
+    rv::RVec<FCCAnalysesJetConstituentsData>
+    get_Sip3dVal_clusterV(const rv::RVec<fastjet::PseudoJet> &jets,
+                          const rv::RVec<FCCAnalysesJetConstituentsData> &D0,
+                          const rv::RVec<FCCAnalysesJetConstituentsData> &Z0,
+                          const rv::RVec<FCCAnalysesJetConstituentsData> &phi0,
+                          const float) {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
 
-      for (std::size_t i = 0; i < jets.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jets.size(); ++i) {
         TVector3 p(jets[i].px(), jets[i].py(), jets[i].pz());
         FCCAnalysesJetConstituentsData cprojs;
-        for (std::size_t j = 0; j < D0[i].size(); ++j)
-        {
+        for (std::size_t j = 0; j < D0[i].size(); ++j) {
           if (D0.at(i).at(j) != -9)
           {
             TVector3 d(-D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)), D0.at(i).at(j) * TMath::Cos(phi0.at(i).at(j)), Z0.at(i).at(j));
@@ -598,11 +581,9 @@ namespace FCCAnalyses
                                                           const rv::RVec<FCCAnalysesJetConstituentsData> &err2_Z0)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (std::size_t i = 0; i < Sip3dVals.size(); ++i)
-      {
+      for (std::size_t i = 0; i < Sip3dVals.size(); ++i) {
         FCCAnalysesJetConstituentsData s;
-        for (std::size_t j = 0; j < Sip3dVals.at(i).size(); ++j)
-        {
+        for (std::size_t j = 0; j < Sip3dVals.at(i).size(); ++j) {
           if (err2_D0.at(i).at(j) > 0.)
           {
             s.push_back(Sip3dVals.at(i).at(j) / sqrt(err2_D0.at(i).at(j) + err2_Z0.at(i).at(j)));
@@ -625,13 +606,11 @@ namespace FCCAnalyses
       rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
       rv::RVec<FCCAnalysesJetConstituentsData> Z0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Z0);
       rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
-      for (std::size_t i = 0; i < jets.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jets.size(); ++i) {
         FCCAnalysesJetConstituentsData tmp;
         TVector3 p_jet(jets[i].momentum.x, jets[i].momentum.y, jets[i].momentum.z);
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (std::size_t j = 0; j < ct.size(); ++j)
-        {
+        for (std::size_t j = 0; j < ct.size(); ++j) {
           if (D0.at(i).at(j) != -9)
           {
             TVector3 d(-D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)), D0.at(i).at(j) * TMath::Cos(phi0.at(i).at(j)), Z0.at(i).at(j));
@@ -658,13 +637,11 @@ namespace FCCAnalyses
       rv::RVec<FCCAnalysesJetConstituentsData> D0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_D0);
       rv::RVec<FCCAnalysesJetConstituentsData> Z0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_Z0);
       rv::RVec<FCCAnalysesJetConstituentsData> phi0 = cast_constituent_2(jcs, tracks, ReconstructedParticle2Track::getRP2TRK_phi);
-      for (std::size_t i = 0; i < jets.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jets.size(); ++i) {
         FCCAnalysesJetConstituentsData tmp;
         TVector3 p_jet(jets[i].px(), jets[i].py(), jets[i].pz());
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (std::size_t j = 0; j < ct.size(); ++j)
-        {
+        for (std::size_t j = 0; j < ct.size(); ++j) {
           if (D0.at(i).at(j) != -9)
           {
             TVector3 d(-D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)), D0.at(i).at(j) * TMath::Cos(phi0.at(i).at(j)), Z0.at(i).at(j));
@@ -683,22 +660,19 @@ namespace FCCAnalyses
       return out;
     }
 
-    rv::RVec<FCCAnalysesJetConstituentsData> get_JetDistVal_clusterV(const rv::RVec<fastjet::PseudoJet> &jets,
-                                                                     const rv::RVec<FCCAnalysesJetConstituents> &jcs,
-                                                                     const rv::RVec<FCCAnalysesJetConstituentsData> &D0,
-                                                                     const rv::RVec<FCCAnalysesJetConstituentsData> &Z0,
-                                                                     const rv::RVec<FCCAnalysesJetConstituentsData> &phi0,
-                                                                     const float)
-    {
+    rv::RVec<FCCAnalysesJetConstituentsData> get_JetDistVal_clusterV(
+        const rv::RVec<fastjet::PseudoJet> &jets,
+        const rv::RVec<FCCAnalysesJetConstituents> &jcs,
+        const rv::RVec<FCCAnalysesJetConstituentsData> &D0,
+        const rv::RVec<FCCAnalysesJetConstituentsData> &Z0,
+        const rv::RVec<FCCAnalysesJetConstituentsData> &phi0, const float) {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
 
-      for (std::size_t i = 0; i < jets.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jets.size(); ++i) {
         FCCAnalysesJetConstituentsData tmp;
         TVector3 p_jet(jets[i].px(), jets[i].py(), jets[i].pz());
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (std::size_t j = 0; j < ct.size(); ++j)
-        {
+        for (std::size_t j = 0; j < ct.size(); ++j) {
           if (D0.at(i).at(j) != -9)
           {
             TVector3 d(-D0.at(i).at(j) * TMath::Sin(phi0.at(i).at(j)), D0.at(i).at(j) * TMath::Cos(phi0.at(i).at(j)), Z0.at(i).at(j));
@@ -722,11 +696,9 @@ namespace FCCAnalyses
                                                             const rv::RVec<FCCAnalysesJetConstituentsData> &err2_Z0)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (std::size_t i = 0; i < JetDistVal.size(); ++i)
-      {
+      for (std::size_t i = 0; i < JetDistVal.size(); ++i) {
         FCCAnalysesJetConstituentsData tmp;
-        for (std::size_t j = 0; j < JetDistVal.at(i).size(); ++j)
-        {
+        for (std::size_t j = 0; j < JetDistVal.at(i).size(); ++j) {
           if (err2_D0.at(i).at(j) > 0)
           {
             float err3d = std::sqrt(err2_D0.at(i).at(j) + err2_Z0.at(i).at(j));
@@ -766,12 +738,10 @@ namespace FCCAnalyses
     )
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (std::size_t i = 0; i < jcs.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jcs.size(); ++i) {
         FCCAnalysesJetConstituents ct = jcs.at(i);
         FCCAnalysesJetConstituentsData tmp;
-        for (std::size_t j = 0; j < ct.size(); ++j)
-        {
+        for (std::size_t j = 0; j < ct.size(); ++j) {
           if (ct.at(j).clusters_begin < nhdata.size() + gammadata.size())
           {
 #if edm4hep_VERSION > EDM4HEP_VERSION(0, 10, 5)
@@ -1087,12 +1057,10 @@ namespace FCCAnalyses
     rv::RVec<FCCAnalysesJetConstituentsData> get_isEl(const rv::RVec<FCCAnalysesJetConstituents> &jcs)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (std::size_t i = 0; i < jcs.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jcs.size(); ++i) {
         FCCAnalysesJetConstituentsData is_El;
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (std::size_t j = 0; j < ct.size(); ++j)
-        {
+        for (std::size_t j = 0; j < ct.size(); ++j) {
           if (std::abs(ct.at(j).charge) > 0 and std::abs(ct.at(j).mass - 0.000510999) < 1.e-05)
           {
             is_El.push_back(1.);
@@ -1111,12 +1079,10 @@ namespace FCCAnalyses
     rv::RVec<FCCAnalysesJetConstituentsData> get_isMu(const rv::RVec<FCCAnalysesJetConstituents> &jcs)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (std::size_t i = 0; i < jcs.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jcs.size(); ++i) {
         FCCAnalysesJetConstituentsData is_Mu;
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (std::size_t j = 0; j < ct.size(); ++j)
-        {
+        for (std::size_t j = 0; j < ct.size(); ++j) {
           if (std::abs(ct.at(j).charge) > 0 and std::abs(ct.at(j).mass - 0.105658) < 1.e-03)
           {
             is_Mu.push_back(1.);
@@ -1135,12 +1101,10 @@ namespace FCCAnalyses
     rv::RVec<FCCAnalysesJetConstituentsData> get_isChargedHad(const rv::RVec<FCCAnalysesJetConstituents> &jcs)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (std::size_t i = 0; i < jcs.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jcs.size(); ++i) {
         FCCAnalysesJetConstituentsData is_ChargedHad;
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (std::size_t j = 0; j < ct.size(); ++j)
-        {
+        for (std::size_t j = 0; j < ct.size(); ++j) {
           if (std::abs(ct.at(j).charge) > 0 and std::abs(ct.at(j).mass - 0.13957) < 1.e-03)
           {
             is_ChargedHad.push_back(1.);
@@ -1159,12 +1123,10 @@ namespace FCCAnalyses
     rv::RVec<FCCAnalysesJetConstituentsData> get_isNeutralHad(const rv::RVec<FCCAnalysesJetConstituents> &jcs)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (std::size_t i = 0; i < jcs.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jcs.size(); ++i) {
         FCCAnalysesJetConstituentsData is_NeutralHad;
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (std::size_t j = 0; j < ct.size(); ++j)
-        {
+        for (std::size_t j = 0; j < ct.size(); ++j) {
 #if edm4hep_VERSION > EDM4HEP_VERSION(0, 10, 5)
           if (ct.at(j).PDG == 130)
 #else
@@ -1184,12 +1146,10 @@ namespace FCCAnalyses
     rv::RVec<FCCAnalysesJetConstituentsData> get_isGamma(const rv::RVec<FCCAnalysesJetConstituents> &jcs)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
-      for (std::size_t i = 0; i < jcs.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jcs.size(); ++i) {
         FCCAnalysesJetConstituentsData is_NeutralHad;
         FCCAnalysesJetConstituents ct = jcs.at(i);
-        for (std::size_t j = 0; j < ct.size(); ++j)
-        {
+        for (std::size_t j = 0; j < ct.size(); ++j) {
 #if edm4hep_VERSION > EDM4HEP_VERSION(0, 10, 5)
           if (ct.at(j).PDG == 22)
 #else
@@ -1215,8 +1175,7 @@ namespace FCCAnalyses
     rv::RVec<int> count_consts(rv::RVec<FCCAnalysesJetConstituents> jets)
     {
       rv::RVec<int> out;
-      for (std::size_t i = 0; i < jets.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jets.size(); ++i) {
         out.push_back(jets.at(i).size());
       }
       return out;
@@ -1225,12 +1184,10 @@ namespace FCCAnalyses
     rv::RVec<int> count_type(const rv::RVec<FCCAnalysesJetConstituentsData> &isType)
     {
       rv::RVec<int> out;
-      for (std::size_t i = 0; i < isType.size(); ++i)
-      {
+      for (std::size_t i = 0; i < isType.size(); ++i) {
         int count = 0;
         rv::RVec<float> istype = isType.at(i);
-        for (std::size_t j = 0; j < istype.size(); ++j)
-        {
+        for (std::size_t j = 0; j < istype.size(); ++j) {
           if ((int)(istype.at(j)) == 1)
             count++;
         }
@@ -1255,8 +1212,7 @@ namespace FCCAnalyses
     rv::RVec<TLorentzVector> sum_tlv_constituents(const rv::RVec<FCCAnalysesJetConstituents> &jets)
     {
       rv::RVec<TLorentzVector> out;
-      for (std::size_t i = 0; i < jets.size(); ++i)
-      {
+      for (std::size_t i = 0; i < jets.size(); ++i) {
         TLorentzVector sum_tlv; // initialized by (0., 0., 0., 0.)
         FCCAnalysesJetConstituents jcs = jets.at(i);
         for (const auto &jc : jcs)
@@ -1292,11 +1248,11 @@ namespace FCCAnalyses
       if(AllJets.size() < 2) return InvariantMasses;
 
       // For each jet, take its invariant mass with the remaining jets. Stop at last jet.
-      for(std::size_t i = 0; i + 1 < AllJets.size(); ++i) {
+      for (std::size_t i = 0; i + 1 < AllJets.size(); ++i) {
 
-        tlv1 = AllJets.at(i); 
+        tlv1 = AllJets.at(i);
 
-        for(std::size_t j=i+1; j < AllJets.size(); ++j){ // go until end
+        for (std::size_t j = i + 1; j < AllJets.size(); ++j) { // go until end
           tlv2 = AllJets.at(j);
           E = tlv1.E() + tlv2.E();
           px = tlv1.Px() + tlv2.Px();
@@ -1305,7 +1261,6 @@ namespace FCCAnalyses
 
           invmass = std::sqrt(E*E - px*px - py*py - pz*pz);
           InvariantMasses.push_back(invmass);
-
         }
       }
 
@@ -1315,8 +1270,7 @@ namespace FCCAnalyses
     rv::RVec<double> compute_residue_energy(const rv::RVec<TLorentzVector>& tlv_jet, const rv::RVec<TLorentzVector>& sum_tlv_jcs) {
     
       rv::RVec<double> out;
-      for (std::size_t i = 0; i < tlv_jet.size(); ++i)
-      {
+      for (std::size_t i = 0; i < tlv_jet.size(); ++i) {
         float de = (sum_tlv_jcs.at(i).E() - tlv_jet.at(i).E()) / tlv_jet.at(i).E();
         out.push_back(de);
       }
@@ -1326,8 +1280,7 @@ namespace FCCAnalyses
     rv::RVec<double> compute_residue_px(const rv::RVec<TLorentzVector> &tlv_jet, const rv::RVec<TLorentzVector> &sum_tlv_jcs)
     {
       rv::RVec<double> out;
-      for (std::size_t i = 0; i < tlv_jet.size(); ++i)
-      {
+      for (std::size_t i = 0; i < tlv_jet.size(); ++i) {
         float dpx = (sum_tlv_jcs.at(i).Px() - tlv_jet.at(i).Px()) / tlv_jet.at(i).Px();
         out.push_back(dpx);
       }
@@ -1337,8 +1290,7 @@ namespace FCCAnalyses
     rv::RVec<double> compute_residue_py(const rv::RVec<TLorentzVector> &tlv_jet, const rv::RVec<TLorentzVector> &sum_tlv_jcs)
     {
       rv::RVec<double> out;
-      for (std::size_t i = 0; i < tlv_jet.size(); ++i)
-      {
+      for (std::size_t i = 0; i < tlv_jet.size(); ++i) {
         float dpy = (sum_tlv_jcs.at(i).Py() - tlv_jet.at(i).Py()) / tlv_jet.at(i).Py();
         out.push_back(dpy);
       }
@@ -1348,8 +1300,7 @@ namespace FCCAnalyses
     rv::RVec<double> compute_residue_pz(const rv::RVec<TLorentzVector> &tlv_jet, const rv::RVec<TLorentzVector> &sum_tlv_jcs)
     {
       rv::RVec<double> out;
-      for (std::size_t i = 0; i < tlv_jet.size(); ++i)
-      {
+      for (std::size_t i = 0; i < tlv_jet.size(); ++i) {
         float dpz = (sum_tlv_jcs.at(i).Pz() - tlv_jet.at(i).Pz()) / tlv_jet.at(i).Pz();
         out.push_back(dpz);
       }
@@ -1359,8 +1310,7 @@ namespace FCCAnalyses
     rv::RVec<double> compute_residue_pt(const rv::RVec<TLorentzVector> &tlv_jet, const rv::RVec<TLorentzVector> &sum_tlv_jcs)
     {
       rv::RVec<double> out;
-      for (std::size_t i = 0; i < tlv_jet.size(); ++i)
-      {
+      for (std::size_t i = 0; i < tlv_jet.size(); ++i) {
         double pt_jet = std::sqrt(tlv_jet.at(i).Px() * tlv_jet.at(i).Px() + tlv_jet.at(i).Py() * tlv_jet.at(i).Py());
         double pt_jcs = std::sqrt(sum_tlv_jcs.at(i).Px() * sum_tlv_jcs.at(i).Px() + sum_tlv_jcs.at(i).Py() * sum_tlv_jcs.at(i).Py());
         double dpt = (pt_jcs - pt_jet) / pt_jet;
@@ -1372,8 +1322,7 @@ namespace FCCAnalyses
     rv::RVec<double> compute_residue_phi(const rv::RVec<TLorentzVector> &tlv_jet, const rv::RVec<TLorentzVector> &sum_tlv_jcs)
     {
       rv::RVec<double> out;
-      for (std::size_t i = 0; i < tlv_jet.size(); ++i)
-      {
+      for (std::size_t i = 0; i < tlv_jet.size(); ++i) {
         double phi_jet = tlv_jet.at(i).Phi();
         double phi_jcs = sum_tlv_jcs.at(i).Phi();
         double dphi = (phi_jcs - phi_jet) / phi_jet;
@@ -1385,8 +1334,7 @@ namespace FCCAnalyses
     rv::RVec<double> compute_residue_theta(const rv::RVec<TLorentzVector> &tlv_jet, const rv::RVec<TLorentzVector> &sum_tlv_jcs)
     {
       rv::RVec<double> out;
-      for (std::size_t i = 0; i < tlv_jet.size(); ++i)
-      {
+      for (std::size_t i = 0; i < tlv_jet.size(); ++i) {
         double theta_jet = tlv_jet.at(i).Theta();
         double theta_jcs = sum_tlv_jcs.at(i).Theta();
         double dtheta = (theta_jcs - theta_jet) / theta_jet;

--- a/analyzers/dataframe/src/JetConstituentsUtils.cc
+++ b/analyzers/dataframe/src/JetConstituentsUtils.cc
@@ -31,12 +31,10 @@ namespace FCCAnalyses
       for (const auto &jet : jets)
       {
         auto &jc = jcs.emplace_back();
-        float energy_jet = jet.energy;
-        float energy_const = 0;
         for (auto it = jet.particles_begin; it < jet.particles_end; ++it)
         {
           jc.emplace_back(rps.at(it));
-          energy_const += rps.at(it).energy;
+
         }
       }
       return jcs;
@@ -455,7 +453,7 @@ namespace FCCAnalyses
     rv::RVec<FCCAnalysesJetConstituentsData> get_Sip2dVal_clusterV(const rv::RVec<fastjet::PseudoJet> &jets,
                                                                    const rv::RVec<FCCAnalysesJetConstituentsData> &D0,
                                                                    const rv::RVec<FCCAnalysesJetConstituentsData> &phi0,
-                                                                   const float Bz)
+                                                                   const float)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
 
@@ -569,7 +567,7 @@ namespace FCCAnalyses
                                                                    const rv::RVec<FCCAnalysesJetConstituentsData> &D0,
                                                                    const rv::RVec<FCCAnalysesJetConstituentsData> &Z0,
                                                                    const rv::RVec<FCCAnalysesJetConstituentsData> &phi0,
-                                                                   const float Bz)
+                                                                   const float)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
 
@@ -689,7 +687,7 @@ namespace FCCAnalyses
                                                                      const rv::RVec<FCCAnalysesJetConstituentsData> &D0,
                                                                      const rv::RVec<FCCAnalysesJetConstituentsData> &Z0,
                                                                      const rv::RVec<FCCAnalysesJetConstituentsData> &phi0,
-                                                                     const float Bz)
+                                                                     const float)
     {
       rv::RVec<FCCAnalysesJetConstituentsData> out;
 

--- a/analyzers/dataframe/src/JetFlavourUtils.cc
+++ b/analyzers/dataframe/src/JetFlavourUtils.cc
@@ -2,6 +2,7 @@
 #include "ONNXRuntime/WeaverInterface.h"
 
 #include <memory>
+#include <cstddef>
 
 namespace FCCAnalyses {
   std::vector<WeaverInterface *> gWeavers;
@@ -49,9 +50,9 @@ namespace FCCAnalyses {
         throw std::runtime_error("Invalid index requested for jet flavour weight.");
       rv::RVec<float> out;
       for (const auto& jet_weights : jets_weights) {
-        if (weight >= jet_weights.size())
+        if (static_cast<std::size_t>(weight) >= jet_weights.size())
           throw std::runtime_error("Flavour weight index exceeds the number of weights registered.");
-        out.emplace_back(jet_weights.at(weight));
+        out.emplace_back(jet_weights.at(static_cast<std::size_t>(weight)));
       }
       return out;
     }

--- a/analyzers/dataframe/src/JetFlavourUtils.cc
+++ b/analyzers/dataframe/src/JetFlavourUtils.cc
@@ -1,8 +1,8 @@
 #include "FCCAnalyses/JetFlavourUtils.h"
 #include "ONNXRuntime/WeaverInterface.h"
 
-#include <memory>
 #include <cstddef>
+#include <memory>
 
 namespace FCCAnalyses {
   std::vector<WeaverInterface *> gWeavers;

--- a/analyzers/dataframe/src/JetTaggingUtils.cc
+++ b/analyzers/dataframe/src/JetTaggingUtils.cc
@@ -9,7 +9,6 @@ get_flavour(ROOT::VecOps::RVec<fastjet::PseudoJet> in,
             ROOT::VecOps::RVec<edm4hep::MCParticleData> MCin) {
   ROOT::VecOps::RVec<int> result(in.size(), 0);
 
-  int loopcount = 0;
   for (size_t i = 0; i < MCin.size(); ++i) {
     auto &parton = MCin[i];
     // Select partons only (for pythia8 71-79, for pythia6 2):

--- a/analyzers/dataframe/src/MCParticle.cc
+++ b/analyzers/dataframe/src/MCParticle.cc
@@ -1,9 +1,8 @@
 #include "FCCAnalyses/MCParticle.h"
+#include <algorithm>
 #include <cstddef>
 #include <iostream>
-#include <algorithm>
 #include <set>
-
 
 namespace FCCAnalyses{
 
@@ -86,14 +85,16 @@ bool  filter_pdgID::operator() (ROOT::VecOps::RVec<edm4hep::MCParticleData> in) 
 
 get_EventPrimaryVertex::get_EventPrimaryVertex( int arg_genstatus) { m_genstatus = arg_genstatus; };
 TVector3 get_EventPrimaryVertex::operator() ( ROOT::VecOps::RVec<edm4hep::MCParticleData> in )  {
-  TVector3 result(-1e12,-1e12,-1e12);
-  for (auto & p: in) {
-     if ( p.generatorStatus == m_genstatus ) {   // generator status code for the incoming particles of the hardest subprocess
-       TVector3 res( p.vertex.x, p.vertex.y, p.vertex.z );
-       result = res;
-       break;
-     }
-   }
+  TVector3 result(-1e12, -1e12, -1e12);
+  for (auto &p : in) {
+    if (p.generatorStatus ==
+        m_genstatus) { // generator status code for the incoming particles of
+                       // the hardest subprocess
+      TVector3 res(p.vertex.x, p.vertex.y, p.vertex.z);
+      result = res;
+      break;
+    }
+  }
 
   return result;
 }
@@ -284,7 +285,7 @@ ROOT::VecOps::RVec<edm4hep::Vector3d> get_endPoint(ROOT::VecOps::RVec<edm4hep::M
     if (db != de) { // particle unstable
         int d1 = ind[db] ;   // first daughter
         if (d1 >= 0 && static_cast<std::size_t>(d1) < in.size())
-            vertex = in.at(d1).vertex ;
+          vertex = in.at(d1).vertex;
     }
     result.push_back(vertex);
   }
@@ -478,7 +479,7 @@ ROOT::VecOps::RVec<int> get_parentid(ROOT::VecOps::RVec<int> mcind, ROOT::VecOps
 edm4hep::MCParticleData sel_byIndex( int idx, ROOT::VecOps::RVec<edm4hep::MCParticleData> in) {
     edm4hep::MCParticleData dummy;
     if (idx >= 0 && static_cast<std::size_t>(idx) < in.size())
-      return in.at(idx) ;
+      return in.at(idx);
     else {
            std::cout << " !!!! in sel_byIndex : index = " << idx << " is larger than the size of the MCParticle block " << in.size() << std::endl;
     }
@@ -498,7 +499,8 @@ std::vector<int> get_list_of_stable_particles_from_decay( int i, ROOT::VecOps::R
   // returns a vector with the indices (in the Particle block) of the stable daughters of the particle i,
   // from the complete decay chain.
 
-  if (i < 0 || static_cast<std::size_t>(i) >= in.size()) return res;
+  if (i < 0 || static_cast<std::size_t>(i) >= in.size())
+    return res;
 
   int db = in.at(i).daughters_begin ;
   int de = in.at(i).daughters_end;
@@ -532,7 +534,8 @@ std::vector<int> get_list_of_particles_from_decay(int i, ROOT::VecOps::RVec<edm4
 
   // returns a vector with the indices (in the Particle block) of the daughters of the particle i
 
-  if (i < 0 || static_cast<std::size_t>(i) >= in.size()) return res;
+  if (i < 0 || static_cast<std::size_t>(i) >= in.size())
+    return res;
 
   int db = in.at(i).daughters_begin ;
   int de = in.at(i).daughters_end;
@@ -655,7 +658,7 @@ ROOT::VecOps::RVec<int>  get_indices::operator() ( ROOT::VecOps::RVec<edm4hep::M
 
    ROOT::VecOps::RVec<int>  result;
 
-   for ( std::size_t imother =0; imother < in.size(); imother ++){
+   for (std::size_t imother = 0; imother < in.size(); imother++) {
      int pdg = in[imother].PDG ;
      bool found_a_mother = false;
      if ( ! m_chargeConjugateMother ) found_a_mother = ( pdg == m_pdg_mother );
@@ -667,7 +670,6 @@ ROOT::VecOps::RVec<int>  get_indices::operator() ( ROOT::VecOps::RVec<edm4hep::M
         result = a;
         break;    // return the first decay found
      }
-
    }
    return result;
 }
@@ -686,11 +688,11 @@ ROOT::VecOps::RVec<float> AngleBetweenTwoMCParticles( ROOT::VecOps::RVec<edm4hep
         return result;
   }
 
-  for (std::size_t i=0; i < p1.size(); i++) {
-     TVector3 q1( p1[i].momentum.x, p1[i].momentum.y, p1[i].momentum.z );
-     TVector3 q2( p2[i].momentum.x, p2[i].momentum.y, p2[i].momentum.z );
-     float delta = fabs( q1.Angle( q2 ) ) ;
-     result.push_back( delta );
+  for (std::size_t i = 0; i < p1.size(); i++) {
+    TVector3 q1(p1[i].momentum.x, p1[i].momentum.y, p1[i].momentum.z);
+    TVector3 q2(p2[i].momentum.x, p2[i].momentum.y, p2[i].momentum.z);
+    float delta = fabs(q1.Angle(q2));
+    result.push_back(delta);
   }
 
   return result;
@@ -762,7 +764,8 @@ int get_lepton_origin(const edm4hep::MCParticleData &p,
 int get_lepton_origin(int index,
                       const ROOT::VecOps::RVec<edm4hep::MCParticleData> &in,
                       const ROOT::VecOps::RVec<int> &ind){
-  if (index < 0 || static_cast<std::size_t>(index) >= in.size()) return -1;
+  if (index < 0 || static_cast<std::size_t>(index) >= in.size())
+    return -1;
   edm4hep::MCParticleData p = in[index];
   return get_lepton_origin( p, in, ind );
 }

--- a/analyzers/dataframe/src/MCParticle.cc
+++ b/analyzers/dataframe/src/MCParticle.cc
@@ -86,9 +86,7 @@ bool  filter_pdgID::operator() (ROOT::VecOps::RVec<edm4hep::MCParticleData> in) 
 get_EventPrimaryVertex::get_EventPrimaryVertex( int arg_genstatus) { m_genstatus = arg_genstatus; };
 TVector3 get_EventPrimaryVertex::operator() ( ROOT::VecOps::RVec<edm4hep::MCParticleData> in )  {
   TVector3 result(-1e12,-1e12,-1e12);
-  int i=0;
   for (auto & p: in) {
-     i++;
      if ( p.generatorStatus == m_genstatus ) {   // generator status code for the incoming particles of the hardest subprocess
        TVector3 res( p.vertex.x, p.vertex.y, p.vertex.z );
        result = res;
@@ -145,8 +143,6 @@ TLorentzVector get_EventPrimaryVertexP4::operator() ( ROOT::VecOps::RVec<edm4hep
 get_tree::get_tree(int arg_index) : m_index(arg_index) {};
 ROOT::VecOps::RVec<int> get_tree::operator() (ROOT::VecOps::RVec<edm4hep::MCParticleData> in, ROOT::VecOps::RVec<int> ind){
   ROOT::VecOps::RVec<int> result;
-  auto & particle = in[m_index];
-
   //for (unsigned j = in.at(i).parents_begin; j != in.at(i).parents_end; ++j){
   //  if
   //  result.push_back(ind.at(j));

--- a/analyzers/dataframe/src/MCParticle.cc
+++ b/analyzers/dataframe/src/MCParticle.cc
@@ -1,4 +1,5 @@
 #include "FCCAnalyses/MCParticle.h"
+#include <cstddef>
 #include <iostream>
 #include <algorithm>
 #include <set>
@@ -282,9 +283,8 @@ ROOT::VecOps::RVec<edm4hep::Vector3d> get_endPoint(ROOT::VecOps::RVec<edm4hep::M
     int de = p.daughters_end;
     if (db != de) { // particle unstable
         int d1 = ind[db] ;   // first daughter
-        if ( d1 >= 0 && d1 < in.size() ) {
+        if (d1 >= 0 && static_cast<std::size_t>(d1) < in.size())
             vertex = in.at(d1).vertex ;
-        }
     }
     result.push_back(vertex);
   }
@@ -477,9 +477,8 @@ ROOT::VecOps::RVec<int> get_parentid(ROOT::VecOps::RVec<int> mcind, ROOT::VecOps
 // returns one MCParticle selected by its index in the particle block
 edm4hep::MCParticleData sel_byIndex( int idx, ROOT::VecOps::RVec<edm4hep::MCParticleData> in) {
     edm4hep::MCParticleData dummy;
-    if ( idx >= 0 && idx < in.size() ) {
-           return in.at(idx) ;
-    }
+    if (idx >= 0 && static_cast<std::size_t>(idx) < in.size())
+      return in.at(idx) ;
     else {
            std::cout << " !!!! in sel_byIndex : index = " << idx << " is larger than the size of the MCParticle block " << in.size() << std::endl;
     }
@@ -499,7 +498,7 @@ std::vector<int> get_list_of_stable_particles_from_decay( int i, ROOT::VecOps::R
   // returns a vector with the indices (in the Particle block) of the stable daughters of the particle i,
   // from the complete decay chain.
 
-  if ( i < 0 || i >= in.size() ) return res;
+  if (i < 0 || static_cast<std::size_t>(i) >= in.size()) return res;
 
   int db = in.at(i).daughters_begin ;
   int de = in.at(i).daughters_end;
@@ -533,7 +532,7 @@ std::vector<int> get_list_of_particles_from_decay(int i, ROOT::VecOps::RVec<edm4
 
   // returns a vector with the indices (in the Particle block) of the daughters of the particle i
 
-  if ( i < 0 || i >= in.size() ) return res;
+  if (i < 0 || static_cast<std::size_t>(i) >= in.size()) return res;
 
   int db = in.at(i).daughters_begin ;
   int de = in.at(i).daughters_end;
@@ -656,7 +655,7 @@ ROOT::VecOps::RVec<int>  get_indices::operator() ( ROOT::VecOps::RVec<edm4hep::M
 
    ROOT::VecOps::RVec<int>  result;
 
-   for ( int imother =0; imother < in.size(); imother ++){
+   for ( std::size_t imother =0; imother < in.size(); imother ++){
      int pdg = in[imother].PDG ;
      bool found_a_mother = false;
      if ( ! m_chargeConjugateMother ) found_a_mother = ( pdg == m_pdg_mother );
@@ -687,7 +686,7 @@ ROOT::VecOps::RVec<float> AngleBetweenTwoMCParticles( ROOT::VecOps::RVec<edm4hep
         return result;
   }
 
-  for (int i=0; i < p1.size(); i++) {
+  for (std::size_t i=0; i < p1.size(); i++) {
      TVector3 q1( p1[i].momentum.x, p1[i].momentum.y, p1[i].momentum.z );
      TVector3 q2( p2[i].momentum.x, p2[i].momentum.y, p2[i].momentum.z );
      float delta = fabs( q1.Angle( q2 ) ) ;
@@ -763,7 +762,7 @@ int get_lepton_origin(const edm4hep::MCParticleData &p,
 int get_lepton_origin(int index,
                       const ROOT::VecOps::RVec<edm4hep::MCParticleData> &in,
                       const ROOT::VecOps::RVec<int> &ind){
-  if ( index < 0 || index >= in.size() ) return -1;
+  if (index < 0 || static_cast<std::size_t>(index) >= in.size()) return -1;
   edm4hep::MCParticleData p = in[index];
   return get_lepton_origin( p, in, ind );
 }

--- a/analyzers/dataframe/src/ReconstructedParticle.cc
+++ b/analyzers/dataframe/src/ReconstructedParticle.cc
@@ -1,4 +1,5 @@
 #include "FCCAnalyses/ReconstructedParticle.h"
+#include <cstddef>
 
 // Standard library
 #include <cstdlib>
@@ -229,10 +230,10 @@ float angular_separationBuilder::operator() ( ROOT::VecOps::RVec<edm4hep::Recons
  float dmin = 999;
  float sum = 0;
  float npairs = 0;
- for (int i=0; i < in.size(); i++) {
+ for (std::size_t i=0; i < in.size(); i++) {
   if ( in.at(i).energy < 0) continue;    // "dummy" particle - cf selRP_matched_to_list
   TVector3 p1( in.at(i).momentum.x, in.at(i).momentum.y, in.at(i).momentum.z );
-  for (int j=i+1; j < in.size(); j++) {
+  for (std::size_t j=i+1; j < in.size(); j++) {
     if ( in.at(j).energy < 0) continue;   // "dummy" particle
     TVector3 p2( in.at(j).momentum.x, in.at(j).momentum.y, in.at(j).momentum.z );
     float delta_ij = fabs( p1.Angle( p2 ) );

--- a/analyzers/dataframe/src/ReconstructedParticle.cc
+++ b/analyzers/dataframe/src/ReconstructedParticle.cc
@@ -230,18 +230,22 @@ float angular_separationBuilder::operator() ( ROOT::VecOps::RVec<edm4hep::Recons
  float dmin = 999;
  float sum = 0;
  float npairs = 0;
- for (std::size_t i=0; i < in.size(); i++) {
-  if ( in.at(i).energy < 0) continue;    // "dummy" particle - cf selRP_matched_to_list
-  TVector3 p1( in.at(i).momentum.x, in.at(i).momentum.y, in.at(i).momentum.z );
-  for (std::size_t j=i+1; j < in.size(); j++) {
-    if ( in.at(j).energy < 0) continue;   // "dummy" particle
-    TVector3 p2( in.at(j).momentum.x, in.at(j).momentum.y, in.at(j).momentum.z );
-    float delta_ij = fabs( p1.Angle( p2 ) );
-    if ( delta_ij > dmax) dmax = delta_ij;
-    if ( delta_ij < dmin) dmin = delta_ij;
-    sum = sum + delta_ij;
-    npairs ++;
-  }
+ for (std::size_t i = 0; i < in.size(); i++) {
+   if (in.at(i).energy < 0)
+     continue; // "dummy" particle - cf selRP_matched_to_list
+   TVector3 p1(in.at(i).momentum.x, in.at(i).momentum.y, in.at(i).momentum.z);
+   for (std::size_t j = i + 1; j < in.size(); j++) {
+     if (in.at(j).energy < 0)
+       continue; // "dummy" particle
+     TVector3 p2(in.at(j).momentum.x, in.at(j).momentum.y, in.at(j).momentum.z);
+     float delta_ij = fabs(p1.Angle(p2));
+     if (delta_ij > dmax)
+       dmax = delta_ij;
+     if (delta_ij < dmin)
+       dmin = delta_ij;
+     sum = sum + delta_ij;
+     npairs++;
+   }
  }
  float delta_max = dmax;
  float delta_min = dmin;

--- a/analyzers/dataframe/src/ReconstructedParticle2MC.cc
+++ b/analyzers/dataframe/src/ReconstructedParticle2MC.cc
@@ -397,7 +397,9 @@ int getTrack2MC_index (int track_index,
           // keep only charged particles
           if ( reco.at( reco_idx ).charge == 0 ) continue;
           mc_index = mcind.at(i);
-          if ( reco.at( reco_idx ).tracks_begin == track_index ) return mc_index;
+          if (track_index >= 0 &&
+              reco.at(reco_idx).tracks_begin == static_cast<unsigned int>(track_index))
+            return mc_index;
       }
  return mc_index;
 }

--- a/analyzers/dataframe/src/ReconstructedParticle2MC.cc
+++ b/analyzers/dataframe/src/ReconstructedParticle2MC.cc
@@ -273,16 +273,17 @@ selRP_PDG::operator() (ROOT::VecOps::RVec<int> recind,
 
   std::vector<edm4hep::ReconstructedParticleData> result;
 
-  for (std::size_t i=0; i<recind.size();i++) {
-      int reco_idx = recind.at(i);
-      int mc_idx = mcind.at(i);
-      int pdg = mc.at(mc_idx).PDG ;
-      if ( m_chargedOnly ) {
-        if ( reco.at( reco_idx ).charge ==0 ) continue;
-      }
-      if ( std::abs( pdg ) == std::abs( m_PDG)  ) {
-         result.push_back( reco.at( reco_idx ) ) ;
-      }
+  for (std::size_t i = 0; i < recind.size(); i++) {
+    int reco_idx = recind.at(i);
+    int mc_idx = mcind.at(i);
+    int pdg = mc.at(mc_idx).PDG;
+    if (m_chargedOnly) {
+      if (reco.at(reco_idx).charge == 0)
+        continue;
+    }
+    if (std::abs(pdg) == std::abs(m_PDG)) {
+      result.push_back(reco.at(reco_idx));
+    }
   }
   return result;
 }
@@ -297,16 +298,17 @@ selRP_PDG_index::operator() (ROOT::VecOps::RVec<int> recind,
 
   ROOT::VecOps::RVec<int> result;
 
-  for (std::size_t i=0; i<recind.size();i++) {
-      int reco_idx = recind.at(i);
-      int mc_idx = mcind.at(i);
-      int pdg = mc.at(mc_idx).PDG ;
-      if ( m_chargedOnly ) {
-        if ( reco.at( reco_idx ).charge ==0 ) continue;
-      }
-      if ( std::abs( pdg ) == std::abs( m_PDG)  ) {
-         result.push_back( reco_idx ) ;
-      }
+  for (std::size_t i = 0; i < recind.size(); i++) {
+    int reco_idx = recind.at(i);
+    int mc_idx = mcind.at(i);
+    int pdg = mc.at(mc_idx).PDG;
+    if (m_chargedOnly) {
+      if (reco.at(reco_idx).charge == 0)
+        continue;
+    }
+    if (std::abs(pdg) == std::abs(m_PDG)) {
+      result.push_back(reco_idx);
+    }
   }
   return result;
 }
@@ -324,13 +326,15 @@ selRP_ChargedHadrons (ROOT::VecOps::RVec<int> recind,
 
   std::vector<edm4hep::ReconstructedParticleData> result;
 
-  for (std::size_t i=0; i<recind.size();i++) {
-      int reco_idx = recind.at(i);
-      int mc_idx = mcind.at(i);
-      int pdg = mc.at(mc_idx).PDG ;
-      if ( reco.at( reco_idx ).charge == 0 ) continue;
-      if ( std::abs( pdg ) == 11 || std::abs( pdg ) == 13 || std::abs( pdg ) == 15 ) continue ;
-      result.push_back( reco.at( reco_idx ) ) ;
+  for (std::size_t i = 0; i < recind.size(); i++) {
+    int reco_idx = recind.at(i);
+    int mc_idx = mcind.at(i);
+    int pdg = mc.at(mc_idx).PDG;
+    if (reco.at(reco_idx).charge == 0)
+      continue;
+    if (std::abs(pdg) == 11 || std::abs(pdg) == 13 || std::abs(pdg) == 15)
+      continue;
+    result.push_back(reco.at(reco_idx));
   }
 
   return result;
@@ -361,7 +365,7 @@ selRP_matched_to_list( ROOT::VecOps::RVec<int>  mcParticles_indices,
 
     // is this MC particle associated with a Reco particle :
     bool found = false;
-    for (std::size_t i=0; i<recind.size();i++) {
+    for (std::size_t i = 0; i < recind.size(); i++) {
       int reco_idx = recind.at(i);
       int mc_idx = mcind.at(i);
       if ( mc_idx == idx ) {
@@ -392,15 +396,16 @@ int getTrack2MC_index (int track_index,
 						 ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> reco) {
   int mc_index = -1;
 
-      for (std::size_t i=0; i<recind.size();i++) {
-          int reco_idx = recind.at(i);
-          // keep only charged particles
-          if ( reco.at( reco_idx ).charge == 0 ) continue;
-          mc_index = mcind.at(i);
-          if (track_index >= 0 &&
-              reco.at(reco_idx).tracks_begin == static_cast<unsigned int>(track_index))
-            return mc_index;
-      }
+  for (std::size_t i = 0; i < recind.size(); i++) {
+    int reco_idx = recind.at(i);
+    // keep only charged particles
+    if (reco.at(reco_idx).charge == 0)
+      continue;
+    mc_index = mcind.at(i);
+    if (track_index >= 0 && reco.at(reco_idx).tracks_begin ==
+                                static_cast<unsigned int>(track_index))
+      return mc_index;
+  }
  return mc_index;
 }
 

--- a/analyzers/dataframe/src/ReconstructedParticle2MC.cc
+++ b/analyzers/dataframe/src/ReconstructedParticle2MC.cc
@@ -1,4 +1,5 @@
 #include "FCCAnalyses/ReconstructedParticle2MC.h"
+#include <cstddef>
 #include <iostream>
 
 namespace FCCAnalyses{
@@ -272,7 +273,7 @@ selRP_PDG::operator() (ROOT::VecOps::RVec<int> recind,
 
   std::vector<edm4hep::ReconstructedParticleData> result;
 
-  for (int i=0; i<recind.size();i++) {
+  for (std::size_t i=0; i<recind.size();i++) {
       int reco_idx = recind.at(i);
       int mc_idx = mcind.at(i);
       int pdg = mc.at(mc_idx).PDG ;
@@ -296,7 +297,7 @@ selRP_PDG_index::operator() (ROOT::VecOps::RVec<int> recind,
 
   ROOT::VecOps::RVec<int> result;
 
-  for (int i=0; i<recind.size();i++) {
+  for (std::size_t i=0; i<recind.size();i++) {
       int reco_idx = recind.at(i);
       int mc_idx = mcind.at(i);
       int pdg = mc.at(mc_idx).PDG ;
@@ -323,7 +324,7 @@ selRP_ChargedHadrons (ROOT::VecOps::RVec<int> recind,
 
   std::vector<edm4hep::ReconstructedParticleData> result;
 
-  for (int i=0; i<recind.size();i++) {
+  for (std::size_t i=0; i<recind.size();i++) {
       int reco_idx = recind.at(i);
       int mc_idx = mcind.at(i);
       int pdg = mc.at(mc_idx).PDG ;
@@ -360,7 +361,7 @@ selRP_matched_to_list( ROOT::VecOps::RVec<int>  mcParticles_indices,
 
     // is this MC particle associated with a Reco particle :
     bool found = false;
-    for (int i=0; i<recind.size();i++) {
+    for (std::size_t i=0; i<recind.size();i++) {
       int reco_idx = recind.at(i);
       int mc_idx = mcind.at(i);
       if ( mc_idx == idx ) {
@@ -391,7 +392,7 @@ int getTrack2MC_index (int track_index,
 						 ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> reco) {
   int mc_index = -1;
 
-      for (int i=0; i<recind.size();i++) {
+      for (std::size_t i=0; i<recind.size();i++) {
           int reco_idx = recind.at(i);
           // keep only charged particles
           if ( reco.at( reco_idx ).charge == 0 ) continue;

--- a/analyzers/dataframe/src/ReconstructedParticle2Track.cc
+++ b/analyzers/dataframe/src/ReconstructedParticle2Track.cc
@@ -515,7 +515,7 @@ getRP2TRK( ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   result.reserve( in.size() );
 
   for (auto & p: in) {
-    if (p.tracks_begin >= 0 && p.tracks_begin<tracks.size()) {
+  if (p.tracks_begin < tracks.size()) {
 	result.push_back(tracks.at(p.tracks_begin) ) ;
     }
   }
@@ -532,7 +532,7 @@ get_recoindTRK( ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   
   for (unsigned int ctr=0; ctr<in.size(); ctr++) {
     edm4hep::ReconstructedParticleData p = in.at(ctr);
-    if (p.tracks_begin >= 0 && p.tracks_begin<tracks.size()) result.push_back(ctr) ;
+  if (p.tracks_begin < tracks.size()) result.push_back(ctr) ;
   }
  return result ;
 }
@@ -550,7 +550,7 @@ hasTRK( ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in ) {
   result.reserve( in.size() );
   
   for (auto & p: in) {
-    if (p.tracks_begin >= 0 && p.tracks_begin != p.tracks_end) result.push_back(true) ;
+  if (p.tracks_begin != p.tracks_end) result.push_back(true) ;
     else result.push_back(false);
   }
  return result ;

--- a/analyzers/dataframe/src/ReconstructedParticle2Track.cc
+++ b/analyzers/dataframe/src/ReconstructedParticle2Track.cc
@@ -216,9 +216,10 @@ namespace ReconstructedParticle2Track{
     return out;
   }
 
-  ROOT::VecOps::RVec<float> XPtoPar_ct(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
-				       const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
-				       const float&) {
+  ROOT::VecOps::RVec<float>
+  XPtoPar_ct(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> &in,
+             const ROOT::VecOps::RVec<edm4hep::TrackState> &tracks,
+             const float &) {
 
     ROOT::VecOps::RVec<float> out;
 
@@ -239,7 +240,6 @@ namespace ReconstructedParticle2Track{
     }
     return out;
   }
-
 
 ROOT::VecOps::RVec<float>
 getRP2TRK_D0(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
@@ -515,8 +515,8 @@ getRP2TRK( ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   result.reserve( in.size() );
 
   for (auto & p: in) {
-  if (p.tracks_begin < tracks.size()) {
-	result.push_back(tracks.at(p.tracks_begin) ) ;
+    if (p.tracks_begin < tracks.size()) {
+      result.push_back(tracks.at(p.tracks_begin));
     }
   }
  return result ;
@@ -532,7 +532,8 @@ get_recoindTRK( ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   
   for (unsigned int ctr=0; ctr<in.size(); ctr++) {
     edm4hep::ReconstructedParticleData p = in.at(ctr);
-  if (p.tracks_begin < tracks.size()) result.push_back(ctr) ;
+    if (p.tracks_begin < tracks.size())
+      result.push_back(ctr);
   }
  return result ;
 }
@@ -550,7 +551,8 @@ hasTRK( ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in ) {
   result.reserve( in.size() );
   
   for (auto & p: in) {
-  if (p.tracks_begin != p.tracks_end) result.push_back(true) ;
+    if (p.tracks_begin != p.tracks_end)
+      result.push_back(true);
     else result.push_back(false);
   }
  return result ;

--- a/analyzers/dataframe/src/ReconstructedParticle2Track.cc
+++ b/analyzers/dataframe/src/ReconstructedParticle2Track.cc
@@ -218,9 +218,8 @@ namespace ReconstructedParticle2Track{
 
   ROOT::VecOps::RVec<float> XPtoPar_ct(const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& in,
 				       const ROOT::VecOps::RVec<edm4hep::TrackState>& tracks,
-				       const float& Bz) {
+				       const float&) {
 
-    const double cSpeed = 2.99792458e8 * 1.0e-9;
     ROOT::VecOps::RVec<float> out;
 
     for (const auto & rp: in) {

--- a/analyzers/dataframe/src/SmearObjects.cc
+++ b/analyzers/dataframe/src/SmearObjects.cc
@@ -193,8 +193,6 @@ ROOT::VecOps::RVec<edm4hep::TrackState> mcTrackParameters(
   edm4hep::TrackState dummy;
 
   for (int itrack = 0; itrack < ntracks; itrack++) {
-    edm4hep::TrackState track = alltracks[itrack];
-
     // find the corresponding MC particle
     int MCindex = -1;
     for (int ireco = 0; ireco < allRecoParticles.size(); ireco++) {
@@ -300,7 +298,7 @@ TVectorD CovSmear(TVectorD x, TMatrixDSym C, TRandom *ran, bool debug = false) {
 // ----------------------------------------------------------------------------
 
 SmearedTracksdNdx::SmearedTracksdNdx(float scale, bool debug = false)
-    : m_scale(scale), m_debug(debug) {}
+    : m_debug(debug), m_scale(scale) {}
 
 ROOT::VecOps::RVec<edm4hep::RecDqdxData> SmearedTracksdNdx::operator()(
     const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>

--- a/analyzers/dataframe/src/SmearObjects.cc
+++ b/analyzers/dataframe/src/SmearObjects.cc
@@ -1,4 +1,5 @@
 #include "FCCAnalyses/SmearObjects.h"
+#include <cstddef>
 
 // std
 #include <iostream>
@@ -77,7 +78,7 @@ ROOT::VecOps::RVec<edm4hep::TrackState> SmearedTracks::operator()(
 
     // find the corresponding MC particle
     int MCindex = -1;
-    for (int ireco = 0; ireco < allRecoParticles.size(); ireco++) {
+    for (std::size_t ireco = 0; ireco < allRecoParticles.size(); ireco++) {
       edm4hep::ReconstructedParticleData rp = allRecoParticles[ireco];
       int track_index = rp.tracks_begin;
       if (track_index == itrack) {
@@ -195,7 +196,7 @@ ROOT::VecOps::RVec<edm4hep::TrackState> mcTrackParameters(
   for (int itrack = 0; itrack < ntracks; itrack++) {
     // find the corresponding MC particle
     int MCindex = -1;
-    for (int ireco = 0; ireco < allRecoParticles.size(); ireco++) {
+    for (std::size_t ireco = 0; ireco < allRecoParticles.size(); ireco++) {
       edm4hep::ReconstructedParticleData rp = allRecoParticles[ireco];
       int track_index = rp.tracks_begin;
       if (track_index == itrack) {
@@ -426,7 +427,7 @@ ROOT::VecOps::RVec<edm4hep::TrackerHit3DData> SmearedTracksTOF::operator()(
 
     // find the corresponding MC particle
     int MCindex = -1;
-    for (int ireco = 0; ireco < allRecoParticles.size(); ireco++) {
+    for (std::size_t ireco = 0; ireco < allRecoParticles.size(); ireco++) {
       edm4hep::ReconstructedParticleData rp = allRecoParticles[ireco];
       int track_index = rp.tracks_begin;
       if (track_index == itrack) {

--- a/analyzers/dataframe/src/SmearObjects.cc
+++ b/analyzers/dataframe/src/SmearObjects.cc
@@ -88,9 +88,8 @@ ROOT::VecOps::RVec<edm4hep::TrackState> SmearedTracks::operator()(
     } // end loop on RPs
 
     if (MCindex < 0 ||
-        MCindex >=
-            mcParticles
-                .size()) { // in principle, this should not happen in delphes,
+        static_cast<std::size_t>(MCindex) >= mcParticles.size()) {
+      // In principle, this should not happen in Delphes,
       // each track should be matched to a MC particle.
       result[itrack] = dummy;
       continue;
@@ -205,7 +204,8 @@ ROOT::VecOps::RVec<edm4hep::TrackState> mcTrackParameters(
       }
     } // end loop on RPs
 
-    if (MCindex < 0 || MCindex >= mcParticles.size()) {
+    if (MCindex < 0 ||
+        static_cast<std::size_t>(MCindex) >= mcParticles.size()) {
       result.push_back(dummy);
       continue;
     }
@@ -324,7 +324,7 @@ ROOT::VecOps::RVec<edm4hep::RecDqdxData> SmearedTracksdNdx::operator()(
 
     // find the corresponding MC particle
     int MCindex = -1;
-    for (int ireco = 0; ireco < allRecoParticles.size(); ireco++) {
+    for (std::size_t ireco = 0; ireco < allRecoParticles.size(); ireco++) {
       edm4hep::ReconstructedParticleData rp = allRecoParticles[ireco];
       int track_index = rp.tracks_begin;
       if (track_index == itrack) {
@@ -334,9 +334,8 @@ ROOT::VecOps::RVec<edm4hep::RecDqdxData> SmearedTracksdNdx::operator()(
     } // end loop on RPs
 
     if (MCindex < 0 ||
-        MCindex >=
-            mcParticles
-                .size()) { // in principle, this should not happen in delphes,
+        static_cast<std::size_t>(MCindex) >= mcParticles.size()) {
+      // In principle, this should not happen in Delphes,
       // each track should be matched to a MC particle.
       result.push_back(dNdxSmeared);
       continue;
@@ -437,9 +436,8 @@ ROOT::VecOps::RVec<edm4hep::TrackerHit3DData> SmearedTracksTOF::operator()(
     } // end loop on RPs
 
     if (MCindex < 0 ||
-        MCindex >=
-            mcParticles
-                .size()) { // in principle, this should not happen in delphes,
+        static_cast<std::size_t>(MCindex) >= mcParticles.size()) {
+      // In principle, this should not happen in Delphes,
       // each track should be matched to a MC particle.
       result[idx_tin] = smeared_thits_0;
       result[idx_tpix] = smeared_thits_1;
@@ -548,7 +546,8 @@ SmearedReconstructedParticle::operator()(
 
     // smear particle only if MC particle found, else return original particle
     // and if type == requested
-    if (MCindex >= 0 and MCindex < mcParticles.size() and
+    if (MCindex >= 0 and
+        static_cast<std::size_t>(MCindex) < mcParticles.size() and
         reco_part_type == m_type) {
       edm4hep::MCParticleData mc_part = mcParticles[MCindex];
 

--- a/analyzers/dataframe/src/Smearing.cc
+++ b/analyzers/dataframe/src/Smearing.cc
@@ -2,7 +2,7 @@
 
 logNormal::logNormal(float arg_a, float arg_b, float arg_c){m_a = arg_a; m_b = arg_b; m_c = arg_c;};
 
-ROOT::VecOps::RVec<float> logNormal::operator() (ROOT::VecOps::RVec<float>) {
+ROOT::VecOps::RVec<float> logNormal::operator()(ROOT::VecOps::RVec<float>) {
   ROOT::VecOps::RVec<float> result;
 
   return result;

--- a/analyzers/dataframe/src/Smearing.cc
+++ b/analyzers/dataframe/src/Smearing.cc
@@ -2,7 +2,7 @@
 
 logNormal::logNormal(float arg_a, float arg_b, float arg_c){m_a = arg_a; m_b = arg_b; m_c = arg_c;};
 
-ROOT::VecOps::RVec<float> logNormal::operator() (ROOT::VecOps::RVec<float> in) {
+ROOT::VecOps::RVec<float> logNormal::operator() (ROOT::VecOps::RVec<float>) {
   ROOT::VecOps::RVec<float> result;
 
   return result;

--- a/analyzers/dataframe/src/VertexFinderLCFIPlus.cc
+++ b/analyzers/dataframe/src/VertexFinderLCFIPlus.cc
@@ -45,13 +45,13 @@ ROOT::VecOps::RVec<ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex>> get_SV
 
     // remove primary tracks & separate non-primary tracks by jet
     std::vector<int> i_jetconsti = jet_consti[j];
-    for (std::size_t ctr=0; ctr<tracks.size(); ctr++) {
+    for (std::size_t ctr = 0; ctr < tracks.size(); ctr++) {
       if(isInPrimary[ctr]) continue; // remove primary tracks
       if(std::find(i_jetconsti.begin(), i_jetconsti.end(), reco_ind_tracks[ctr]) == i_jetconsti.end()) {
 	np_tracks.push_back(tracks[ctr]); // separate tracks by jet
       }
     }
-    
+
     if(debug_me) std::cout<<"primary tracks removed; there are "<<np_tracks.size()<<" non-primary tracks in jet#"<<j+1<<std::endl;
     
     // V0 rejection (tight) - perform V0 rejection with tight constraints if user chooses
@@ -170,11 +170,11 @@ ROOT::VecOps::RVec<int> VertexSeed_best(ROOT::VecOps::RVec<edm4hep::TrackState> 
   tr_pair.push_back(tr_j);
   VertexingUtils::FCCAnalysesVertex vtx_seed;
   double chi2_min = 99;
-  
-  for(int i=0; i<nTr-1; i++) {
+
+  for (int i = 0; i < nTr - 1; i++) {
     tr_pair[0] = tracks[i];
-    
-    for(int j=i+1; j<nTr; j++) {
+
+    for (int j = i + 1; j < nTr; j++) {
       tr_pair[1] = tracks[j];
       
       // V0 rejection (loose)
@@ -231,7 +231,7 @@ ROOT::VecOps::RVec<int> addTrack_best(ROOT::VecOps::RVec<edm4hep::TrackState> tr
   tr_vtx.push_back(tr_i);
 
   // find best track to add to the vtx
-  for(int i=0; i<nTr; i++) {
+  for (int i = 0; i < nTr; i++) {
     if(std::find(vtx_tr.begin(), vtx_tr.end(), i) != vtx_tr.end()) continue;
     tr_vtx[iTr] = tracks[i];
     
@@ -248,7 +248,7 @@ ROOT::VecOps::RVec<int> addTrack_best(ROOT::VecOps::RVec<edm4hep::TrackState> tr
     if(chi2_vtx < chi2_min) {
       isel = i;
       chi2_min = chi2_vtx;
-    }    
+    }
   }
 
   if(isel>=0) result.push_back(isel);
@@ -286,8 +286,8 @@ ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> findSVfromTracks(ROOT::Vec
     
     if(debug_me){
       std::cout << "tracks_fin.size(): " << tracks_fin.size() << std::endl;
-      for(std::size_t i=0; i<vtx_seed.size();i++)
-	std::cout << "vtx_seed: " << vtx_seed[i] << std::endl;
+      for (std::size_t i = 0; i < vtx_seed.size(); i++)
+        std::cout << "vtx_seed: " << vtx_seed[i] << std::endl;
     }
     if(vtx_seed.size() == 0) break;
     
@@ -393,11 +393,11 @@ ROOT::VecOps::RVec<bool> isV0(ROOT::VecOps::RVec<edm4hep::TrackState> np_tracks,
   t_pair.push_back(tr_j);
   VertexingUtils::FCCAnalysesVertex V0;
   //
-  for(int i=0; i<nTr-1; i++) {
+  for (int i = 0; i < nTr - 1; i++) {
     if(result[i] == true) continue;
     t_pair[0] = np_tracks[i];
 
-    for(int j=i+1; j<nTr; j++) {
+    for (int j = i + 1; j < nTr; j++) {
       if(result[j] == true) continue;
       if(t_pair[0].omega * np_tracks[j].omega > 0) continue; // don't pair tracks with same charge (same sign curvature = same sign charge)
       t_pair[1] = np_tracks[j];
@@ -428,8 +428,8 @@ ROOT::VecOps::RVec<bool> isV0(ROOT::VecOps::RVec<edm4hep::TrackState> np_tracks,
 	result[i] = true;
 	result[j] = true;
 	break;
-      }	
-      //  
+      }
+      //
     }
   }
 
@@ -474,11 +474,11 @@ VertexingUtils::FCCAnalysesV0 get_V0s(ROOT::VecOps::RVec<edm4hep::TrackState> np
   tr_pair.push_back(tr_i);
   tr_pair.push_back(tr_j);
   //
-  for(int i=0; i<nTr-1; i++) {
+  for (int i = 0; i < nTr - 1; i++) {
     if(isInV0[i] == true) continue; // don't pair a track if it already forms a V0
     tr_pair[0] = np_tracks[i];
 
-    for(int j=i+1; j<nTr; j++) {
+    for (int j = i + 1; j < nTr; j++) {
       if(isInV0[j] == true) continue; // don't pair a track if it already forms a V0
       if(tr_pair[0].omega * np_tracks[j].omega > 0) continue; // don't pair tracks with same charge (same sign curvature = same sign charge)
       tr_pair[1] = np_tracks[j];
@@ -572,11 +572,11 @@ VertexingUtils::FCCAnalysesV0 get_V0s(ROOT::VecOps::RVec<edm4hep::TrackState> np
   tr_pair.push_back(tr_i);
   tr_pair.push_back(tr_j);
   //
-  for(int i=0; i<nTr-1; i++) {
+  for (int i = 0; i < nTr - 1; i++) {
     if(isInV0[i] == true) continue; // don't pair a track if it already forms a V0
     tr_pair[0] = np_tracks[i];
 
-    for(int j=i+1; j<nTr; j++) {
+    for (int j = i + 1; j < nTr; j++) {
       if(isInV0[j] == true) continue; // don't pair a track if it already forms a V0
       if(tr_pair[0].omega * np_tracks[j].omega > 0) continue; // don't pair tracks with same charge (same sign curvature = same sign charge)
       tr_pair[1] = np_tracks[j];
@@ -692,77 +692,89 @@ VertexingUtils::FCCAnalysesV0 get_V0s_jet(ROOT::VecOps::RVec<edm4hep::Reconstruc
     
     // remove primary tracks & separate non-primary tracks by jet
     std::vector<int> i_jetconsti = jet_consti[j];
-    for (std::size_t ctr=0; ctr<tracks.size(); ctr++) {
+    for (std::size_t ctr = 0; ctr < tracks.size(); ctr++) {
       if(isInPrimary[ctr]) continue; // remove primary tracks
       if(std::find(i_jetconsti.begin(), i_jetconsti.end(), reco_ind_tracks[ctr]) == i_jetconsti.end()) {
 	np_tracks.push_back(tracks[ctr]); // separate tracks by jet
       }
     }
-    
+
     if(debug_me) std::cout<<"primary tracks removed; there are "<<np_tracks.size()<<" non-primary tracks in jet#"<<j+1<<std::endl;
 
     int nTr = np_tracks.size();
     if(nTr<2) continue;    
     ROOT::VecOps::RVec<bool> isInV0(nTr, false);
     //
-    for(int i=0; i<nTr-1; i++) {
+    for (int i = 0; i < nTr - 1; i++) {
       if(isInV0[i] == true) continue; // don't pair a track if it already forms a V0
       tr_pair[0] = np_tracks[i];
-      
-      for(int trackIndex=i+1; trackIndex<nTr; trackIndex++) {
-	if(isInV0[trackIndex] == true) continue; // don't pair a track if it already forms a V0
-	if(tr_pair[0].omega * np_tracks[trackIndex].omega > 0) continue; // don't pair tracks with same charge (same sign curvature = same sign charge)
-	tr_pair[1] = np_tracks[trackIndex];
-	
-	ROOT::VecOps::RVec<double> V0_cand = get_V0candidate(V0_vtx, tr_pair, PV, true, chi2_cut);
-	if(V0_cand[0] == -1) continue;
-	
-	// Ks
-	if(V0_cand[0]>isKs[0] && V0_cand[0]<isKs[1] && V0_cand[4]>isKs[2] && V0_cand[5]>isKs[3]) {
-	  if(debug_me) std::cout<<"Found a Ks"<<std::endl;
-	  isInV0[i] = true;
-	  isInV0[trackIndex] = true;
-	  vtx.push_back(V0_vtx);
-	  pdgAbs.push_back(310);
-	  invM.push_back(V0_cand[0]);
-	  i_nSV++;
-	  break;
-	}
-	  
-	// Lambda0
-	else if(V0_cand[1]>isLambda0[0] && V0_cand[1]<isLambda0[1] && V0_cand[4]>isLambda0[2] && V0_cand[5]>isLambda0[3]) {
-	  if(debug_me) std::cout<<"Found a Lambda0"<<std::endl;
-	  isInV0[i] = true;
-	  isInV0[trackIndex] = true;
-	  vtx.push_back(V0_vtx);
-	  pdgAbs.push_back(3122);
-	  invM.push_back(V0_cand[1]);
-	  i_nSV++;
-	  break;
-	}
-	else if(V0_cand[2]>isLambda0[0] && V0_cand[2]<isLambda0[1] && V0_cand[4]>isLambda0[2] && V0_cand[5]>isLambda0[3]) {
-	  if(debug_me) std::cout<<"Found a Lambda0"<<std::endl;
-	  isInV0[i] = true;
-	  isInV0[trackIndex] = true;
-	  vtx.push_back(V0_vtx);
-	  pdgAbs.push_back(3122);
-	  invM.push_back(V0_cand[2]);
-	  i_nSV++;
-	  break;
-	}
-	
-	// photon conversion
-	else if(V0_cand[3]<isGamma[1] && V0_cand[4]>isGamma[2] && V0_cand[5]>isGamma[3]) {
-	  if(debug_me) std::cout<<"Found a Photon coversion"<<std::endl;
-	  isInV0[i] = true;
-	  isInV0[trackIndex] = true;
-	  vtx.push_back(V0_vtx);
-	  pdgAbs.push_back(22);
-	  invM.push_back(V0_cand[3]);
-	  i_nSV++;
-	  break;
-	}
-	//      
+
+      for (int trackIndex = i + 1; trackIndex < nTr; trackIndex++) {
+        if (isInV0[trackIndex] == true)
+          continue; // don't pair a track if it already forms a V0
+        if (tr_pair[0].omega * np_tracks[trackIndex].omega > 0)
+          continue; // don't pair tracks with same charge (same sign curvature =
+                    // same sign charge)
+        tr_pair[1] = np_tracks[trackIndex];
+
+        ROOT::VecOps::RVec<double> V0_cand =
+            get_V0candidate(V0_vtx, tr_pair, PV, true, chi2_cut);
+        if (V0_cand[0] == -1)
+          continue;
+
+        // Ks
+        if (V0_cand[0] > isKs[0] && V0_cand[0] < isKs[1] &&
+            V0_cand[4] > isKs[2] && V0_cand[5] > isKs[3]) {
+          if (debug_me)
+            std::cout << "Found a Ks" << std::endl;
+          isInV0[i] = true;
+          isInV0[trackIndex] = true;
+          vtx.push_back(V0_vtx);
+          pdgAbs.push_back(310);
+          invM.push_back(V0_cand[0]);
+          i_nSV++;
+          break;
+        }
+
+        // Lambda0
+        else if (V0_cand[1] > isLambda0[0] && V0_cand[1] < isLambda0[1] &&
+                 V0_cand[4] > isLambda0[2] && V0_cand[5] > isLambda0[3]) {
+          if (debug_me)
+            std::cout << "Found a Lambda0" << std::endl;
+          isInV0[i] = true;
+          isInV0[trackIndex] = true;
+          vtx.push_back(V0_vtx);
+          pdgAbs.push_back(3122);
+          invM.push_back(V0_cand[1]);
+          i_nSV++;
+          break;
+        } else if (V0_cand[2] > isLambda0[0] && V0_cand[2] < isLambda0[1] &&
+                   V0_cand[4] > isLambda0[2] && V0_cand[5] > isLambda0[3]) {
+          if (debug_me)
+            std::cout << "Found a Lambda0" << std::endl;
+          isInV0[i] = true;
+          isInV0[trackIndex] = true;
+          vtx.push_back(V0_vtx);
+          pdgAbs.push_back(3122);
+          invM.push_back(V0_cand[2]);
+          i_nSV++;
+          break;
+        }
+
+        // photon conversion
+        else if (V0_cand[3] < isGamma[1] && V0_cand[4] > isGamma[2] &&
+                 V0_cand[5] > isGamma[3]) {
+          if (debug_me)
+            std::cout << "Found a Photon coversion" << std::endl;
+          isInV0[i] = true;
+          isInV0[trackIndex] = true;
+          vtx.push_back(V0_vtx);
+          pdgAbs.push_back(22);
+          invM.push_back(V0_cand[3]);
+          i_nSV++;
+          break;
+        }
+        //
       }
     }
 

--- a/analyzers/dataframe/src/VertexFinderLCFIPlus.cc
+++ b/analyzers/dataframe/src/VertexFinderLCFIPlus.cc
@@ -708,10 +708,10 @@ VertexingUtils::FCCAnalysesV0 get_V0s_jet(ROOT::VecOps::RVec<edm4hep::Reconstruc
       if(isInV0[i] == true) continue; // don't pair a track if it already forms a V0
       tr_pair[0] = np_tracks[i];
       
-      for(unsigned int j=i+1; j<nTr; j++) {
-	if(isInV0[j] == true) continue; // don't pair a track if it already forms a V0
-	if(tr_pair[0].omega * np_tracks[j].omega > 0) continue; // don't pair tracks with same charge (same sign curvature = same sign charge)
-	tr_pair[1] = np_tracks[j];
+      for(unsigned int trackIndex=i+1; trackIndex<nTr; trackIndex++) {
+	if(isInV0[trackIndex] == true) continue; // don't pair a track if it already forms a V0
+	if(tr_pair[0].omega * np_tracks[trackIndex].omega > 0) continue; // don't pair tracks with same charge (same sign curvature = same sign charge)
+	tr_pair[1] = np_tracks[trackIndex];
 	
 	ROOT::VecOps::RVec<double> V0_cand = get_V0candidate(V0_vtx, tr_pair, PV, true, chi2_cut);
 	if(V0_cand[0] == -1) continue;
@@ -720,7 +720,7 @@ VertexingUtils::FCCAnalysesV0 get_V0s_jet(ROOT::VecOps::RVec<edm4hep::Reconstruc
 	if(V0_cand[0]>isKs[0] && V0_cand[0]<isKs[1] && V0_cand[4]>isKs[2] && V0_cand[5]>isKs[3]) {
 	  if(debug_me) std::cout<<"Found a Ks"<<std::endl;
 	  isInV0[i] = true;
-	  isInV0[j] = true;
+	  isInV0[trackIndex] = true;
 	  vtx.push_back(V0_vtx);
 	  pdgAbs.push_back(310);
 	  invM.push_back(V0_cand[0]);
@@ -732,7 +732,7 @@ VertexingUtils::FCCAnalysesV0 get_V0s_jet(ROOT::VecOps::RVec<edm4hep::Reconstruc
 	else if(V0_cand[1]>isLambda0[0] && V0_cand[1]<isLambda0[1] && V0_cand[4]>isLambda0[2] && V0_cand[5]>isLambda0[3]) {
 	  if(debug_me) std::cout<<"Found a Lambda0"<<std::endl;
 	  isInV0[i] = true;
-	  isInV0[j] = true;
+	  isInV0[trackIndex] = true;
 	  vtx.push_back(V0_vtx);
 	  pdgAbs.push_back(3122);
 	  invM.push_back(V0_cand[1]);
@@ -742,7 +742,7 @@ VertexingUtils::FCCAnalysesV0 get_V0s_jet(ROOT::VecOps::RVec<edm4hep::Reconstruc
 	else if(V0_cand[2]>isLambda0[0] && V0_cand[2]<isLambda0[1] && V0_cand[4]>isLambda0[2] && V0_cand[5]>isLambda0[3]) {
 	  if(debug_me) std::cout<<"Found a Lambda0"<<std::endl;
 	  isInV0[i] = true;
-	  isInV0[j] = true;
+	  isInV0[trackIndex] = true;
 	  vtx.push_back(V0_vtx);
 	  pdgAbs.push_back(3122);
 	  invM.push_back(V0_cand[2]);
@@ -754,7 +754,7 @@ VertexingUtils::FCCAnalysesV0 get_V0s_jet(ROOT::VecOps::RVec<edm4hep::Reconstruc
 	else if(V0_cand[3]<isGamma[1] && V0_cand[4]>isGamma[2] && V0_cand[5]>isGamma[3]) {
 	  if(debug_me) std::cout<<"Found a Photon coversion"<<std::endl;
 	  isInV0[i] = true;
-	  isInV0[j] = true;
+	  isInV0[trackIndex] = true;
 	  vtx.push_back(V0_vtx);
 	  pdgAbs.push_back(22);
 	  invM.push_back(V0_cand[3]);

--- a/analyzers/dataframe/src/VertexFinderLCFIPlus.cc
+++ b/analyzers/dataframe/src/VertexFinderLCFIPlus.cc
@@ -2,6 +2,7 @@
 // contact: kunal.gautam@cern.ch
 
 #include "FCCAnalyses/VertexFinderLCFIPlus.h"
+#include <cstddef>
 #include <iostream>
 
 namespace FCCAnalyses{
@@ -44,7 +45,7 @@ ROOT::VecOps::RVec<ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex>> get_SV
 
     // remove primary tracks & separate non-primary tracks by jet
     std::vector<int> i_jetconsti = jet_consti[j];
-    for (int ctr=0; ctr<tracks.size(); ctr++) {
+    for (std::size_t ctr=0; ctr<tracks.size(); ctr++) {
       if(isInPrimary[ctr]) continue; // remove primary tracks
       if(std::find(i_jetconsti.begin(), i_jetconsti.end(), reco_ind_tracks[ctr]) == i_jetconsti.end()) {
 	np_tracks.push_back(tracks[ctr]); // separate tracks by jet
@@ -170,10 +171,10 @@ ROOT::VecOps::RVec<int> VertexSeed_best(ROOT::VecOps::RVec<edm4hep::TrackState> 
   VertexingUtils::FCCAnalysesVertex vtx_seed;
   double chi2_min = 99;
   
-  for(unsigned int i=0; i<nTr-1; i++) {
+  for(int i=0; i<nTr-1; i++) {
     tr_pair[0] = tracks[i];
     
-    for(unsigned int j=i+1; j<nTr; j++) {
+    for(int j=i+1; j<nTr; j++) {
       tr_pair[1] = tracks[j];
       
       // V0 rejection (loose)
@@ -230,7 +231,7 @@ ROOT::VecOps::RVec<int> addTrack_best(ROOT::VecOps::RVec<edm4hep::TrackState> tr
   tr_vtx.push_back(tr_i);
 
   // find best track to add to the vtx
-  for(unsigned int i=0; i<nTr; i++) {
+  for(int i=0; i<nTr; i++) {
     if(std::find(vtx_tr.begin(), vtx_tr.end(), i) != vtx_tr.end()) continue;
     tr_vtx[iTr] = tracks[i];
     
@@ -285,14 +286,14 @@ ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> findSVfromTracks(ROOT::Vec
     
     if(debug_me){
       std::cout << "tracks_fin.size(): " << tracks_fin.size() << std::endl;
-      for(int i=0; i<vtx_seed.size();i++)
+      for(std::size_t i=0; i<vtx_seed.size();i++)
 	std::cout << "vtx_seed: " << vtx_seed[i] << std::endl;
     }
     if(vtx_seed.size() == 0) break;
     
     // add tracks to the seed, check if a track is added; if not break loop
     ROOT::VecOps::RVec<int> vtx_fin = vtx_seed;
-    int vtx_fin_size = 0; // to start the loop
+    std::size_t vtx_fin_size = 0; // to start the loop
     while(vtx_fin_size != vtx_fin.size()) {
       vtx_fin_size = vtx_fin.size();
       vtx_fin = addTrack_best(tracks_fin, vtx_fin, PV, chi2_cut, invM_cut, chi2Tr_cut);
@@ -392,11 +393,11 @@ ROOT::VecOps::RVec<bool> isV0(ROOT::VecOps::RVec<edm4hep::TrackState> np_tracks,
   t_pair.push_back(tr_j);
   VertexingUtils::FCCAnalysesVertex V0;
   //
-  for(unsigned int i=0; i<nTr-1; i++) {
+  for(int i=0; i<nTr-1; i++) {
     if(result[i] == true) continue;
     t_pair[0] = np_tracks[i];
 
-    for(unsigned int j=i+1; j<nTr; j++) {
+    for(int j=i+1; j<nTr; j++) {
       if(result[j] == true) continue;
       if(t_pair[0].omega * np_tracks[j].omega > 0) continue; // don't pair tracks with same charge (same sign curvature = same sign charge)
       t_pair[1] = np_tracks[j];
@@ -473,11 +474,11 @@ VertexingUtils::FCCAnalysesV0 get_V0s(ROOT::VecOps::RVec<edm4hep::TrackState> np
   tr_pair.push_back(tr_i);
   tr_pair.push_back(tr_j);
   //
-  for(unsigned int i=0; i<nTr-1; i++) {
+  for(int i=0; i<nTr-1; i++) {
     if(isInV0[i] == true) continue; // don't pair a track if it already forms a V0
     tr_pair[0] = np_tracks[i];
 
-    for(unsigned int j=i+1; j<nTr; j++) {
+    for(int j=i+1; j<nTr; j++) {
       if(isInV0[j] == true) continue; // don't pair a track if it already forms a V0
       if(tr_pair[0].omega * np_tracks[j].omega > 0) continue; // don't pair tracks with same charge (same sign curvature = same sign charge)
       tr_pair[1] = np_tracks[j];
@@ -571,11 +572,11 @@ VertexingUtils::FCCAnalysesV0 get_V0s(ROOT::VecOps::RVec<edm4hep::TrackState> np
   tr_pair.push_back(tr_i);
   tr_pair.push_back(tr_j);
   //
-  for(unsigned int i=0; i<nTr-1; i++) {
+  for(int i=0; i<nTr-1; i++) {
     if(isInV0[i] == true) continue; // don't pair a track if it already forms a V0
     tr_pair[0] = np_tracks[i];
 
-    for(unsigned int j=i+1; j<nTr; j++) {
+    for(int j=i+1; j<nTr; j++) {
       if(isInV0[j] == true) continue; // don't pair a track if it already forms a V0
       if(tr_pair[0].omega * np_tracks[j].omega > 0) continue; // don't pair tracks with same charge (same sign curvature = same sign charge)
       tr_pair[1] = np_tracks[j];
@@ -691,7 +692,7 @@ VertexingUtils::FCCAnalysesV0 get_V0s_jet(ROOT::VecOps::RVec<edm4hep::Reconstruc
     
     // remove primary tracks & separate non-primary tracks by jet
     std::vector<int> i_jetconsti = jet_consti[j];
-    for (int ctr=0; ctr<tracks.size(); ctr++) {
+    for (std::size_t ctr=0; ctr<tracks.size(); ctr++) {
       if(isInPrimary[ctr]) continue; // remove primary tracks
       if(std::find(i_jetconsti.begin(), i_jetconsti.end(), reco_ind_tracks[ctr]) == i_jetconsti.end()) {
 	np_tracks.push_back(tracks[ctr]); // separate tracks by jet
@@ -704,11 +705,11 @@ VertexingUtils::FCCAnalysesV0 get_V0s_jet(ROOT::VecOps::RVec<edm4hep::Reconstruc
     if(nTr<2) continue;    
     ROOT::VecOps::RVec<bool> isInV0(nTr, false);
     //
-    for(unsigned int i=0; i<nTr-1; i++) {
+    for(int i=0; i<nTr-1; i++) {
       if(isInV0[i] == true) continue; // don't pair a track if it already forms a V0
       tr_pair[0] = np_tracks[i];
       
-      for(unsigned int trackIndex=i+1; trackIndex<nTr; trackIndex++) {
+      for(int trackIndex=i+1; trackIndex<nTr; trackIndex++) {
 	if(isInV0[trackIndex] == true) continue; // don't pair a track if it already forms a V0
 	if(tr_pair[0].omega * np_tracks[trackIndex].omega > 0) continue; // don't pair tracks with same charge (same sign curvature = same sign charge)
 	tr_pair[1] = np_tracks[trackIndex];

--- a/analyzers/dataframe/src/VertexFitterSimple.cc
+++ b/analyzers/dataframe/src/VertexFitterSimple.cc
@@ -1,6 +1,6 @@
 #include "FCCAnalyses/VertexFitterSimple.h"
-#include <cstddef>
 #include "FCCAnalyses/MCParticle.h"
+#include <cstddef>
 
 #include "edm4hep/EDM4hepVersion.h"
 
@@ -69,7 +69,7 @@ VertexingUtils::FCCAnalysesVertex VertexFitter(
   for (auto &p : recoparticles) {
     // std::cout << " in VertexFitter:  a recoparticle with charge = " <<
     // p.charge << std::endl;
-  if (p.tracks_begin < thetracks.size()) {
+    if (p.tracks_begin < thetracks.size()) {
       reco_ind.push_back(p.tracks_begin);
     }
   }

--- a/analyzers/dataframe/src/VertexFitterSimple.cc
+++ b/analyzers/dataframe/src/VertexFitterSimple.cc
@@ -69,7 +69,7 @@ VertexingUtils::FCCAnalysesVertex VertexFitter(
   for (auto &p : recoparticles) {
     // std::cout << " in VertexFitter:  a recoparticle with charge = " <<
     // p.charge << std::endl;
-    if (p.tracks_begin >= 0 && p.tracks_begin < thetracks.size()) {
+  if (p.tracks_begin < thetracks.size()) {
       reco_ind.push_back(p.tracks_begin);
     }
   }

--- a/analyzers/dataframe/src/VertexFitterSimple.cc
+++ b/analyzers/dataframe/src/VertexFitterSimple.cc
@@ -1,4 +1,5 @@
 #include "FCCAnalyses/VertexFitterSimple.h"
+#include <cstddef>
 #include "FCCAnalyses/MCParticle.h"
 
 #include "edm4hep/EDM4hepVersion.h"
@@ -64,7 +65,7 @@ VertexingUtils::FCCAnalysesVertex VertexFitter(
 
   // fill the indices of the tracks
   ROOT::VecOps::RVec<int> reco_ind;
-  int Ntr = tracks.size();
+  const std::size_t Ntr = tracks.size();
   for (auto &p : recoparticles) {
     // std::cout << " in VertexFitter:  a recoparticle with charge = " <<
     // p.charge << std::endl;
@@ -123,9 +124,9 @@ VertexFitter_Tk(int Primary, ROOT::VecOps::RVec<edm4hep::TrackState> tracks,
   // if the collection of all tracks has been passed, keep trace of the indices
   // of the tracks that are used to fit this vertex
   if (alltracks.size() > 0) {
-    for (int i = 0; i < tracks.size(); i++) { // the fitted tracks
+    for (std::size_t i = 0; i < tracks.size(); i++) { // the fitted tracks
       edm4hep::TrackState tr1 = tracks[i];
-      for (int j = 0; j < alltracks.size();
+      for (std::size_t j = 0; j < alltracks.size();
            j++) { // the collection of all tracks
         edm4hep::TrackState tr2 = alltracks[j];
         if (VertexingUtils::compare_Tracks(tr1, tr2)) {

--- a/analyzers/dataframe/src/VertexingUtils.cc
+++ b/analyzers/dataframe/src/VertexingUtils.cc
@@ -1,6 +1,6 @@
 #include "FCCAnalyses/VertexingUtils.h"
-#include <cstddef>
 #include "FCCAnalyses/VertexFitterSimple.h"
+#include <cstddef>
 
 #include "TrkUtil.h" // from delphes
 

--- a/analyzers/dataframe/src/VertexingUtils.cc
+++ b/analyzers/dataframe/src/VertexingUtils.cc
@@ -1422,7 +1422,6 @@ get_d3d_SV(ROOT::VecOps::RVec<ROOT::VecOps::RVec<FCCAnalysesVertex>> vertices,
 ROOT::VecOps::RVec<ROOT::VecOps::RVec<TVector3>> get_position_SV(
     ROOT::VecOps::RVec<ROOT::VecOps::RVec<FCCAnalysesVertex>> vertices) {
   ROOT::VecOps::RVec<ROOT::VecOps::RVec<TVector3>> result;
-  ROOT::VecOps::RVec<TVector3> i_result;
 
   for (unsigned int i = 0; i < vertices.size(); i++) {
     ROOT::VecOps::RVec<TVector3> i_result;

--- a/analyzers/dataframe/src/VertexingUtils.cc
+++ b/analyzers/dataframe/src/VertexingUtils.cc
@@ -1,4 +1,5 @@
 #include "FCCAnalyses/VertexingUtils.h"
+#include <cstddef>
 #include "FCCAnalyses/VertexFitterSimple.h"
 
 #include "TrkUtil.h" // from delphes
@@ -303,7 +304,7 @@ FCCAnalysesVertex
 get_FCCAnalysesVertex(ROOT::VecOps::RVec<FCCAnalysesVertex> TheVertexColl,
                       int index) {
   FCCAnalysesVertex result;
-  if (index < TheVertexColl.size())
+  if (index >= 0 && static_cast<std::size_t>(index) < TheVertexColl.size())
     result = TheVertexColl.at(index);
   return result;
 }
@@ -328,7 +329,7 @@ get_VertexData(ROOT::VecOps::RVec<FCCAnalysesVertex> TheVertexColl) {
 edm4hep::VertexData
 get_VertexData(ROOT::VecOps::RVec<FCCAnalysesVertex> TheVertexColl, int index) {
   edm4hep::VertexData result;
-  if (index < TheVertexColl.size())
+  if (index >= 0 && static_cast<std::size_t>(index) < TheVertexColl.size())
     result = TheVertexColl.at(index).vertex;
   return result;
 }
@@ -354,13 +355,14 @@ ROOT::VecOps::RVec<int> get_VertexRecoParticlesInd(
 
   ROOT::VecOps::RVec<int> result;
   ROOT::VecOps::RVec<int> indices_tracks = TheVertex.reco_ind;
-  for (int i = 0; i < indices_tracks.size(); i++) {
-    int tk_index = indices_tracks[i];
-    for (int j = 0; j < reco.size(); j++) {
+  for (std::size_t i = 0; i < indices_tracks.size(); i++) {
+    const int tk_index = indices_tracks[i];
+    for (std::size_t j = 0; j < reco.size(); j++) {
       auto &p = reco[j];
       if (p.tracks_begin == p.tracks_end)
         continue;
-      if (p.tracks_begin == tk_index) {
+      if (tk_index >= 0 &&
+          p.tracks_begin == static_cast<unsigned int>(tk_index)) {
         result.push_back(j);
         break;
       }
@@ -473,7 +475,7 @@ double get_invM_pairs(FCCAnalysesVertex vertex, double m1, double m2) {
   double m[2] = {m1, m2};
   int nTr = p_tracks.size();
 
-  for (unsigned int i = 0; i < nTr; i++) {
+  for (int i = 0; i < nTr; i++) {
     TLorentzVector p4_tr;
     p4_tr.SetXYZM(p_tracks[i].X(), p_tracks[i].Y(), p_tracks[i].Z(), m[i]);
     p4_vtx += p4_tr;
@@ -499,7 +501,7 @@ get_invM_pairs(ROOT::VecOps::RVec<FCCAnalysesVertex> vertices, double m1,
     double m[2] = {m1, m2};
     int nTr = p_tracks.size();
 
-    for (unsigned int i = 0; i < nTr; i++) {
+    for (int i = 0; i < nTr; i++) {
       TLorentzVector p4_tr;
       p4_tr.SetXYZM(p_tracks[i].X(), p_tracks[i].Y(), p_tracks[i].Z(), m[i]);
       p4_vtx += p4_tr;
@@ -938,16 +940,16 @@ get_relTheta_SV(ROOT::VecOps::RVec<FCCAnalysesVertex> vertices,
                 ROOT::VecOps::RVec<fastjet::PseudoJet> jets) {
   ROOT::VecOps::RVec<double> result;
 
-  unsigned int j = 0;
-  int nSV = nSV_jet[0];
-  for (unsigned int i = 0; i < vertices.size(); i++) {
+  std::size_t j = 0;
+  std::size_t nSV = static_cast<std::size_t>(nSV_jet[0]);
+  for (std::size_t i = 0; i < vertices.size(); i++) {
     auto &ivtx = vertices[i];
     TVector3 xyz(ivtx.vertex.position[0], ivtx.vertex.position[1],
                  ivtx.vertex.position[2]);
 
     if (i >= nSV) {
       j++;
-      nSV += nSV_jet[j];
+      nSV += static_cast<std::size_t>(nSV_jet[j]);
     }
     auto &ijet = jets[j];
     double jetTheta = ijet.theta();
@@ -965,16 +967,16 @@ get_relPhi_SV(ROOT::VecOps::RVec<FCCAnalysesVertex> vertices,
               ROOT::VecOps::RVec<fastjet::PseudoJet> jets) {
   ROOT::VecOps::RVec<double> result;
 
-  unsigned int j = 0;
-  int nSV = nSV_jet[0];
-  for (unsigned int i = 0; i < vertices.size(); i++) {
+  std::size_t j = 0;
+  std::size_t nSV = static_cast<std::size_t>(nSV_jet[0]);
+  for (std::size_t i = 0; i < vertices.size(); i++) {
     auto &ivtx = vertices[i];
     TVector3 xyz(ivtx.vertex.position[0], ivtx.vertex.position[1],
                  ivtx.vertex.position[2]);
 
     if (i >= nSV) {
       j++;
-      nSV += nSV_jet[j];
+      nSV += static_cast<std::size_t>(nSV_jet[j]);
     }
     auto &ijet = jets[j];
     TVector3 jetP(ijet.px(), ijet.py(), ijet.pz());
@@ -1040,13 +1042,13 @@ std::vector<std::vector<edm4hep::TrackState>> get_tracksInJets(
 
   int nJet = jets.size();
   //
-  for (unsigned int j = 0; j < nJet; j++) {
+  for (int j = 0; j < nJet; j++) {
 
     std::vector<int> i_jetconsti = jet_consti[j];
 
     for (unsigned int ip : i_jetconsti) {
       auto &p = recoparticles[ip];
-      if (p.tracks_begin >= 0 && p.tracks_begin < thetracks.size())
+      if (p.tracks_begin < thetracks.size())
         iJet_tracks.push_back(thetracks.at(p.tracks_begin));
     }
 

--- a/analyzers/dataframe/src/WeaverUtils.cc
+++ b/analyzers/dataframe/src/WeaverUtils.cc
@@ -1,8 +1,8 @@
 #include "FCCAnalyses/WeaverUtils.h"
 #include "ONNXRuntime/WeaverInterface.h"
 
-#include <memory>
 #include <cstddef>
+#include <memory>
 
 namespace FCCAnalyses {
   std::unique_ptr<WeaverInterface> gWeaver2;

--- a/analyzers/dataframe/src/WeaverUtils.cc
+++ b/analyzers/dataframe/src/WeaverUtils.cc
@@ -2,6 +2,7 @@
 #include "ONNXRuntime/WeaverInterface.h"
 
 #include <memory>
+#include <cstddef>
 
 namespace FCCAnalyses {
   std::unique_ptr<WeaverInterface> gWeaver2;
@@ -46,9 +47,9 @@ namespace FCCAnalyses {
         throw std::runtime_error("Invalid index requested for object weight " + std::to_string(weight) + ".");
       ROOT::VecOps::RVec<float> out;
       for (const auto& object_weights : objects_weights) {
-        if (weight >= object_weights.size())
+        if (static_cast<std::size_t>(weight) >= object_weights.size())
           throw std::runtime_error("Flavour weight index exceeds the number of weights registered.");
-        out.emplace_back(object_weights.at(weight));
+        out.emplace_back(object_weights.at(static_cast<std::size_t>(weight)));
       }
       return out;
     }

--- a/analyzers/dataframe/src/myFinalSel.cc
+++ b/analyzers/dataframe/src/myFinalSel.cc
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <cstdlib>
+#include <cstddef>
 #include <vector>
 
 namespace FCCAnalyses{
@@ -90,7 +91,7 @@ float get_min(ROOT::VecOps::RVec<float> in,
 
   for (size_t i = 0; i < in.size(); ++i){
     if (ispv.at(i)>0)continue;
-    if (index==i)continue;
+    if (index >= 0 && static_cast<std::size_t>(index) == i)continue;
     if (in.at(i)<min)min=in.at(i);
   }
   return min;
@@ -102,7 +103,7 @@ float get_max(ROOT::VecOps::RVec<float> in,
 
   for (size_t i = 0; i < in.size(); ++i){
     if (ispv.at(i)>0)continue;
-    if (index==i)continue;
+    if (index >= 0 && static_cast<std::size_t>(index) == i)continue;
     if (in.at(i)>max)max=in.at(i);
   }
   return max;
@@ -117,7 +118,7 @@ float get_ave(ROOT::VecOps::RVec<float> in,
   float aven=0.;
   for (size_t i = 0; i < in.size(); ++i){
     if (ispv.at(i)>0)continue;
-    if (index==i)continue;
+    if (index >= 0 && static_cast<std::size_t>(index) == i)continue;
 
     ave+=in.at(i);
     aven+=1.;

--- a/analyzers/dataframe/src/myFinalSel.cc
+++ b/analyzers/dataframe/src/myFinalSel.cc
@@ -1,8 +1,8 @@
 #include "FCCAnalyses/myFinalSel.h"
 
-#include <iostream>
-#include <cstdlib>
 #include <cstddef>
+#include <cstdlib>
+#include <iostream>
 #include <vector>
 
 namespace FCCAnalyses{
@@ -91,7 +91,8 @@ float get_min(ROOT::VecOps::RVec<float> in,
 
   for (size_t i = 0; i < in.size(); ++i){
     if (ispv.at(i)>0)continue;
-    if (index >= 0 && static_cast<std::size_t>(index) == i)continue;
+    if (index >= 0 && static_cast<std::size_t>(index) == i)
+      continue;
     if (in.at(i)<min)min=in.at(i);
   }
   return min;
@@ -103,7 +104,8 @@ float get_max(ROOT::VecOps::RVec<float> in,
 
   for (size_t i = 0; i < in.size(); ++i){
     if (ispv.at(i)>0)continue;
-    if (index >= 0 && static_cast<std::size_t>(index) == i)continue;
+    if (index >= 0 && static_cast<std::size_t>(index) == i)
+      continue;
     if (in.at(i)>max)max=in.at(i);
   }
   return max;
@@ -118,7 +120,8 @@ float get_ave(ROOT::VecOps::RVec<float> in,
   float aven=0.;
   for (size_t i = 0; i < in.size(); ++i){
     if (ispv.at(i)>0)continue;
-    if (index >= 0 && static_cast<std::size_t>(index) == i)continue;
+    if (index >= 0 && static_cast<std::size_t>(index) == i)
+      continue;
 
     ave+=in.at(i);
     aven+=1.;

--- a/analyzers/dataframe/src/myUtils.cc
+++ b/analyzers/dataframe/src/myUtils.cc
@@ -1,9 +1,9 @@
 #include "FCCAnalyses/myUtils.h"
 
 // std
-#include <iostream>
-#include <cstdlib>
 #include <cstddef>
+#include <cstdlib>
+#include <iostream>
 #include <vector>
 
 // EDM4hep
@@ -502,7 +502,7 @@ ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertexMC> get_MCVertexObject(ROOT:
       ROOT::VecOps::RVec<int> vertexIndices;
       vertexIndices.push_back(tmpvecint.at(i));
       vertex.vertex=vertexPos;
-      vertex.mc_ind=vertexIndices;
+      vertex.mc_ind = vertexIndices;
       result.push_back(vertex);
     }
     else{
@@ -783,12 +783,11 @@ ROOT::VecOps::RVec<int> getMC_daughter(int daughterindex,
 						ROOT::VecOps::RVec<int> ind){
   ROOT::VecOps::RVec<int> result;
   for (size_t i = 0; i < in.size(); ++i) {
-  if (daughterindex < 0 ||
-      static_cast<unsigned int>(daughterindex) >=
-          in.at(i).daughters_end - in.at(i).daughters_begin) {
+    if (daughterindex < 0 ||
+        static_cast<unsigned int>(daughterindex) >=
+            in.at(i).daughters_end - in.at(i).daughters_begin) {
       result.push_back(-999);
-    }
-    else {
+    } else {
       result.push_back(ind.at(in.at(i).daughters_begin+daughterindex));
     }
   }
@@ -800,12 +799,10 @@ ROOT::VecOps::RVec<int> getMC_parent(int parentindex,
 					      ROOT::VecOps::RVec<int> ind){
   ROOT::VecOps::RVec<int> result;
   for (size_t i = 0; i < in.size(); ++i) {
-  if (parentindex < 0 ||
-      static_cast<unsigned int>(parentindex) >=
-          in.at(i).parents_end - in.at(i).parents_begin) {
+    if (parentindex < 0 || static_cast<unsigned int>(parentindex) >=
+                               in.at(i).parents_end - in.at(i).parents_begin) {
       result.push_back(-999);
-    }
-    else {
+    } else {
       result.push_back(ind.at(in.at(i).parents_begin+parentindex));
     }
   }
@@ -816,24 +813,21 @@ int getMC_parent(int parentindex,
 			  edm4hep::MCParticleData in,
 			  ROOT::VecOps::RVec<int> ind){
   int result;
-  if (parentindex < 0 ||
-      static_cast<unsigned int>(parentindex) >= in.parents_end - in.parents_begin)
+  if (parentindex < 0 || static_cast<unsigned int>(parentindex) >=
+                             in.parents_end - in.parents_begin)
     result = -999;
   else
     result = ind.at(in.parents_begin+parentindex);
   return result;
 }
 
-
-ROOT::VecOps::RVec<FCCAnalysesComposite> add_truthmatched(ROOT::VecOps::RVec<FCCAnalysesComposite> comp,
-								   ROOT::VecOps::RVec<edm4hep::MCParticleData> mc,
-								   //ROOT::VecOps::RVec<ROOT::VecOps::RVec<int>> rp2mc){
-								   ROOT::VecOps::RVec<int> rp2mc,
- ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>,
-								   ROOT::VecOps::RVec<int> ind){
-
-
-
+ROOT::VecOps::RVec<FCCAnalysesComposite>
+add_truthmatched(ROOT::VecOps::RVec<FCCAnalysesComposite> comp,
+                 ROOT::VecOps::RVec<edm4hep::MCParticleData> mc,
+                 // ROOT::VecOps::RVec<ROOT::VecOps::RVec<int>> rp2mc){
+                 ROOT::VecOps::RVec<int> rp2mc,
+                 ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>,
+                 ROOT::VecOps::RVec<int> ind) {
 
   for (size_t i = 0; i < comp.size(); ++i) {
     //std::cout << "compo " << i << "  charge " << comp.at(i).charge<< std::endl;
@@ -847,7 +841,7 @@ ROOT::VecOps::RVec<FCCAnalysesComposite> add_truthmatched(ROOT::VecOps::RVec<FCC
       int mcassoc = rp2mc.at(index.at(j));
       //if (mcassoc.size()==1){
       //mother.push_back(mcassoc.at(0));
-      int mother1=getMC_parent(0, mc.at(mcassoc), ind);
+      int mother1 = getMC_parent(0, mc.at(mcassoc), ind);
       mother.push_back(mother1);
       motherPDG.push_back(mc.at(mother1).PDG);
       //std::cout << "mother 1 "<<mother1<<"  mother2  " << mother2<< std::endl;
@@ -885,8 +879,6 @@ ROOT::VecOps::RVec<FCCAnalysesComposite> add_truthmatched(ROOT::VecOps::RVec<FCC
    return comp;
 }
 
-
-
 ROOT::VecOps::RVec<int> get_trueVertex(ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertexMC> vertex,
 						ROOT::VecOps::RVec<edm4hep::MCParticleData> mc,
 						ROOT::VecOps::RVec<int> ind,
@@ -919,13 +911,13 @@ ROOT::VecOps::RVec<int> get_trueVertex(ROOT::VecOps::RVec<VertexingUtils::FCCAna
   return result;
 }
 
-ROOT::VecOps::RVec<FCCAnalysesComposite2> add_truthmatched2(ROOT::VecOps::RVec<FCCAnalysesComposite2> comp,
-								     ROOT::VecOps::RVec<edm4hep::MCParticleData> mc,
-								     ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
-								     ROOT::VecOps::RVec<int> rp2mc,
- ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>,
-								     ROOT::VecOps::RVec<int> ind){
-
+ROOT::VecOps::RVec<FCCAnalysesComposite2>
+add_truthmatched2(ROOT::VecOps::RVec<FCCAnalysesComposite2> comp,
+                  ROOT::VecOps::RVec<edm4hep::MCParticleData> mc,
+                  ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
+                  ROOT::VecOps::RVec<int> rp2mc,
+                  ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>,
+                  ROOT::VecOps::RVec<int> ind) {
 
   for (size_t i = 0; i < comp.size(); ++i) {
     ROOT::VecOps::RVec<int> index = vertex.at(comp.at(i).vertex).reco_ind;
@@ -935,7 +927,7 @@ ROOT::VecOps::RVec<FCCAnalysesComposite2> add_truthmatched2(ROOT::VecOps::RVec<F
     for (size_t j = 0; j < index.size(); ++j) {
 
       int mcassoc = rp2mc.at(index.at(j));
-      int mother1=getMC_parent(0, mc.at(mcassoc), ind);
+      int mother1 = getMC_parent(0, mc.at(mcassoc), ind);
       mother.push_back(mother1);
       motherPDG.push_back(mc.at(mother1).PDG);
     }
@@ -1051,7 +1043,10 @@ filter_PV::operator()(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
     for (size_t i = 0; i < index.size(); ++i) {
       const int track_index = index.at(i);
       if (track_index >= 0 &&
-          p.tracks_begin == static_cast<unsigned int>(track_index)) {found=true; break;}
+          p.tracks_begin == static_cast<unsigned int>(track_index)) {
+        found = true;
+        break;
+      }
     }
     if (found==false && m_pv==false)result.push_back(p);
     else if (found==true && m_pv==true)result.push_back(p);
@@ -1467,7 +1462,8 @@ bool isPV(edm4hep::ReconstructedParticleData recop, ROOT::VecOps::RVec<int> pvin
   for (size_t i = 0; i < pvindex.size(); ++i) {
     const int track_index = pvindex.at(i);
     if (track_index >= 0 &&
-        recop.tracks_begin == static_cast<unsigned int>(track_index)) return true;
+        recop.tracks_begin == static_cast<unsigned int>(track_index))
+      return true;
   }
   return false;
 }
@@ -1646,10 +1642,9 @@ ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> get_RP_atVertex(ROOT::Vec
   return recop;
 }
 
-
-
-
-float build_invmass(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop, ROOT::VecOps::RVec<int> index){
+float build_invmass(
+    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop,
+    ROOT::VecOps::RVec<int> index) {
   TLorentzVector tlv;
   for (size_t i=0;i<index.size();i++){
     TLorentzVector tmp_tlv = ReconstructedParticle::get_tlv(recop[index.at(i)]);
@@ -1658,7 +1653,9 @@ float build_invmass(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop
   return tlv.M();
 }
 
-TLorentzVector build_tlv(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop, ROOT::VecOps::RVec<int> index){
+TLorentzVector
+build_tlv(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop,
+          ROOT::VecOps::RVec<int> index) {
   TLorentzVector tlv;
   for (size_t i=0;i<index.size();i++){
     TLorentzVector tmp_tlv = ReconstructedParticle::get_tlv(recop[index.at(i)]);
@@ -1666,7 +1663,6 @@ TLorentzVector build_tlv(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> 
   }
   return tlv;
 }
-
 
 ROOT::VecOps::RVec<FCCAnalysesComposite2> build_tau23pi(ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
 								 ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop){
@@ -1985,10 +1981,13 @@ ROOT::VecOps::RVec<FCCAnalysesComposite2> build_Bd2MuMu(ROOT::VecOps::RVec<Verte
   return result;
 }
 
-sel_tau23pi::sel_tau23pi(float arg_masslow, float arg_masshigh, float arg_p, float arg_angle, bool arg_rho):m_masslow(arg_masslow),m_masshigh(arg_masshigh),m_p(arg_p),m_angle(arg_angle),m_rho(arg_rho){};
-ROOT::VecOps::RVec<FCCAnalysesComposite2>
-sel_tau23pi::operator() (ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
-				    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop){
+sel_tau23pi::sel_tau23pi(float arg_masslow, float arg_masshigh, float arg_p,
+                         float arg_angle, bool arg_rho)
+    : m_masslow(arg_masslow), m_masshigh(arg_masshigh), m_p(arg_p),
+      m_angle(arg_angle), m_rho(arg_rho) {};
+ROOT::VecOps::RVec<FCCAnalysesComposite2> sel_tau23pi::operator()(
+    ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
+    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop) {
 
   ROOT::VecOps::RVec<FCCAnalysesComposite2> result;
   //std::cout <<"n reco V " << vertex.size()<<std::endl;
@@ -2055,9 +2054,6 @@ sel_tau23pi::operator() (ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> v
   }
   return result;
 }
-
-
-
 
 ROOT::VecOps::RVec<float> get_Vertex_thrusthemis_angle(ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
 								ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop,
@@ -2254,10 +2250,12 @@ ROOT::VecOps::RVec<float> get_mass(ROOT::VecOps::RVec<ROOT::VecOps::RVec<edm4hep
 					    int index){
 
   ROOT::VecOps::RVec<float> result;
-  if (index < 0) return result;
+  if (index < 0)
+    return result;
   const auto particle_index = static_cast<std::size_t>(index);
   for (auto &p:in){
-      if (particle_index >= p.size())continue;
+    if (particle_index >= p.size())
+      continue;
     result.push_back(p.at(particle_index).mass);
   }
   return result;

--- a/analyzers/dataframe/src/myUtils.cc
+++ b/analyzers/dataframe/src/myUtils.cc
@@ -82,15 +82,6 @@ bool isPrimaryVtx(const edm4hep::VertexData& vertex) {
 #endif
 }
 
-bool isPrimaryOrSecondaryVtx(const edm4hep::VertexData &vertex) {
-#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 10, 5)
-  return vertex.primary > 0;
-#else
-  return edm4hep::utils::checkAnyBits(vertex.type,
-                                      edm4hep::Vertex::BITPrimaryVertex,
-                                      edm4hep::Vertex::BITSecondaryVertex);
-#endif
-}
 } // namespace
 
 int get_PV_ntracks(ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex){
@@ -507,10 +498,10 @@ ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertexMC> get_MCVertexObject(ROOT:
 
     if (result.size()==0){
       VertexingUtils::FCCAnalysesVertexMC vertex;
-      ROOT::VecOps::RVec<int> ind;
-      ind.push_back(tmpvecint.at(i));
+      ROOT::VecOps::RVec<int> vertexIndices;
+      vertexIndices.push_back(tmpvecint.at(i));
       vertex.vertex=vertexPos;
-      vertex.mc_ind=ind;
+      vertex.mc_ind=vertexIndices;
       result.push_back(vertex);
     }
     else{
@@ -832,7 +823,7 @@ ROOT::VecOps::RVec<FCCAnalysesComposite> add_truthmatched(ROOT::VecOps::RVec<FCC
 								   ROOT::VecOps::RVec<edm4hep::MCParticleData> mc,
 								   //ROOT::VecOps::RVec<ROOT::VecOps::RVec<int>> rp2mc){
 								   ROOT::VecOps::RVec<int> rp2mc,
-								   ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop,
+ ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>,
 								   ROOT::VecOps::RVec<int> ind){
 
 
@@ -851,8 +842,6 @@ ROOT::VecOps::RVec<FCCAnalysesComposite> add_truthmatched(ROOT::VecOps::RVec<FCC
       //if (mcassoc.size()==1){
       //mother.push_back(mcassoc.at(0));
       int mother1=getMC_parent(0, mc.at(mcassoc), ind);
-      int mother2=getMC_parent(1, mc.at(mcassoc), ind);
-
       mother.push_back(mother1);
       motherPDG.push_back(mc.at(mother1).PDG);
       //std::cout << "mother 1 "<<mother1<<"  mother2  " << mother2<< std::endl;
@@ -928,7 +917,7 @@ ROOT::VecOps::RVec<FCCAnalysesComposite2> add_truthmatched2(ROOT::VecOps::RVec<F
 								     ROOT::VecOps::RVec<edm4hep::MCParticleData> mc,
 								     ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
 								     ROOT::VecOps::RVec<int> rp2mc,
-								     ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop,
+ ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>,
 								     ROOT::VecOps::RVec<int> ind){
 
 
@@ -941,8 +930,6 @@ ROOT::VecOps::RVec<FCCAnalysesComposite2> add_truthmatched2(ROOT::VecOps::RVec<F
 
       int mcassoc = rp2mc.at(index.at(j));
       int mother1=getMC_parent(0, mc.at(mcassoc), ind);
-      int mother2=getMC_parent(1, mc.at(mcassoc), ind);
-
       mother.push_back(mother1);
       motherPDG.push_back(mc.at(mother1).PDG);
     }
@@ -1653,7 +1640,6 @@ ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> get_RP_atVertex(ROOT::Vec
 
 
 float build_invmass(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop, ROOT::VecOps::RVec<int> index){
-  float result=0;
   TLorentzVector tlv;
   for (size_t i=0;i<index.size();i++){
     TLorentzVector tmp_tlv = ReconstructedParticle::get_tlv(recop[index.at(i)]);
@@ -1663,7 +1649,6 @@ float build_invmass(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop
 }
 
 TLorentzVector build_tlv(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop, ROOT::VecOps::RVec<int> index){
-  float result=0;
   TLorentzVector tlv;
   for (size_t i=0;i<index.size();i++){
     TLorentzVector tmp_tlv = ReconstructedParticle::get_tlv(recop[index.at(i)]);
@@ -1990,9 +1975,9 @@ ROOT::VecOps::RVec<FCCAnalysesComposite2> build_Bd2MuMu(ROOT::VecOps::RVec<Verte
   return result;
 }
 
-build_tau23pi::build_tau23pi(float arg_masslow, float arg_masshigh, float arg_p, float arg_angle, bool arg_rho):m_masslow(arg_masslow),m_masshigh(arg_masshigh),m_p(arg_p),m_angle(arg_angle),m_rho(arg_rho){};
+sel_tau23pi::sel_tau23pi(float arg_masslow, float arg_masshigh, float arg_p, float arg_angle, bool arg_rho):m_masslow(arg_masslow),m_masshigh(arg_masshigh),m_p(arg_p),m_angle(arg_angle),m_rho(arg_rho){};
 ROOT::VecOps::RVec<FCCAnalysesComposite2>
-build_tau23pi::operator() (ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
+sel_tau23pi::operator() (ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> vertex,
 				    ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> recop){
 
   ROOT::VecOps::RVec<FCCAnalysesComposite2> result;

--- a/analyzers/dataframe/src/myUtils.cc
+++ b/analyzers/dataframe/src/myUtils.cc
@@ -3,6 +3,7 @@
 // std
 #include <iostream>
 #include <cstdlib>
+#include <cstddef>
 #include <vector>
 
 // EDM4hep
@@ -782,7 +783,9 @@ ROOT::VecOps::RVec<int> getMC_daughter(int daughterindex,
 						ROOT::VecOps::RVec<int> ind){
   ROOT::VecOps::RVec<int> result;
   for (size_t i = 0; i < in.size(); ++i) {
-    if (daughterindex+1>in.at(i).daughters_end-in.at(i).daughters_begin) {
+  if (daughterindex < 0 ||
+      static_cast<unsigned int>(daughterindex) >=
+          in.at(i).daughters_end - in.at(i).daughters_begin) {
       result.push_back(-999);
     }
     else {
@@ -797,7 +800,9 @@ ROOT::VecOps::RVec<int> getMC_parent(int parentindex,
 					      ROOT::VecOps::RVec<int> ind){
   ROOT::VecOps::RVec<int> result;
   for (size_t i = 0; i < in.size(); ++i) {
-    if (parentindex+1>in.at(i).parents_end-in.at(i).parents_begin) {
+  if (parentindex < 0 ||
+      static_cast<unsigned int>(parentindex) >=
+          in.at(i).parents_end - in.at(i).parents_begin) {
       result.push_back(-999);
     }
     else {
@@ -811,7 +816,8 @@ int getMC_parent(int parentindex,
 			  edm4hep::MCParticleData in,
 			  ROOT::VecOps::RVec<int> ind){
   int result;
-  if (parentindex+1>in.parents_end-in.parents_begin)
+  if (parentindex < 0 ||
+      static_cast<unsigned int>(parentindex) >= in.parents_end - in.parents_begin)
     result = -999;
   else
     result = ind.at(in.parents_begin+parentindex);
@@ -1043,7 +1049,9 @@ filter_PV::operator()(ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in,
   for (auto & p: in) {
     bool found=false;
     for (size_t i = 0; i < index.size(); ++i) {
-      if (p.tracks_begin==index.at(i)){found=true; break;}
+      const int track_index = index.at(i);
+      if (track_index >= 0 &&
+          p.tracks_begin == static_cast<unsigned int>(track_index)) {found=true; break;}
     }
     if (found==false && m_pv==false)result.push_back(p);
     else if (found==true && m_pv==true)result.push_back(p);
@@ -1457,7 +1465,9 @@ ROOT::VecOps::RVec<edm4hep::VertexData> getFCCAnalysesComposite_vertex(ROOT::Vec
 bool isPV(edm4hep::ReconstructedParticleData recop, ROOT::VecOps::RVec<int> pvindex){
 
   for (size_t i = 0; i < pvindex.size(); ++i) {
-    if (recop.tracks_begin==pvindex.at(i))return true;
+    const int track_index = pvindex.at(i);
+    if (track_index >= 0 &&
+        recop.tracks_begin == static_cast<unsigned int>(track_index)) return true;
   }
   return false;
 }
@@ -2244,9 +2254,11 @@ ROOT::VecOps::RVec<float> get_mass(ROOT::VecOps::RVec<ROOT::VecOps::RVec<edm4hep
 					    int index){
 
   ROOT::VecOps::RVec<float> result;
+  if (index < 0) return result;
+  const auto particle_index = static_cast<std::size_t>(index);
   for (auto &p:in){
-    if (index>=p.size())continue;
-    result.push_back(p.at(index).mass);
+      if (particle_index >= p.size())continue;
+    result.push_back(p.at(particle_index).mass);
   }
   return result;
 }

--- a/tests/integration/low_level_edm4hep.cxx
+++ b/tests/integration/low_level_edm4hep.cxx
@@ -7,6 +7,8 @@
 #include <edm4hep/MCParticleData.h>
 #include <edm4hep/SimCalorimeterHitData.h>
 
+#include <vector>
+
 ROOT::VecOps::RVec<edm4hep::MCParticleData>
 selElectrons(ROOT::VecOps::RVec<edm4hep::MCParticleData> &inParticles) {
   ROOT::VecOps::RVec<edm4hep::MCParticleData> electrons;
@@ -23,16 +25,16 @@ struct selPDG {
   selPDG(int pdg, bool chargeConjugateAllowed);
   const int m_pdg;
   const bool m_chargeConjugateAllowed;
-  ROOT::VecOps::RVec<edm4hep::MCParticleData>
-  operator()(ROOT::VecOps::RVec<edm4hep::MCParticleData> &inParticles);
+  std::vector<edm4hep::MCParticleData>
+  operator()(const ROOT::VecOps::RVec<edm4hep::MCParticleData> &inParticles) const;
 };
 
 selPDG::selPDG(int pdg, bool chargeConjugateAllowed)
     : m_pdg(pdg), m_chargeConjugateAllowed(chargeConjugateAllowed){};
 
-ROOT::VecOps::RVec<edm4hep::MCParticleData>
-selPDG::operator()(ROOT::VecOps::RVec<edm4hep::MCParticleData> &inParticles) {
-  ROOT::VecOps::RVec<edm4hep::MCParticleData> result;
+std::vector<edm4hep::MCParticleData>
+selPDG::operator()(const ROOT::VecOps::RVec<edm4hep::MCParticleData> &inParticles) const {
+  std::vector<edm4hep::MCParticleData> result;
   for (size_t i = 0; i < inParticles.size(); ++i) {
     auto &particle = inParticles[i];
     if (m_chargeConjugateAllowed) {
@@ -53,6 +55,16 @@ ROOT::VecOps::RVec<float>
 getPx(ROOT::VecOps::RVec<edm4hep::MCParticleData> inParticles) {
   ROOT::VecOps::RVec<float> result;
   for (auto &p : inParticles) {
+    result.push_back(p.momentum.x);
+  }
+
+  return result;
+}
+
+ROOT::VecOps::RVec<float>
+getPxStd(const std::vector<edm4hep::MCParticleData> &inParticles) {
+  ROOT::VecOps::RVec<float> result;
+  for (const auto &p : inParticles) {
     result.push_back(p.momentum.x);
   }
 
@@ -93,7 +105,7 @@ int main(int argc, const char *argv[]) {
   auto rdf2 = rdf.Define("particles_px", getPx, {"Particle"});
   // auto rdf3 = rdf2.Define("electrons", selElectrons, {"MCParticles"});
   auto rdf3 = rdf2.Define("electrons", selPDG(11, false), {"Particle"});
-  auto rdf4 = rdf3.Define("electrons_px", getPx, {"electrons"});
+  auto rdf4 = rdf3.Define("electrons_px", getPxStd, {"electrons"});
   auto h_particles_px = rdf4.Histo1D("particles_px");
   auto h_electrons_px = rdf4.Histo1D("electrons_px");
 

--- a/tests/integration/low_level_edm4hep.cxx
+++ b/tests/integration/low_level_edm4hep.cxx
@@ -25,15 +25,15 @@ struct selPDG {
   selPDG(int pdg, bool chargeConjugateAllowed);
   const int m_pdg;
   const bool m_chargeConjugateAllowed;
-  std::vector<edm4hep::MCParticleData>
-  operator()(const ROOT::VecOps::RVec<edm4hep::MCParticleData> &inParticles) const;
+  std::vector<edm4hep::MCParticleData> operator()(
+      const ROOT::VecOps::RVec<edm4hep::MCParticleData> &inParticles) const;
 };
 
 selPDG::selPDG(int pdg, bool chargeConjugateAllowed)
     : m_pdg(pdg), m_chargeConjugateAllowed(chargeConjugateAllowed){};
 
-std::vector<edm4hep::MCParticleData>
-selPDG::operator()(const ROOT::VecOps::RVec<edm4hep::MCParticleData> &inParticles) const {
+std::vector<edm4hep::MCParticleData> selPDG::operator()(
+    const ROOT::VecOps::RVec<edm4hep::MCParticleData> &inParticles) const {
   std::vector<edm4hep::MCParticleData> result;
   for (size_t i = 0; i < inParticles.size(); ++i) {
     auto &particle = inParticles[i];


### PR DESCRIPTION
- Resolve GCC 16 compiler warnings across FCCAnalyses.
- Standardize signed collection-index bounds checks while retaining valid negative sentinel handling.
- Remove unused code, shadowed names, deprecated copy diagnostics, and the non-standard VLA in the thrust algorithm.