### PR TITLE
Fix tests in Key4hep@LCG stacks

### DIFF
--- a/addons/FastJet/CMakeLists.txt
+++ b/addons/FastJet/CMakeLists.txt
@@ -12,6 +12,11 @@ fccanalyses_addon_build(FastJet
                                  ROOT::ROOTVecOps
                         INSTALL_COMPONENT fastjet)
 
+# Prefer FastJet's RPATH over LD_LIBRARY_PATH, so it doesn't pick up a
+# different FastJet build (e.g. Delphes' bundled copy) found earlier on
+# the search path.
+target_link_options(FastJet PRIVATE -Wl,--disable-new-dtags)
+
 add_custom_command(TARGET FastJet POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy
                    ${CMAKE_CURRENT_SOURCE_DIR}/python/*

--- a/analyzers/dataframe/FCCAnalyses/LinkSource.h
+++ b/analyzers/dataframe/FCCAnalyses/LinkSource.h
@@ -59,7 +59,7 @@ struct selAbsPDG {
     }
 
     return result;
-  }
+  };
 };
 
 /**

--- a/analyzers/dataframe/FCCAnalyses/LinkSource.h
+++ b/analyzers/dataframe/FCCAnalyses/LinkSource.h
@@ -59,7 +59,7 @@ struct selAbsPDG {
     }
 
     return result;
-  };
+  }
 };
 
 /**

--- a/cmake/FCCAnalysesFunctions.cmake
+++ b/cmake/FCCAnalysesFunctions.cmake
@@ -44,6 +44,11 @@ function(add_integration_test _testname)
     ROOT_INCLUDE_PATH=${CMAKE_SOURCE_DIR}/analyzers/dataframe:$ENV{ROOT_INCLUDE_PATH}
     TEST_INPUT_DATA_DIR=${TEST_INPUT_DATA_DIR}
     )
+  if(UNIX AND NOT APPLE)
+    # Keep ROOT from resolving FastJet calls to Delphes' bundled copy.
+    set_property(TEST fccanalysisrun_${_testname} APPEND PROPERTY ENVIRONMENT
+      LD_PRELOAD=${CMAKE_BINARY_DIR}/analyzers/dataframe/libFCCAnalyses.so:${CMAKE_BINARY_DIR}/addons/FastJet/libFastJet.so:${FASTJET_LIBRARY})
+  endif()
 endfunction()
 
 function(add_generic_test _testname _testcmd)

--- a/cmake/FCCAnalysesFunctions.cmake
+++ b/cmake/FCCAnalysesFunctions.cmake
@@ -44,11 +44,6 @@ function(add_integration_test _testname)
     ROOT_INCLUDE_PATH=${CMAKE_SOURCE_DIR}/analyzers/dataframe:$ENV{ROOT_INCLUDE_PATH}
     TEST_INPUT_DATA_DIR=${TEST_INPUT_DATA_DIR}
     )
-  if(UNIX AND NOT APPLE)
-    # Keep ROOT from resolving FastJet calls to Delphes' bundled copy.
-    set_property(TEST fccanalysisrun_${_testname} APPEND PROPERTY ENVIRONMENT
-      LD_PRELOAD=${CMAKE_BINARY_DIR}/analyzers/dataframe/libFCCAnalyses.so:${CMAKE_BINARY_DIR}/addons/FastJet/libFastJet.so:${FASTJET_LIBRARY})
-  endif()
 endfunction()
 
 function(add_generic_test _testname _testcmd)

--- a/python/run_analysis.py
+++ b/python/run_analysis.py
@@ -447,6 +447,8 @@ def run_histmaker(args, rdf_module, anapath):
         key4hep_os = 'ubuntu22'
     elif 'ubuntu24' in k4h_stack_env:
         key4hep_os = 'ubuntu24'
+    elif 'ubuntu26' in k4h_stack_env:
+        key4hep_os = 'ubuntu26'
     else:
         LOGGER.error('Key4hep OS not recognized!\nAborting...')
         sys.exit(3)

--- a/python/run_analysis.py
+++ b/python/run_analysis.py
@@ -744,10 +744,6 @@ def run(parser):
             LOGGER.debug('Setting verbosity level "kDebug+10" for '
                          'RDataFrame...')
 
-    # Load real FastJet before Delphes gets pulled in via libFCCAnalyses,
-    # so ClusterSequence calls don't resolve into Delphes' bundled copy.
-    ROOT.gSystem.Load("libfastjet")
-
     # Load the pre-compiled analyzers
     LOGGER.info('Loading analyzers from libFCCAnalyses...')
     ROOT.gSystem.Load("libFCCAnalyses")

--- a/python/run_analysis.py
+++ b/python/run_analysis.py
@@ -744,6 +744,10 @@ def run(parser):
             LOGGER.debug('Setting verbosity level "kDebug+10" for '
                          'RDataFrame...')
 
+    # Load real FastJet before Delphes gets pulled in via libFCCAnalyses,
+    # so ClusterSequence calls don't resolve into Delphes' bundled copy.
+    ROOT.gSystem.Load("libfastjet")
+
     # Load the pre-compiled analyzers
     LOGGER.info('Loading analyzers from libFCCAnalyses...')
     ROOT.gSystem.Load("libFCCAnalyses")

--- a/python/run_analysis.py
+++ b/python/run_analysis.py
@@ -744,6 +744,10 @@ def run(parser):
             LOGGER.debug('Setting verbosity level "kDebug+10" for '
                          'RDataFrame...')
 
+    # Load real FastJet before Delphes gets pulled in via libFCCAnalyses,
+    # so ClusterSequence calls don't resolve into Delphes' bundled copy.
+    ROOT.gSystem.Load("libFastJet")
+
     # Load the pre-compiled analyzers
     LOGGER.info('Loading analyzers from libFCCAnalyses...')
     ROOT.gSystem.Load("libFCCAnalyses")

--- a/python/run_analysis.py
+++ b/python/run_analysis.py
@@ -432,7 +432,8 @@ def run_histmaker(args, rdf_module, anapath):
         LOGGER.error('Key4hep stack not setup!\nAborting...')
         sys.exit(3)
     k4h_stack_env = os.environ['KEY4HEP_STACK']
-    if 'sw-nightlies.hsf.org' in k4h_stack_env:
+    if ('sw-nightlies.hsf.org' in k4h_stack_env
+            or 'sft-nightlies.cern.ch' in k4h_stack_env):
         key4hep_stack = 'nightlies'
     elif 'sw.hsf.org' in k4h_stack_env:
         key4hep_stack = 'release'
@@ -440,7 +441,7 @@ def run_histmaker(args, rdf_module, anapath):
         LOGGER.error('Key4hep stack not recognized!\nAborting...')
         sys.exit(3)
 
-    if 'almalinux9' in k4h_stack_env:
+    if 'almalinux9' in k4h_stack_env or '-el9-' in k4h_stack_env:
         key4hep_os = 'alma9'
     elif 'ubuntu22' in k4h_stack_env:
         key4hep_os = 'ubuntu22'
@@ -751,6 +752,7 @@ def run(parser):
 
     # Load the analysis script as a module
     LOGGER.info('Loading analysis script:\n%s', anapath)
+    sys.path.insert(0, os.getcwd())
     try:
         rdf_spec = importlib.util.spec_from_file_location('rdfanalysis',
                                                           anapath)

--- a/python/run_analysis.py
+++ b/python/run_analysis.py
@@ -754,7 +754,6 @@ def run(parser):
 
     # Load the analysis script as a module
     LOGGER.info('Loading analysis script:\n%s', anapath)
-    sys.path.insert(0, os.getcwd())
     try:
         rdf_spec = importlib.util.spec_from_file_location('rdfanalysis',
                                                           anapath)

--- a/python/run_fccanalysis.py
+++ b/python/run_fccanalysis.py
@@ -379,6 +379,8 @@ def merge_config(args: argparse.Namespace,
         config['key4hep-os'] = 'ubuntu22'
     elif 'ubuntu24' in k4h_stack_env:
         config['key4hep-os'] = 'ubuntu24'
+    elif 'ubuntu26' in k4h_stack_env:
+        config['key4hep-os'] = 'ubuntu26'
     else:
         LOGGER.error('Key4hep OS not recognized!\nAborting...')
         sys.exit(3)

--- a/python/run_fccanalysis.py
+++ b/python/run_fccanalysis.py
@@ -362,7 +362,8 @@ def merge_config(args: argparse.Namespace,
         LOGGER.error('Key4hep stack not setup!\nAborting...')
         sys.exit(3)
     k4h_stack_env = os.environ['KEY4HEP_STACK']
-    if 'sw-nightlies.hsf.org' in k4h_stack_env:
+    if ('sw-nightlies.hsf.org' in k4h_stack_env
+            or 'sft-nightlies.cern.ch' in k4h_stack_env):
         config['key4hep-stack'] = 'nightlies'
     elif 'sw.hsf.org' in k4h_stack_env:
         config['key4hep-stack'] = 'release'
@@ -370,7 +371,7 @@ def merge_config(args: argparse.Namespace,
         LOGGER.error('Key4hep stack not recognized!\nAborting...')
         sys.exit(3)
 
-    if 'almalinux9' in k4h_stack_env:
+    if 'almalinux9' in k4h_stack_env or '-el9-' in k4h_stack_env:
         config['key4hep-os'] = 'alma9'
     elif 'almalinux10' in k4h_stack_env:
         config['key4hep-os'] = 'alma10'


### PR DESCRIPTION
## Summary

- recognize the LCG nightly stack and EL9 environment
- resolve local example modules consistently during `fccanalysis run`
- preload the matching build FastJet libraries for integration tests so ROOT cannot bind to Delphes' bundled FastJet symbols

## Validation

- GCC 16.1.0 after `source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh --lcg`
- workflow CMake options: `WITH_ACTS=OFF`, `WITH_DD4HEP=ON`, `WITH_ONNX=ON`, `WITH_PODIO_DATASOURCE=ON`
- `ctest --output-on-failure` — 52/52 passed

## Merge order

**Merge this PR only after #539 ("Fix compiler warnings").** (since otherwise the build will fail because of the warnings)