### PR TITLE
Fix GCC 16 build for stdout redirection

### DIFF
--- a/analyzers/dataframe/src/VertexFitterSimple.cc
+++ b/analyzers/dataframe/src/VertexFitterSimple.cc
@@ -9,6 +9,7 @@
 #include "TString.h"
 
 #include <fcntl.h>
+#include <unistd.h>
 
 //#include "TrkUtil.h"    // from delphes
 


### PR DESCRIPTION
## Summary

- include `<unistd.h>` where `dup`, `dup2`, and `close` are used to redirect stdout

See https://github.com/HEP-FCC/FCCAnalyses/pull/539#discussion_r3824535230