### PR TITLE
ci: cancel superseded Build and Test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: 'Build and Test'
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- add concurrency control to the Build and Test workflow
- cancel superseded runs for the same workflow and ref

## Testing

- git diff --check