### PR TITLE
Bump version to 0.13.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16.9)
 
 
-project(FCCAnalyses VERSION 0.12.0
+project(FCCAnalyses VERSION 0.13.1
                     LANGUAGES CXX
 )
 

--- a/bin/fccanalysis
+++ b/bin/fccanalysis
@@ -67,7 +67,7 @@ def main():
     '''
     Starting point for fccanalysis command
     '''
-    parser = argparse.ArgumentParser(description='FCCAnalyses v0.12.0')
+    parser = argparse.ArgumentParser(description='FCCAnalyses v0.13.1')
 
     # Verbosity arguments
     verbosity_argument_group = parser.add_mutually_exclusive_group()

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -48,7 +48,7 @@ PROJECT_NAME           = "FCCAnalyses"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = @FCCANALYSES_VERSION@
+PROJECT_NUMBER         = @PROJECT_VERSION@
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/man/man1/fccanalysis-build.1
+++ b/man/man1/fccanalysis-build.1
@@ -1,6 +1,6 @@
 .\" Manpage for fccanalysis-build
 .\" Contact FCC-PED-SoftwareAndComputing-Analysis@cern.ch to correct errors or typos.
-.TH FCCANALYSIS\-BUILD 1 "17 Jan 2024" "0.12.0" "fccanalysis-build man page"
+.TH FCCANALYSIS\-BUILD 1 "17 Jan 2024" "0.13.1" "fccanalysis-build man page"
 .SH NAME
 \fBfccanalysis\-build\fR \(en helper to build FCCAnalyses framework locally
 .SH SYNOPSIS

--- a/man/man1/fccanalysis-combine.1
+++ b/man/man1/fccanalysis-combine.1
@@ -1,6 +1,6 @@
 .\" Manpage for fccanalysis-combine
 .\" Contact FCC-PED-SoftwareAndComputing-Analysis@cern.ch to correct errors or typos.
-.TH FCCANALYSIS\-COMBINE 1 "27 Mar 2025" "0.12.0" "fccanalysis-combine man page"
+.TH FCCANALYSIS\-COMBINE 1 "27 Mar 2025" "0.13.1" "fccanalysis-combine man page"
 .SH NAME
 \fBfccanalysis\-combine\fR \(en prepares datacards for Combine
 .SH SYNOPSIS

--- a/man/man1/fccanalysis-final.1
+++ b/man/man1/fccanalysis-final.1
@@ -1,6 +1,6 @@
 .\" Manpage for fccanalysis-final
 .\" Contact FCC-PED-SoftwareAndComputing-Analysis@cern.ch to correct errors or typos.
-.TH FCCANALYSIS\-FINAL 1 "13 Nov 2025" "0.12.0" "fccanalysis-final man page"
+.TH FCCANALYSIS\-FINAL 1 "13 Nov 2025" "0.13.1" "fccanalysis-final man page"
 .SH NAME
 \fBfccanalysis\-final\fR \(en finalize your analysis into histograms
 .SH SYNOPSIS

--- a/man/man1/fccanalysis-pin.1
+++ b/man/man1/fccanalysis-pin.1
@@ -1,6 +1,6 @@
 .\" Manpage for fccanalysis-pin
 .\" Contact FCC-PED-SoftwareAndComputing-Analysis@cern.ch to correct errors or typos.
-.TH FCCANALYSIS\-PIN 1 "24 Sep 2025" "0.12.0" "fccanalysis-pin man page"
+.TH FCCANALYSIS\-PIN 1 "24 Sep 2025" "0.13.1" "fccanalysis-pin man page"
 .SH NAME
 \fBfccanalysis\-pin\fR \(en pin the Key4hep stack version
 .SH SYNOPSIS

--- a/man/man1/fccanalysis-plots.1
+++ b/man/man1/fccanalysis-plots.1
@@ -1,6 +1,6 @@
 .\" Manpage for fccanalysis-plots
 .\" Contact FCC-PED-SoftwareAndComputing-Analysis@cern.ch to correct errors or typos.
-.TH FCCANALYSIS\-PLOTS 1 "28 Jun 2024" "0.12.0" "fccanalysis-plots man page"
+.TH FCCANALYSIS\-PLOTS 1 "28 Jun 2024" "0.13.1" "fccanalysis-plots man page"
 .SH NAME
 \fBfccanalysis\-plots\fR \(en generate analysis plots
 .SH SYNOPSIS

--- a/man/man1/fccanalysis-run.1
+++ b/man/man1/fccanalysis-run.1
@@ -1,6 +1,6 @@
 .\" Manpage for fccanalysis-run
 .\" Contact FCC-PED-SoftwareAndComputing-Analysis@cern.ch to correct errors or typos.
-.TH FCCANALYSIS\-RUN 1 "12 June 2025" "0.12.0" "fccanalysis-run man page"
+.TH FCCANALYSIS\-RUN 1 "12 June 2025" "0.13.1" "fccanalysis-run man page"
 
 .SH NAME
 \fBfccanalysis\-run\fR \- run FCC analysis

--- a/man/man1/fccanalysis-submit.1
+++ b/man/man1/fccanalysis-submit.1
@@ -1,6 +1,6 @@
 .\" Manpage for fccanalysis-submit
 .\" Contact FCC-PED-SoftwareAndComputing-Analysis@cern.ch to correct errors or typos.
-.TH FCCANALYSIS\-SUBMIT 1 "14 May 2025" "0.12.0" "fccanalysis-submit man page"
+.TH FCCANALYSIS\-SUBMIT 1 "14 May 2025" "0.13.1" "fccanalysis-submit man page"
 
 .SH NAME
 \fBfccanalysis\-submit\fR \- submit FCC analysis to be run on a distributed system

--- a/man/man1/fccanalysis-test.1
+++ b/man/man1/fccanalysis-test.1
@@ -1,6 +1,6 @@
 .\" Manpage for fccanalysis-test
 .\" Contact FCC-PED-SoftwareAndComputing-Analysis@cern.ch to correct errors or typos.
-.TH FCCANALYSIS\-TEST 1 "17 Jan 2024" "0.12.0" "fccanalysis-test man page"
+.TH FCCANALYSIS\-TEST 1 "17 Jan 2024" "0.13.1" "fccanalysis-test man page"
 .SH NAME
 \fBfccanalysis\-test\fR \(en test FCCAnalyses framework
 .SH SYNOPSIS

--- a/man/man1/fccanalysis.1
+++ b/man/man1/fccanalysis.1
@@ -1,6 +1,6 @@
 .\" Manpage for fccanalysis
 .\" Contact FCC-PED-SoftwareAndComputing-Analysis@cern.ch to correct errors or typos.
-.TH FCCANALYSIS 1 "17 Jan 2024" "0.12.0" "fccanalysis man page"
+.TH FCCANALYSIS 1 "17 Jan 2024" "0.13.1" "fccanalysis man page"
 .SH NAME
 \fBfccanalysis\fR \(en write, build and run your FCC analysis
 .SH SYNOPSIS

--- a/man/man7/fccanalysis-combine-script.7
+++ b/man/man7/fccanalysis-combine-script.7
@@ -1,6 +1,6 @@
 .\" Manpage for fccanalysis-combine-script
 .\" Contact FCC-PED-SoftwareAndComputing-Analysis@cern.ch to correct errors or typos.
-.TH FCCANALYSIS\-COMBINE\-SCRIPT 7 "27 Mar 2025" "0.12.0" "fccanalysis-combine-script man page"
+.TH FCCANALYSIS\-COMBINE\-SCRIPT 7 "27 Mar 2025" "0.13.1" "fccanalysis-combine-script man page"
 .SH NAME
 \fBfccanalysis\-combine\-script\fR \(en analysis script for the combine stage of the
 analysis

--- a/man/man7/fccanalysis-final-script.7
+++ b/man/man7/fccanalysis-final-script.7
@@ -1,6 +1,6 @@
 .\" Manpage for fccanalysis-final-script
 .\" Contact FCC-PED-SoftwareAndComputing-Analysis@cern.ch to correct errors or typos.
-.TH FCCANALYSIS\-FINAL\-SCRIPT 7 "13 Nov 2025" "0.12.0" "fccanalysis-final-script man page"
+.TH FCCANALYSIS\-FINAL\-SCRIPT 7 "13 Nov 2025" "0.13.1" "fccanalysis-final-script man page"
 .SH NAME
 \fBfccanalysis\-final\-script\fR \(en analysis script for the final stage of the
 analysis

--- a/man/man7/fccanalysis-plots-script.7
+++ b/man/man7/fccanalysis-plots-script.7
@@ -1,6 +1,6 @@
 .\" Manpage for fccanalysis-plots-script
 .\" Contact FCC-PED-SoftwareAndComputing-Analysis@cern.ch to correct errors or typos.
-.TH FCCANALYSIS\-PLOTS\-SCRIPT 7 "05 Aug 2025" "0.12.0" "fccanalysis-plots-script man page"
+.TH FCCANALYSIS\-PLOTS\-SCRIPT 7 "05 Aug 2025" "0.13.1" "fccanalysis-plots-script man page"
 .SH NAME
 \fBfccanalysis\-plots\-script\fR \(en analysis script for the plots stage of the
 analysis

--- a/man/man7/fccanalysis-script.7
+++ b/man/man7/fccanalysis-script.7
@@ -1,6 +1,6 @@
 .\" Manpage for fccanalysis-script
 .\" Contact FCC-PED-SoftwareAndComputing-Analysis@cern.ch to correct errors or typos.
-.TH FCCANALYSIS\-SCRIPT 7 "12 Nov 2025" "0.12.0" "fccanalysis-script man page"
+.TH FCCANALYSIS\-SCRIPT 7 "12 Nov 2025" "0.13.1" "fccanalysis-script man page"
 .SH NAME
 \fBfccanalysis\-script\fR \(en analysis steering script specification
 


### PR DESCRIPTION
Prepares the v0.13.1 release.

`CMakeLists.txt` was never bumped for v0.13.0, so the project version, the
`fccanalysis --help` string and all 13 man page headers still reported 0.12.0.
This updates all of them:

- `CMakeLists.txt` — `project(FCCAnalyses VERSION ...)`
- `bin/fccanalysis` — argument parser description
- `man/man1/*.1`, `man/man7/*.7` — `.TH` version field only; the dates are left
  untouched since they record when each page's content last changed

Also fixes `doc/Doxyfile.in`, which set `PROJECT_NUMBER = @FCCANALYSES_VERSION@`.
That variable is not defined anywhere in the project, so `configure_file(... @ONLY)`
expanded it to an empty string and the generated documentation never displayed a
version at all. It now derives from `@PROJECT_VERSION@`, which CMake sets from the
`project()` call and which cannot drift out of sync again.

The `v0.13.1` tag will be created on master once this is merged.
